### PR TITLE
chore: add query schema versioning for smart playlists

### DIFF
--- a/docs/database.md
+++ b/docs/database.md
@@ -255,6 +255,7 @@ Stores playlist/collection information for curated post collections.
 | `name`        | TEXT (NOT NULL)                   | Playlist display name                          |
 | `is_smart`    | INTEGER (BOOLEAN, DEFAULT 0)      | Smart playlist flag (dynamic tag-based queries) |
 | `query_json`  | TEXT (DEFAULT '')                 | JSON-encoded smart playlist query              |
+| `query_schema_version` | INTEGER (NOT NULL, DEFAULT 1) | Version of smart playlist query DSL for safe parsing/migrations |
 | `icon_name`   | TEXT (DEFAULT '')                 | Icon name for playlist display                 |
 | `created_at`  | INTEGER (TIMESTAMP, NOT NULL)     | Creation timestamp (timestamp mode, ms)        |
 
@@ -275,6 +276,7 @@ export const playlists = sqliteTable(
       .notNull()
       .default(false),
     queryJson: text("query_json").default(""),
+    querySchemaVersion: integer("query_schema_version").notNull().default(1),
     iconName: text("icon_name").default(""),
     createdAt: integer("created_at", { mode: "timestamp" })
       .notNull()
@@ -286,6 +288,8 @@ export const playlists = sqliteTable(
   })
 );
 ```
+
+Smart playlist queries are versioned. When changing the DSL, increment `query_schema_version` and provide a migrator from version N to N+1 before enabling the new parser in runtime code.
 
 **TypeScript Types:**
 

--- a/drizzle/0016_add_smart_query_version.sql
+++ b/drizzle/0016_add_smart_query_version.sql
@@ -1,0 +1,1 @@
+ALTER TABLE playlists ADD COLUMN query_schema_version INTEGER NOT NULL DEFAULT 1;

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -106,6 +106,13 @@
       "when": 1769269368000,
       "tag": "0015_add_view_metadata",
       "breakpoints": true
+    },
+    {
+      "idx": 15,
+      "version": "5",
+      "when": 1769269369000,
+      "tag": "0016_add_smart_query_version",
+      "breakpoints": true
     }
   ]
 }

--- a/src/main/db/schema.ts
+++ b/src/main/db/schema.ts
@@ -154,6 +154,7 @@ export const playlists = sqliteTable(
       .notNull()
       .default(false),
     queryJson: text("query_json").default(""),
+    querySchemaVersion: integer("query_schema_version").notNull().default(1),
     iconName: text("icon_name").default(""),
     createdAt: integer("created_at", { mode: "timestamp" })
       .notNull()

--- a/src/main/ipc/controllers/PlaylistController.ts
+++ b/src/main/ipc/controllers/PlaylistController.ts
@@ -18,7 +18,6 @@ import {
   RemovePostsFromPlaylistSchema,
   GetPlaylistPostsSchema,
   ResolvePlaylistPostsSchema,
-  SmartPlaylistQuerySchema,
   type CreatePlaylistRequest,
   type UpdatePlaylistRequest,
   type AddPostsToPlaylistRequest,
@@ -27,6 +26,10 @@ import {
   type ResolvePlaylistPostsRequest,
   type SmartPlaylistQuery,
 } from "../../../shared/schemas/playlist";
+import {
+  CURRENT_SMART_QUERY_SCHEMA_VERSION,
+  parseSmartQuery,
+} from "../../../shared/schemas/smart-playlist-query";
 import { isVideoUrl } from "@shared/utils/media";
 import { EXTERNAL_ARTIST_ID, MAX_RANDOM_PAGES } from "../../../shared/constants";
 import { getSqliteInstance } from "../../db/client";
@@ -682,6 +685,7 @@ export class PlaylistController extends BaseController {
           name: data.name,
           isSmart: data.isSmart ?? true, // Default to Smart Collection
           queryJson: data.queryJson ?? "",
+          querySchemaVersion: CURRENT_SMART_QUERY_SCHEMA_VERSION,
           iconName: data.iconName ?? "",
         })
         .returning()
@@ -701,16 +705,16 @@ export class PlaylistController extends BaseController {
       // Use Zod schema validation to ensure data integrity
       if (playlist.isSmart && playlist.queryJson) {
         try {
-          // SECURITY: Validate queryJson using Zod schema before parsing
-          // This prevents crashes from invalid JSON or malicious data
-          const parseResult = SmartPlaylistQuerySchema.safeParse(JSON.parse(playlist.queryJson));
-          
-          if (parseResult.success) {
+          const parsedQuery = parseSmartQuery(
+            playlist.queryJson,
+            playlist.querySchemaVersion
+          );
+          if (parsedQuery) {
             // SECURITY: Wrap JSON.stringify in try-catch to prevent crashes from circular references or invalid data
             try {
               log.info(
                 `[PlaylistController] Smart playlist ${playlist.id} query_json:`,
-                JSON.stringify(parseResult.data, null, 2)
+                JSON.stringify(parsedQuery, null, 2)
               );
             } catch (stringifyError) {
               // If JSON.stringify fails (circular reference, etc.), log a safe message
@@ -725,8 +729,7 @@ export class PlaylistController extends BaseController {
             }
           } else {
             log.warn(
-              `[PlaylistController] Invalid query_json schema for playlist ${playlist.id}:`,
-              parseResult.error.errors
+              `[PlaylistController] Invalid query_json schema for playlist ${playlist.id} (version ${playlist.querySchemaVersion})`
             );
           }
         } catch (parseError) {
@@ -820,6 +823,7 @@ export class PlaylistController extends BaseController {
       }
       if (data.queryJson !== undefined) {
         updateData.queryJson = data.queryJson;
+        updateData.querySchemaVersion = CURRENT_SMART_QUERY_SCHEMA_VERSION;
       }
       if (data.iconName !== undefined) {
         updateData.iconName = data.iconName;
@@ -1214,31 +1218,26 @@ export class PlaylistController extends BaseController {
         return [];
       }
 
-      // Parse and validate queryJson using Zod schema
-      // SECURITY: Never trust JSON.parse without validation - use Zod schema to ensure data integrity
-      // This prevents crashes from invalid JSON or malicious data in database
+      // Parse and validate queryJson via versioned smart-query resolver
       let query: SmartPlaylistQuery;
-      try {
-        const rawParsed = JSON.parse(playlist.queryJson);
-        const parseResult = SmartPlaylistQuerySchema.safeParse(rawParsed);
-        
-        if (!parseResult.success) {
-          log.error(
-            `[PlaylistController] Invalid query_json schema for smart playlist ${playlistId}:`,
-            parseResult.error.errors
-          );
-          throw new Error(`Invalid query_json schema for smart playlist ${playlistId}: ${parseResult.error.message}`);
-        }
-        
-        query = parseResult.data;
-        log.info(`[PlaylistController] Parsed query_json for smart playlist ${playlistId}:`, JSON.stringify(query));
-      } catch (error) {
+      const parsedQuery = parseSmartQuery(
+        playlist.queryJson,
+        playlist.querySchemaVersion
+      );
+      if (!parsedQuery) {
         log.error(
           `[PlaylistController] Failed to parse query_json for smart playlist ${playlistId}:`,
-          error
+          `version=${playlist.querySchemaVersion}`
         );
-        throw new Error(`Invalid query_json for smart playlist ${playlistId}: ${error instanceof Error ? error.message : String(error)}`);
+        throw new Error(
+          `Invalid query_json for smart playlist ${playlistId} (version ${playlist.querySchemaVersion})`
+        );
       }
+      query = parsedQuery;
+      log.info(
+        `[PlaylistController] Parsed query_json for smart playlist ${playlistId}:`,
+        JSON.stringify(query)
+      );
 
       // Smart playlist: Hybrid Search - always query both local DB and remote API concurrently
       // Step 1: Query local DB using FTS5

--- a/src/renderer/components/pages/PlaylistsPage.tsx
+++ b/src/renderer/components/pages/PlaylistsPage.tsx
@@ -165,7 +165,10 @@ const PlaylistGallery: React.FC<PlaylistGalleryProps> = ({ playlist, onBack }) =
     // Provider must match the actual source of posts to prevent 404 or invalid data
     let provider: "rule34" | "gelbooru" | undefined = undefined;
     if (playlist.isSmart && playlist.queryJson) {
-      const parsedQuery = parsePlaylistQuery(playlist.queryJson);
+      const parsedQuery = parsePlaylistQuery(
+        playlist.queryJson,
+        playlist.querySchemaVersion
+      );
       provider = parsedQuery?.provider;
     }
     
@@ -648,7 +651,10 @@ export const PlaylistsPage: React.FC<PlaylistsPageProps> = ({ onBack }) => {
                       setPlaylistType(playlist.isSmart ? "smart" : "manual");
                       if (playlist.isSmart && playlist.queryJson) {
                         // Use shared utility to parse queryJson (Renderer shouldn't know DB format)
-                        const queryJson = parsePlaylistQuery(playlist.queryJson);
+                        const queryJson = parsePlaylistQuery(
+                          playlist.queryJson,
+                          playlist.querySchemaVersion
+                        );
                         setSmartTags(queryJson?.tags || []);
                       } else {
                         setSmartTags([]);

--- a/src/renderer/features/viewer/ViewerDialog.tsx
+++ b/src/renderer/features/viewer/ViewerDialog.tsx
@@ -184,7 +184,10 @@ const PostNotFoundFallback = ({
               // SECURITY: Validate queryJson using parsePlaylistQuery utility
               // This prevents crashes from invalid JSON or malicious data
               if (playlist?.isSmart && playlist.queryJson) {
-                const parsedQuery = parsePlaylistQuery(playlist.queryJson);
+                const parsedQuery = parsePlaylistQuery(
+                  playlist.queryJson,
+                  playlist.querySchemaVersion
+                );
                 if (parsedQuery?.provider) {
                   provider = parsedQuery.provider;
                 }

--- a/src/shared/schemas/playlist.ts
+++ b/src/shared/schemas/playlist.ts
@@ -1,4 +1,9 @@
 import { z } from "zod";
+import {
+  SmartQueryTagSchema,
+  type SmartQueryV1,
+  parseSmartQuery,
+} from "./smart-playlist-query";
 
 /**
  * Smart Playlist Tag Schema
@@ -6,10 +11,7 @@ import { z } from "zod";
  * Tag-centric structure for smart playlists.
  * Tags can be included (AND logic) or excluded (OR logic).
  */
-export const SmartPlaylistTagSchema = z.object({
-  tag: z.string().min(1, "Tag cannot be empty"),
-  type: z.enum(["include", "exclude"]),
-});
+export const SmartPlaylistTagSchema = SmartQueryTagSchema;
 
 export type SmartPlaylistTag = z.infer<typeof SmartPlaylistTagSchema>;
 
@@ -24,11 +26,11 @@ export type SmartPlaylistTag = z.infer<typeof SmartPlaylistTagSchema>;
  * This is critical for shadow insert operations - wrong provider = 404 or invalid data.
  */
 export const SmartPlaylistQuerySchema = z.object({
-  tags: z.array(SmartPlaylistTagSchema).min(1, "At least one tag is required"),
+  tags: z.array(SmartQueryTagSchema).min(1, "At least one tag is required"),
   provider: z.enum(["rule34", "gelbooru"]).optional().default("rule34"),
 });
 
-export type SmartPlaylistQuery = z.infer<typeof SmartPlaylistQuerySchema>;
+export type SmartPlaylistQuery = SmartQueryV1;
 
 /**
  * Create Playlist Schema
@@ -167,16 +169,9 @@ export type ResolvePlaylistPostsRequest = z.infer<typeof ResolvePlaylistPostsSch
  * @param queryJson - JSON string from database (may be empty for manual playlists)
  * @returns Parsed SmartPlaylistQuery or null if invalid/empty
  */
-export function parsePlaylistQuery(queryJson: string | null | undefined): SmartPlaylistQuery | null {
-  if (!queryJson || queryJson.trim() === "") {
-    return null;
-  }
-  
-  try {
-    return JSON.parse(queryJson) as SmartPlaylistQuery;
-  } catch (_error) {
-    // Invalid JSON - return null instead of throwing
-    // This allows graceful handling in UI
-    return null;
-  }
+export function parsePlaylistQuery(
+  queryJson: string | null | undefined,
+  querySchemaVersion = 1
+): SmartPlaylistQuery | null {
+  return parseSmartQuery(queryJson, querySchemaVersion);
 }

--- a/src/shared/schemas/smart-playlist-query.ts
+++ b/src/shared/schemas/smart-playlist-query.ts
@@ -1,0 +1,35 @@
+import { z } from "zod";
+
+export const CURRENT_SMART_QUERY_SCHEMA_VERSION = 1;
+
+export const SmartQueryTagSchema = z.object({
+  tag: z.string().min(1, "Tag cannot be empty"),
+  type: z.enum(["include", "exclude"]),
+});
+
+// v1: current smart-playlist DSL in production
+export const SmartQueryV1Schema = z.object({
+  tags: z.array(SmartQueryTagSchema).min(1, "At least one tag is required"),
+  provider: z.enum(["rule34", "gelbooru"]).optional().default("rule34"),
+});
+
+export type SmartQueryV1 = z.infer<typeof SmartQueryV1Schema>;
+
+export function parseSmartQuery(
+  json: string | null | undefined,
+  version: number
+): SmartQueryV1 | null {
+  if (!json || json.trim() === "") {
+    return null;
+  }
+
+  try {
+    const parsed = JSON.parse(json);
+    if (version === 1) {
+      return SmartQueryV1Schema.parse(parsed);
+    }
+    return null;
+  } catch {
+    return null;
+  }
+}


### PR DESCRIPTION
- Introduced `query_schema_version` to the playlists schema for managing smart playlist query versions.
- Updated `PlaylistController` to handle versioned smart queries, ensuring backward compatibility and safe parsing.
- Refactored `parsePlaylistQuery` to utilize the new versioning system, enhancing query validation and error handling.
- Documented the need for version increments and migrations when changing the smart playlist query DSL.