### PR TITLE
chore: add view metadata to posts schema and update related logic

### DIFF
--- a/docs/database.md
+++ b/docs/database.md
@@ -128,6 +128,8 @@ Caches post metadata for filtering, statistics, and download management. Support
 | `published_at` | INTEGER (NOT NULL)                     | Publication timestamp (timestamp mode, ms)    |
 | `created_at`   | INTEGER (NOT NULL)                     | When added to local database (timestamp ms)   |
 | `is_viewed`    | INTEGER (BOOLEAN, NOT NULL, DEFAULT 0) | Whether post has been viewed                  |
+| `last_viewed_at` | INTEGER (NULL)                       | Last time post was viewed (timestamp mode, ms) |
+| `view_count`   | INTEGER (NOT NULL, DEFAULT 0)          | Number of times post was viewed               |
 | `is_favorited` | INTEGER (BOOLEAN, NOT NULL, DEFAULT 0) | Whether post has been favorited               |
 
 **Unique Constraint:** `(artist_id, post_id)` - Prevents duplicate posts per artist.
@@ -137,6 +139,7 @@ Caches post metadata for filtering, statistics, and download management. Support
 - `postIdIdx` - Index on `post_id` for efficient lookups
 - `artistIdIdx` - Index on `artist_id` for artist-based queries
 - `isViewedIdx` - Index on `is_viewed` for view status filtering
+- `posts_last_viewed_at_idx` - Index on `last_viewed_at` for recently viewed sorting
 - `publishedAtIdx` - Index on `published_at` for date-based sorting
 - `isFavoritedIdx` - Index on `is_favorited` for favorites filtering
 - `posts_media_type_idx` - Index on `media_type` for fast image/video filtering
