### PR TITLE
refactor: update database initialization to include migrations path

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "postinstall": "electron-builder install-app-deps",
     "lint": "eslint . --ext ts,tsx --report-unused-disable-directives --max-warnings 0",
     "validate": "npm run typecheck && npm run lint",
-    "dist": "npm run build && electron-builder --publish always",
+    "dist": "npm run build && electron-builder",
     "release:minor": "npm version minor && git push --follow-tags",
     "release:patch": "npm version patch && git push --follow-tags",
     "release:major": "npm version major && git push --follow-tags"
@@ -115,6 +115,7 @@
       "!**/tsconfig.json",
       "!**/.eslintrc*",
       "!**/.vscode",
+      "drizzle/**",
       "!**/.gitattributes"
     ],
     "extraFiles": [],

--- a/src/main/db/db-worker.ts
+++ b/src/main/db/db-worker.ts
@@ -134,7 +134,10 @@ function sendSuccess(id: string, data?: unknown): void {
   sendResponse({ id, success: true, data });
 }
 
-function initializeDatabase(initialDbPath: string): void {
+function initializeDatabase(
+  initialDbPath: string,
+  migrationsPath: string
+): void {
   try {
     dbInstance = new Database(initialDbPath, {
       verbose: process.env.NODE_ENV === "development" ? console.log : undefined,
@@ -142,7 +145,6 @@ function initializeDatabase(initialDbPath: string): void {
     db = drizzle(dbInstance, { schema });
     dbPath = initialDbPath;
 
-    const migrationsPath = path.join(process.cwd(), "drizzle");
     logger.info(`Migrations: Path: ${migrationsPath}`);
     migrate(db, { migrationsFolder: migrationsPath });
     logger.info("Migrations: Success.");
@@ -538,7 +540,7 @@ if (parentPort) {
       setTimeout(() => process.exit(0), 100);
     } else if (msg.type === "init") {
       try {
-        initializeDatabase(msg.dbPath);
+        initializeDatabase(msg.dbPath, msg.migrationsPath);
         sendSuccess(msg.id);
       } catch (e) {
         sendError(msg.id, e);

--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -10,7 +10,7 @@ logger.info("🚀 Application starting...");
 
 process.env.USER_DATA_PATH = app.getPath("userData");
 
-let dbWorkerClient: DbWorkerClient | null = null; // Делаем null, пока не инициализируем
+let dbWorkerClient: DbWorkerClient | null = null;
 let mainWindow: BrowserWindow | null = null;
 let DB_PATH: string;
 
@@ -28,11 +28,18 @@ if (!gotTheLock) {
     }
   });
 
-  // 🛑 ФИКС: Вызываем initializeAppAndWindow только после того, как Electron готов.
   app.on("ready", initializeAppAndWindow);
 }
 
-// 🛑 УДАЛЕНА: Старая функция initializeAppAndReady (ее логика перенесена ниже)
+function getMigrationsPath(): string {
+  const isDev = process.env.NODE_ENV === "development";
+
+  if (isDev) {
+    return path.join(process.cwd(), "drizzle");
+  }
+
+  return path.join(process.resourcesPath, "drizzle");
+}
 
 /**
  * Асинхронная функция, которая запускается после app.ready.
@@ -42,9 +49,12 @@ async function initializeAppAndWindow() {
   try {
     DB_PATH = path.join(app.getPath("userData"), "metadata.db");
 
+    const MIGRATIONS_PATH = getMigrationsPath();
+    logger.info(`Main: Migrations Path: ${MIGRATIONS_PATH}`);
+
     // === 1. АСИНХРОННАЯ ИНИЦИАЛИЗАЦИЯ DB WORKER ===
     // Блокировка здесь безопасна, так как Electron уже готов.
-    dbWorkerClient = await DbWorkerClient.initialize(DB_PATH);
+    dbWorkerClient = await DbWorkerClient.initialize(DB_PATH, MIGRATIONS_PATH);
     logger.info("✅ Main: DB Worker Client initialized and ready.");
 
     // === 2. Инициализация сервисов и создание окна ===


### PR DESCRIPTION
- Modified the DbWorkerClient to accept a migrations path during initialization, enhancing database setup flexibility.
- Updated the main application logic to retrieve and log the migrations path based on the environment.
- Adjusted the database worker to utilize the new migrations path for improved migration handling.
- Cleaned up code by removing unnecessary comments and ensuring consistent formatting.