### PR TITLE
Update version to 1.0.1 and enhance artist post retrieval functionality

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,12 +1,12 @@
 {
   "name": "nsfw-booru-desktop-client",
   "productName": "NSFW Booru Client",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "A modern, secure desktop companion for browsing booru-style imageboard content",
   "main": "out/main/main.js",
   "type": "module",
   "scripts": {
-    "dev": "electron-vite dev",
+    "dev": "chcp 65001 && electron-vite dev",
     "build": "electron-vite build",
     "preview": "electron-vite preview",
     "db:migrate": "ts-node src/main/db/migrate.ts",

--- a/src/main/bridge.ts
+++ b/src/main/bridge.ts
@@ -29,8 +29,7 @@ const ipcBridge: IpcBridge = {
 
   getTrackedArtists: () => ipcRenderer.invoke("db:get-artists"),
   addArtist: (artist) => ipcRenderer.invoke("db:add-artist", artist),
-  getArtistPosts: (id, page) =>
-    ipcRenderer.invoke("db:get-posts", { artistId: id, page }),
+  getArtistPosts: (params) => ipcRenderer.invoke("db:get-posts", params),
   deleteArtist: (id) => ipcRenderer.invoke("db:delete-artist", id),
 
   openExternal: (url) => ipcRenderer.invoke("app:open-external", url),

--- a/src/main/ipc.ts
+++ b/src/main/ipc.ts
@@ -104,7 +104,7 @@ export const registerIpcHandlers = (dbService: DbService) => {
 
     const { artistId, page } = validation.data;
 
-    const limit = 1000;
+    const limit = 50;
     const offset = (page - 1) * limit;
     return dbService.getPostsByArtist(artistId, limit, offset);
   });

--- a/src/renderer.d.ts
+++ b/src/renderer.d.ts
@@ -15,7 +15,10 @@ export interface IpcApi {
   deleteArtist: (id: number) => Promise<void>;
 
   // Posts
-  getArtistPosts: (artistId: number, page?: number) => Promise<Post[]>;
+  getArtistPosts: (params: {
+    artistId: number;
+    page: number;
+  }) => Promise<Post[]>;
 
   // Sync
   syncAll: () => Promise<boolean>;


### PR DESCRIPTION
- Incremented version number in package.json to 1.0.1.
- Modified getArtistPosts API to accept an object with artistId and page parameters for improved clarity and flexibility.
- Adjusted IPC handler to match the new getArtistPosts signature.
- Updated pagination logic in ArtistGallery component to support dynamic page navigation and display the current page number.
- Reduced the limit of posts retrieved per request from 1000 to 50 for better performance and user experience.