@@ -168,6 +171,8 @@ export const posts = sqliteTable(
     isViewed: integer("is_viewed", { mode: "boolean" })
       .default(false)
       .notNull(),
+    lastViewedAt: integer("last_viewed_at", { mode: "timestamp" }),
+    viewCount: integer("view_count").default(0).notNull(),
     isFavorited: integer("is_favorited", { mode: "boolean" })
       .default(false)
       .notNull(),
@@ -177,6 +182,7 @@ export const posts = sqliteTable(
     postIdIdx: index("postIdIdx").on(table.postId),
     artistIdIdx: index("artistIdIdx").on(table.artistId),
     isViewedIdx: index("isViewedIdx").on(table.isViewed),
+    lastViewedAtIdx: index("posts_last_viewed_at_idx").on(table.lastViewedAt),
     publishedAtIdx: index("publishedAtIdx").on(table.publishedAt),
     isFavoritedIdx: index("isFavoritedIdx").on(table.isFavorited),
     mediaTypeIdx: index("posts_media_type_idx").on(table.mediaType),
@@ -577,7 +583,15 @@ import { posts } from "./schema";
 import { eq } from "drizzle-orm";
 
 const db = getDb();
-db.update(posts).set({ isViewed: true }).where(eq(posts.id, 123)).run();
+db
+  .update(posts)
+  .set({
+    isViewed: true,
+    lastViewedAt: new Date(),
+    viewCount: sql`${posts.viewCount} + 1`,
+  })
+  .where(eq(posts.id, 123))
+  .run();
 ```
 
 #### Toggle Post Favorite

--- a/drizzle/0015_add_view_metadata.sql
+++ b/drizzle/0015_add_view_metadata.sql
@@ -1,0 +1,3 @@
+ALTER TABLE posts ADD COLUMN last_viewed_at INTEGER;
+ALTER TABLE posts ADD COLUMN view_count INTEGER NOT NULL DEFAULT 0;
+CREATE INDEX posts_last_viewed_at_idx ON posts(last_viewed_at);

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -99,6 +99,13 @@
       "when": 1769269367000,
       "tag": "0014_add_theme",
       "breakpoints": true
+    },
+    {
+      "idx": 14,
+      "version": "5",
+      "when": 1769269368000,
+      "tag": "0015_add_view_metadata",
+      "breakpoints": true
     }
   ]
 }

--- a/src/main/db/schema.ts
+++ b/src/main/db/schema.ts
@@ -85,6 +85,8 @@ export const posts = sqliteTable(
     isViewed: integer("is_viewed", { mode: "boolean" })
       .notNull()
       .default(false),
+    lastViewedAt: integer("last_viewed_at", { mode: "timestamp" }),
+    viewCount: integer("view_count").notNull().default(0),
     isFavorited: integer("is_favorited", { mode: "boolean" }) // Добавили поле
       .notNull()
       .default(false),
@@ -94,6 +96,7 @@ export const posts = sqliteTable(
     postIdIdx: index("postIdIdx").on(t.postId),
     artistIdIdx: index("artistIdIdx").on(t.artistId),
     isViewedIdx: index("isViewedIdx").on(t.isViewed),
+    lastViewedAtIdx: index("posts_last_viewed_at_idx").on(t.lastViewedAt),
     publishedAtIdx: index("publishedAtIdx").on(t.publishedAt),
     isFavoritedIdx: index("isFavoritedIdx").on(t.isFavorited),
     // Composite index for common filter combination: artistId + rating + isViewed

--- a/src/main/ipc/controllers/PostsController.ts
+++ b/src/main/ipc/controllers/PostsController.ts
@@ -79,6 +79,9 @@ export class PostsController extends BaseController {
   // Cache FTS table existence check (schema doesn't change at runtime)
   // Initialized once at setup() to avoid blocking synchronous calls
   private ftsTableExistsCache: boolean = false;
+  // Cache optional view metadata columns presence for backward compatibility
+  // Initialized once at setup() to avoid runtime SQL errors on old DBs
+  private viewMetadataColumnsAvailable: boolean = false;
   
   // Cache EXTERNAL_ARTIST_ID existence check (avoids repeated DB queries)
   // Initialized once at first shadowInsertPost call
@@ -121,6 +124,31 @@ export class PostsController extends BaseController {
         error
       );
       this.ftsTableExistsCache = false;
+    }
+  }
+
+  /**
+   * Initialize posts view metadata columns existence check (called once at setup)
+   * Keeps markViewed backward-compatible with databases that haven't applied migration yet.
+   */
+  private initializeViewMetadataColumnsCheck(): void {
+    try {
+      const sqlite = getSqliteInstance();
+      const columns = sqlite
+        .prepare<[], { name: string }>("PRAGMA table_info(posts)")
+        .all();
+      const columnNames = new Set(columns.map((column) => column.name));
+      this.viewMetadataColumnsAvailable =
+        columnNames.has("last_viewed_at") && columnNames.has("view_count");
+      log.info(
+        `[PostsController] View metadata columns available: ${this.viewMetadataColumnsAvailable}`
+      );
+    } catch (error) {
+      log.warn(
+        "[PostsController] Failed to check view metadata columns, using isViewed-only fallback:",
+        error
+      );
+      this.viewMetadataColumnsAvailable = false;
     }
   }
 
@@ -212,6 +240,7 @@ export class PostsController extends BaseController {
 
     // Initialize FTS table check once at setup (avoids blocking synchronous calls at runtime)
     this.initializeFtsTableCheck();
+    this.initializeViewMetadataColumnsCheck();
 
     log.info("[PostsController] All handlers registered");
   }
@@ -881,6 +910,24 @@ export class PostsController extends BaseController {
       // Decrement artist counter only when state transitions false -> true.
       if (postData) {
         db.transaction((tx) => {
+          // Ensure external placeholder artist exists for FK constraint.
+          // Browse viewed flow may insert external posts before any favorite action.
+          const now = new Date();
+          tx.insert(artists)
+            .values({
+              id: EXTERNAL_ARTIST_ID,
+              name: `Artist ${EXTERNAL_ARTIST_ID}`,
+              tag: `${EXTERNAL_ARTIST_TAG_PREFIX}${EXTERNAL_ARTIST_ID}`,
+              provider: "rule34",
+              type: "tag",
+              apiEndpoint: "",
+              lastPostId: 0,
+              newPostsCount: 0,
+              createdAt: now,
+            })
+            .onConflictDoNothing()
+            .run();
+
           const existingPost = tx
             .select({
               id: posts.id,
@@ -898,14 +945,25 @@ export class PostsController extends BaseController {
             .get();
 
           if (existingPost) {
+            if (this.viewMetadataColumnsAvailable) {
+              tx.update(posts)
+                .set({
+                  isViewed: true,
+                  lastViewedAt: new Date(),
+                  viewCount: sql`${posts.viewCount} + 1`,
+                })
+                .where(eq(posts.id, existingPost.id))
+                .run();
+            } else {
+              tx.update(posts)
+                .set({ isViewed: true })
+                .where(eq(posts.id, existingPost.id))
+                .run();
+            }
+
             if (existingPost.isViewed) {
               return;
             }
-
-            tx.update(posts)
-              .set({ isViewed: true })
-              .where(eq(posts.id, existingPost.id))
-              .run();
 
             tx.update(artists)
               .set({
@@ -916,10 +974,10 @@ export class PostsController extends BaseController {
             return;
           }
 
-          const now = new Date();
+          const insertNow = new Date();
           const publishedAt = postData.publishedAt
             ? new Date(postData.publishedAt)
-            : now;
+            : insertNow;
 
           tx.insert(posts)
             .values({
@@ -933,8 +991,14 @@ export class PostsController extends BaseController {
               tags: postData.tags ?? "",
               mediaType: isVideoUrl(postData.fileUrl) ? "video" : "image",
               publishedAt: publishedAt,
-              createdAt: now,
+              createdAt: insertNow,
               isViewed: true, // Set to true since we're marking as viewed
+              ...(this.viewMetadataColumnsAvailable
+                ? {
+                    lastViewedAt: insertNow,
+                    viewCount: 1,
+                  }
+                : {}),
               isFavorited: false,
             })
             .run();
@@ -964,14 +1028,25 @@ export class PostsController extends BaseController {
             return false;
           }
 
+          if (this.viewMetadataColumnsAvailable) {
+            tx.update(posts)
+              .set({
+                isViewed: true,
+                lastViewedAt: new Date(),
+                viewCount: sql`${posts.viewCount} + 1`,
+              })
+              .where(eq(posts.id, postId))
+              .run();
+          } else {
+            tx.update(posts)
+              .set({ isViewed: true })
+              .where(eq(posts.id, postId))
+              .run();
+          }
+
           if (post.isViewed) {
             return true;
           }
-
-          tx.update(posts)
-            .set({ isViewed: true })
-            .where(eq(posts.id, postId))
-            .run();
 
           tx.update(artists)
             .set({

--- a/src/main/ipc/controllers/SearchController.ts
+++ b/src/main/ipc/controllers/SearchController.ts
@@ -186,6 +186,8 @@ export class SearchController extends BaseController {
       publishedAt: booruPost.createdAt,
       createdAt: booruPost.createdAt,
       isViewed: false,
+      lastViewedAt: null,
+      viewCount: 0,
       isFavorited: false,
     };
   }

--- a/src/renderer/components/pages/Browse.tsx
+++ b/src/renderer/components/pages/Browse.tsx
@@ -1,5 +1,10 @@
 import React, { useMemo, forwardRef, useCallback } from "react";
-import { useQuery } from "@tanstack/react-query";
+import {
+  useQuery,
+  useMutation,
+  useQueryClient,
+  type InfiniteData,
+} from "@tanstack/react-query";
 import { Search, Loader2 } from "lucide-react";
 import { VirtuosoGrid } from "react-virtuoso";
 import log from "electron-log/renderer";
@@ -14,6 +19,9 @@ import { useDownloadAll } from "../../hooks/useDownloadAll";
 import { DownloadAllButton } from "../downloads/DownloadAllButton";
 import { useWorkerFilteredPosts } from "../../hooks/useWorkerFilteredPosts";
 import type { WorkerFilterConfig } from "../../hooks/useWorkerProcessor";
+import type { Post } from "../../../main/db/schema";
+import { normalizePostToPostData } from "../../../shared/utils/post-normalization";
+import { EXTERNAL_ARTIST_ID } from "../../../shared/constants";
 
 // --- Компоненты для виртуализации (Grid/Masonry Layout) ---
 
@@ -85,6 +93,7 @@ const parseTags = (query: string): string[] => {
 // --- Основной компонент ---
 
 export const Browse = () => {
+  const queryClient = useQueryClient();
   // Use individual selectors to prevent unnecessary re-renders
   const query = useSearchStore((state) => state.query);
   const openViewer = useViewerStore((state) => state.open);
@@ -255,6 +264,41 @@ export const Browse = () => {
     canDownload,
   } = useDownloadAll(allPosts);
 
+  const viewMutation = useMutation({
+    mutationFn: async (post: Post) => {
+      const postData =
+        post.artistId === EXTERNAL_ARTIST_ID
+          ? normalizePostToPostData(post)
+          : undefined;
+      await window.api.markPostAsViewed(post.id, postData);
+      return post.id;
+    },
+    onSuccess: (postId) => {
+      queryClient.setQueryData<InfiniteData<Post[]>>(
+        ["search", tags],
+        (oldData) => {
+          if (!oldData) return oldData;
+          return {
+            ...oldData,
+            pages: oldData.pages.map((page) =>
+              page.map((post) =>
+                post.id === postId ? { ...post, isViewed: true } : post
+              )
+            ),
+          };
+        }
+      );
+    },
+    onError: (err) => {
+      const errorCode = (err as { code?: string })?.code;
+      if (errorCode === "RATE_LIMIT") {
+        return;
+      }
+      const errorMessage = err instanceof Error ? err.message : String(err);
+      log.error("[Browse] Failed to mark post as viewed:", errorMessage);
+    },
+  });
+
   const handlePostClick = (index: number) => {
     const postIds = allPosts.map((p) => p.id);
     const post = allPosts[index];
@@ -262,6 +306,10 @@ export const Browse = () => {
     if (!post) {
       log.warn("[Browse] handlePostClick: post not found at index", index);
       return;
+    }
+
+    if (!post.isViewed) {
+      viewMutation.mutate(post);
     }
 
     // Open viewer with search origin

--- a/src/renderer/components/pages/Favorites.tsx
+++ b/src/renderer/components/pages/Favorites.tsx
@@ -233,8 +233,8 @@ export const Favorites = () => {
       await window.api.markPostAsViewed(postId);
     },
     onSuccess: (_, postId) => {
-      queryClient.setQueryData<InfiniteData<Post[]>>(
-        ["posts", "favorites"],
+      queryClient.setQueriesData<InfiniteData<Post[]>>(
+        { queryKey: ["posts", "favorites"] },
         (oldData) => {
           if (!oldData) return oldData;
           return {

--- a/src/renderer/components/pages/Updates.tsx
+++ b/src/renderer/components/pages/Updates.tsx
@@ -256,8 +256,8 @@ export const Updates = () => {
     },
     onSuccess: (_, postId) => {
       // Update cache for updates feed using helper function
-      queryClient.setQueryData<InfiniteData<Post[]>>(
-        ["posts", "updates"],
+      queryClient.setQueriesData<InfiniteData<Post[]>>(
+        { queryKey: ["posts", "updates"] },
         (oldData) =>
           updatePostInInfiniteData(oldData, postId, (post) => ({
             ...post,

--- a/src/renderer/features/artists/ArtistGallery.tsx
+++ b/src/renderer/features/artists/ArtistGallery.tsx
@@ -172,8 +172,8 @@ export const ArtistGallery: React.FC<ArtistGalleryProps> = ({
       await window.api.markPostAsViewed(postId);
     },
     onSuccess: (_, postId) => {
-      queryClient.setQueryData<InfiniteData<Post[]>>(
-        ["posts", artist.id],
+      queryClient.setQueriesData<InfiniteData<Post[]>>(
+        { queryKey: ["posts", artist.id] },
         (oldData) => {
           if (!oldData) return oldData;
           return {
@@ -253,6 +253,8 @@ export const ArtistGallery: React.FC<ArtistGalleryProps> = ({
         tags: undefined, // No tag filtering in artist gallery
         aiFilter: aiFilter === "all" ? undefined : aiFilter,
         mediaType: mediaType === "all" ? undefined : mediaType,
+        source,
+        sortOrder,
       },
       ids: postIds,
       initialIndex: index,

--- a/src/renderer/features/viewer/ViewerDialog.tsx
+++ b/src/renderer/features/viewer/ViewerDialog.tsx
@@ -384,11 +384,20 @@ const useCurrentPost = (
       }
       case "artist": {
         // CRITICAL: Match query key from ArtistGallery.tsx
-        // QueryKey includes: ["posts", artistId, aiFilter, mediaType]
+        // QueryKey includes: ["posts", artistId, aiFilter, mediaType, source, sortOrder]
         // This ensures cache lookup matches the query key used for fetching artist posts
         const aiFilter = origin.aiFilter ?? "all";
         const mediaType = origin.mediaType ?? "all";
-        return ["posts", origin.artistId, aiFilter, mediaType] as const;
+        const source = origin.source ?? "all";
+        const sortOrder = origin.sortOrder ?? "desc";
+        return [
+          "posts",
+          origin.artistId,
+          aiFilter,
+          mediaType,
+          source,
+          sortOrder,
+        ] as const;
       }
       case "search": {
         return ["search", origin.tags] as const;

--- a/src/renderer/features/viewer/hooks/useViewerController.ts
+++ b/src/renderer/features/viewer/hooks/useViewerController.ts
@@ -95,16 +95,17 @@ export function useViewerController({
     // Update all relevant caches optimistically (immediate UI feedback)
     // Update artist gallery cache if post has artistId
     if (post.artistId) {
-      const artistQueryKey = ["posts", post.artistId];
-      queryClient.setQueryData<InfiniteData<Post[]>>(artistQueryKey, (old) =>
+      queryClient.setQueriesData<InfiniteData<Post[]>>(
+        { queryKey: ["posts", post.artistId] },
+        (old) =>
         updatePostInCache(old, post.id, (p) => ({ ...p, isViewed: true }))
       );
     }
 
     // Update updates feed cache
-    const updatesQueryKey = ["posts", "updates"];
-    queryClient.setQueryData<InfiniteData<Post[]>>(updatesQueryKey, (old) =>
-      updatePostInCache(old, post.id, (p) => ({ ...p, isViewed: true }))
+    queryClient.setQueriesData<InfiniteData<Post[]>>(
+      { queryKey: ["posts", "updates"] },
+      (old) => updatePostInCache(old, post.id, (p) => ({ ...p, isViewed: true }))
     );
 
     // Update search cache (for Browse page) if post is from search
@@ -168,8 +169,9 @@ export function useViewerController({
       // Update all relevant caches using shared utility
       // Update artist gallery cache if post has artistId
       if (post.artistId) {
-        const artistQueryKey = ["posts", post.artistId];
-        queryClient.setQueryData<InfiniteData<Post[]>>(artistQueryKey, (old) =>
+        queryClient.setQueriesData<InfiniteData<Post[]>>(
+          { queryKey: ["posts", post.artistId] },
+          (old) =>
           updatePostInCache(old, post.id, (p) => ({
             ...p,
             isFavorited: newState,
@@ -178,12 +180,13 @@ export function useViewerController({
       }
 
       // Update updates feed cache
-      const updatesQueryKey = ["posts", "updates"];
-      queryClient.setQueryData<InfiniteData<Post[]>>(updatesQueryKey, (old) =>
-        updatePostInCache(old, post.id, (p) => ({
-          ...p,
-          isFavorited: newState,
-        }))
+      queryClient.setQueriesData<InfiniteData<Post[]>>(
+        { queryKey: ["posts", "updates"] },
+        (old) =>
+          updatePostInCache(old, post.id, (p) => ({
+            ...p,
+            isFavorited: newState,
+          }))
       );
 
       // Update search cache (for Browse page) if post is from search
@@ -199,37 +202,38 @@ export function useViewerController({
 
       // Update favorites cache separately
       const favoritesQueryKey = ["posts", "favorites"];
-      const oldFavoritesData =
-        queryClient.getQueryData<InfiniteData<Post[]>>(favoritesQueryKey);
+      const favoritesQueriesData =
+        queryClient.getQueriesData<InfiniteData<Post[]>>({
+          queryKey: favoritesQueryKey,
+        });
+      const oldFavoritesData = favoritesQueriesData[0]?.[1];
 
-      if (oldFavoritesData) {
-        queryClient.setQueryData<InfiniteData<Post[]>>(
-          favoritesQueryKey,
-          (old) => {
-            if (!old) return old;
+      queryClient.setQueriesData<InfiniteData<Post[]>>(
+        { queryKey: favoritesQueryKey },
+        (old) => {
+          if (!old) return old;
 
-            // If removing from favorites, filter out the post
-            if (!newState) {
-              return {
-                ...old,
-                pages: old.pages
-                  .map((page) => page.filter((p) => p.id !== post.id))
-                  .filter((page) => page.length > 0),
-              };
-            }
-
-            // If adding to favorites, update existing post
+          // If removing from favorites, filter out the post
+          if (!newState) {
             return {
               ...old,
-              pages: old.pages.map((page) =>
-                page.map((p) =>
-                  p.id === post.id ? { ...p, isFavorited: newState } : p
-                )
-              ),
+              pages: old.pages
+                .map((page) => page.filter((p) => p.id !== post.id))
+                .filter((page) => page.length > 0),
             };
           }
-        );
-      }
+
+          // If adding to favorites, update existing post
+          return {
+            ...old,
+            pages: old.pages.map((page) =>
+              page.map((p) =>
+                p.id === post.id ? { ...p, isFavorited: newState } : p
+              )
+            ),
+          };
+        }
+      );
 
       // Invalidate favorites query if removing from favorites or post not in cache
       const foundInCache = oldFavoritesData?.pages.some((page) =>

--- a/src/renderer/hooks/useWorkerFilteredPosts.ts
+++ b/src/renderer/hooks/useWorkerFilteredPosts.ts
@@ -89,6 +89,8 @@ export function useWorkerFilteredPosts(
               publishedAt,
               createdAt,
               isViewed: workerPost.isViewed,
+              lastViewedAt: null,
+              viewCount: 0,
               isFavorited: workerPost.isFavorited,
             };
           });

--- a/src/renderer/store/viewerStore.ts
+++ b/src/renderer/store/viewerStore.ts
@@ -5,7 +5,15 @@ export type ViewerOrigin =
   | { kind: "search"; tags: string[] }
   | { kind: "favorites"; tags?: string[] }
   | { kind: "updates"; tags?: string[] }
-  | { kind: "artist"; artistId: number; tags?: string[]; aiFilter?: "all" | "hide" | "only"; mediaType?: "all" | "images" | "videos" }
+  | {
+      kind: "artist";
+      artistId: number;
+      tags?: string[];
+      aiFilter?: "all" | "hide" | "only";
+      mediaType?: "all" | "images" | "videos";
+      source?: "all" | "favorites" | "subscriptions";
+      sortOrder?: "asc" | "desc";
+    }
   | { kind: "playlist"; playlistId: number; mediaType?: "all" | "images" | "videos"; sortOrder?: "asc" | "desc"; provider?: "rule34" | "gelbooru" };
 
 // Очередь просмотра


### PR DESCRIPTION
- Introduced `last_viewed_at` and `view_count` fields to the posts schema for tracking post views.
- Updated database migration to include new indices for efficient querying of view metadata.
- Enhanced `PostsController` to handle backward compatibility for existing databases without the new fields.
- Modified post update logic to increment view count and set last viewed timestamp.
- Updated various components to utilize the new view metadata, ensuring consistent behavior across the application.