### PR TITLE
chore: update verifyCredentials to accept optional providerId

### DIFF
--- a/src/main/bridge.ts
+++ b/src/main/bridge.ts
@@ -162,7 +162,7 @@ export interface IpcBridge {
   createBackup: () => Promise<BackupResponse>;
   restoreBackup: () => Promise<BackupResponse>;
 
-  verifyCredentials: () => Promise<boolean>;
+  verifyCredentials: (providerId?: ProviderId) => Promise<boolean>;
 
   // Playlists
   createPlaylist: (data: CreatePlaylistRequest) => Promise<Playlist>;
@@ -205,7 +205,8 @@ const ipcBridge: IpcBridge = {
   resolveTagsByType: (tags, type) =>
     ipcRenderer.invoke(IPC_CHANNELS.API.RESOLVE_TAGS_BY_TYPE, tags, type),
 
-  verifyCredentials: () => ipcRenderer.invoke("app:verify-creds"),
+  verifyCredentials: (providerId) =>
+    ipcRenderer.invoke("app:verify-creds", providerId),
 
   getSettings: () => ipcRenderer.invoke(IPC_CHANNELS.SETTINGS.GET),
   saveDownloadFolder: (path) =>

--- a/src/main/ipc/controllers/AuthController.ts
+++ b/src/main/ipc/controllers/AuthController.ts
@@ -9,6 +9,7 @@ import { IPC_CHANNELS } from "../channels";
 import type { BetterSQLite3Database } from "drizzle-orm/better-sqlite3";
 import type * as schema from "../../db/schema";
 import type { SyncService } from "../../services/sync-service";
+import type { ProviderId } from "../../providers";
 
 type AppDatabase = BetterSQLite3Database<typeof schema>;
 
@@ -34,8 +35,11 @@ export class AuthController extends BaseController {
   public setup(): void {
     this.handle(
       IPC_CHANNELS.APP.VERIFY_CREDS,
-      z.tuple([]),
-      this.verifyCredentials.bind(this)
+      z.tuple([z.enum(["rule34", "gelbooru"]).optional()]),
+      this.verifyCredentials.bind(this) as (
+        event: IpcMainInvokeEvent,
+        ...args: unknown[]
+      ) => Promise<unknown>
     );
     this.handle(
       IPC_CHANNELS.APP.LOGOUT,
@@ -52,10 +56,13 @@ export class AuthController extends BaseController {
    * @param _event - IPC event (unused)
    * @returns true if credentials are valid, false otherwise
    */
-  private async verifyCredentials(_event: IpcMainInvokeEvent): Promise<boolean> {
+  private async verifyCredentials(
+    _event: IpcMainInvokeEvent,
+    providerId?: ProviderId
+  ): Promise<boolean> {
     try {
       const syncService = this.getSyncService();
-      return await syncService.checkCredentials();
+      return await syncService.checkCredentials(providerId);
     } catch (error) {
       log.error("[AuthController] Failed to verify credentials:", error);
       throw error;

--- a/src/main/services/sync-service.ts
+++ b/src/main/services/sync-service.ts
@@ -188,7 +188,7 @@ export class SyncService {
     }
   }
 
-  public async checkCredentials(): Promise<boolean> {
+  public async checkCredentials(providerId: ProviderId = "rule34"): Promise<boolean> {
     try {
       const settings = await this.getDecryptedSettings();
       if (!settings?.userId || !settings?.apiKey) {
@@ -201,7 +201,7 @@ export class SyncService {
         `SyncService: Verifying connectivity for User ID: ${settings.userId}...`
       );
 
-      const provider = getProvider("rule34");
+      const provider = getProvider(providerId);
       const isValid = await provider.checkAuth({
         userId: settings.userId,
         apiKey: settings.apiKey,

--- a/src/renderer.d.ts
+++ b/src/renderer.d.ts
@@ -117,7 +117,7 @@ export interface IpcApi extends IpcBridge {
   restoreBackup: () => Promise<BackupResponse>;
   writeToClipboard: (text: string) => Promise<boolean>;
 
-  verifyCredentials: () => Promise<boolean>;
+  verifyCredentials: (providerId?: ProviderId) => Promise<boolean>;
 
   // Playlists
   createPlaylist: (data: CreatePlaylistRequest) => Promise<Playlist>;

--- a/src/renderer/features/onboarding/Onboarding.tsx
+++ b/src/renderer/features/onboarding/Onboarding.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useState } from "react";
 import { useForm } from "react-hook-form";
 import { z, ZodIssueOptionalMessage, ErrorMapCtx } from "zod";
 import { zodResolver } from "@hookform/resolvers/zod";
@@ -7,6 +7,14 @@ import log from "electron-log/renderer";
 import { Button } from "@/components/ui/button";
 import { KeyRound, User } from "lucide-react";
 import { credsBaseSchema, CredsFormValues } from "@/schemas/form-schemas";
+import { PROVIDER_IDS, type ProviderId } from "../../../shared/constants";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
 
 interface OnboardingProps {
   onComplete: () => void;
@@ -33,6 +41,8 @@ const parseCredentialsFromText = (text: string): { userId?: string; apiKey?: str
 
 export const Onboarding: React.FC<OnboardingProps> = ({ onComplete }) => {
   const { t } = useTranslation();
+  const [verifyProviderId, setVerifyProviderId] = useState<ProviderId>("rule34");
+  const [verificationError, setVerificationError] = useState<string>("");
 
   const {
     register,
@@ -76,7 +86,15 @@ export const Onboarding: React.FC<OnboardingProps> = ({ onComplete }) => {
 
   const onSubmit = async (data: CredsFormValues) => {
     try {
+      setVerificationError("");
       await window.api.saveSettings(data);
+      const isValid = await window.api.verifyCredentials(verifyProviderId);
+      if (!isValid) {
+        setVerificationError(
+          "Credentials are invalid for the selected provider. Check your User ID/API key and try again."
+        );
+        return;
+      }
       onComplete();
     } catch (e) {
       const message = e instanceof Error ? e.message : "Unknown save error.";
@@ -164,6 +182,31 @@ export const Onboarding: React.FC<OnboardingProps> = ({ onComplete }) => {
               </span>
             )}
           </div>
+
+          <div>
+            <label className="block mb-1 text-sm font-medium text-slate-400">
+              Verify for
+            </label>
+            <Select
+              value={verifyProviderId}
+              onValueChange={(value: ProviderId) => setVerifyProviderId(value)}
+            >
+              <SelectTrigger className="w-full text-white bg-slate-950 border-slate-700 focus:ring-2 focus:ring-blue-500">
+                <SelectValue placeholder="Select provider" />
+              </SelectTrigger>
+              <SelectContent>
+                {PROVIDER_IDS.map((providerId) => (
+                  <SelectItem key={providerId} value={providerId}>
+                    {providerId}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          </div>
+
+          {verificationError && (
+            <div className="text-xs text-red-500">{verificationError}</div>
+          )}
 
           <Button
             type="submit"


### PR DESCRIPTION
- Modified the `verifyCredentials` method in both the `IpcApi` and `IpcBridge` interfaces to accept an optional `providerId` parameter.
- Updated the `AuthController` to handle the new parameter in the verification process.
- Enhanced the `SyncService` to utilize the provided `providerId` when checking credentials, defaulting to "rule34".
- Integrated a provider selection feature in the `Onboarding` component, allowing users to specify the provider for credential verification, improving user experience and flexibility.