### PR TITLE
Fix/updates-batch-mark-read

### DIFF
--- a/.cursorrules
+++ b/.cursorrules
@@ -40,7 +40,7 @@ You do not tolerate sloppy code, "any" types, "as" casting, magic numbers, or pr
    - **No Magic**: NO Magic Numbers or Magic Strings. Extract constants.
    - **Definitions**: Use `type` for fixed definitions, `interface` for extendable structures.
    - **Python**: Type hinting is mandatory (TypeDict, Pydantic). No bare `try-except`.
-   - **Unused Imports**: **MANDATORY** - After every code change, remove all unused imports and variables. Run `npm run typecheck` to verify. Unused code is technical debt and must be cleaned immediately.
+  - **Unused Imports**: **MANDATORY** - After every code change, remove all unused imports and variables. Run `npm run validate` to verify. Unused code is technical debt and must be cleaned immediately.
 
 5. **Testing**:
    - Focus on behavior/integration over implementation details.

--- a/src/main/bridge.ts
+++ b/src/main/bridge.ts
@@ -85,6 +85,7 @@ export interface IpcBridge {
   getPostsCountWithFilters: (params: Pick<GetPostsRequest, "artistId" | "filters">) => Promise<number>;
 
   togglePostViewed: (postId: number) => Promise<boolean>;
+  markAllPostsAsViewed: () => Promise<{ updatedCount: number }>;
 
   resetPostCache: (postId: number) => Promise<boolean>;
 
@@ -256,6 +257,8 @@ const ipcBridge: IpcBridge = {
 
   togglePostViewed: (postId) =>
     ipcRenderer.invoke("db:toggle-post-viewed", postId),
+  markAllPostsAsViewed: () =>
+    ipcRenderer.invoke(IPC_CHANNELS.DB.MARK_ALL_VIEWED),
 
   resetPostCache: (postId) => ipcRenderer.invoke("db:reset-post-cache", postId),
 

--- a/src/main/ipc/channels.ts
+++ b/src/main/ipc/channels.ts
@@ -26,6 +26,7 @@ export const IPC_CHANNELS = {
     GET_POSTS_COUNT: "db:get-posts-count",
     GET_POSTS_COUNT_WITH_FILTERS: "db:get-posts-count-with-filters",
     MARK_VIEWED: "db:mark-post-viewed",
+    MARK_ALL_VIEWED: "db:mark-all-viewed",
     TOGGLE_FAVORITE: "db:toggle-post-favorite",
     SYNC_ALL: "db:sync-all",
     TOGGLE_POST_VIEWED: "db:toggle-post-viewed" as const,

--- a/src/main/ipc/controllers/PostsController.ts
+++ b/src/main/ipc/controllers/PostsController.ts
@@ -208,6 +208,14 @@ export class PostsController extends BaseController {
       ) => Promise<unknown>
     );
     this.handle(
+      IPC_CHANNELS.DB.MARK_ALL_VIEWED,
+      z.tuple([]),
+      this.markAllViewed.bind(this) as (
+        event: IpcMainInvokeEvent,
+        ...args: unknown[]
+      ) => Promise<unknown>
+    );
+    this.handle(
       IPC_CHANNELS.DB.RESET_POST_CACHE,
       z.tuple([z.number().int().positive()]),
       // Type assertion is safe: BaseController validates args with Zod schema before calling handler
@@ -1072,6 +1080,30 @@ export class PostsController extends BaseController {
     } catch (error) {
       log.error("[PostsController] Failed to mark post as viewed:", error);
       return false;
+    }
+  }
+
+  /**
+   * Mark all posts as viewed in one batch operation.
+   * Uses synchronous better-sqlite3 statement to avoid async transaction overhead.
+   */
+  private async markAllViewed(
+    _event: IpcMainInvokeEvent
+  ): Promise<{ updatedCount: number }> {
+    try {
+      const sqlite = getSqliteInstance();
+      const result = sqlite
+        .prepare(
+          "UPDATE posts SET is_viewed = 1 WHERE is_viewed = 0 OR is_viewed IS NULL"
+        )
+        .run();
+
+      const updatedCount = result.changes;
+      log.info(`[PostsController] Mark all viewed completed. Updated: ${updatedCount}`);
+      return { updatedCount };
+    } catch (error) {
+      log.error("[PostsController] Failed to mark all posts as viewed:", error);
+      return { updatedCount: 0 };
     }
   }
 

--- a/src/renderer.d.ts
+++ b/src/renderer.d.ts
@@ -83,6 +83,7 @@ export interface IpcApi extends IpcBridge {
   getArtistPostsCount: (params: GetPostsCountRequest) => Promise<number>;
 
   togglePostViewed: (postId: number) => Promise<boolean>;
+  markAllPostsAsViewed: () => Promise<{ updatedCount: number }>;
 
   resetPostCache: (postId: number) => Promise<boolean>;
 

--- a/src/renderer/components/pages/Updates.tsx
+++ b/src/renderer/components/pages/Updates.tsx
@@ -5,7 +5,7 @@ import {
   useMutation,
   InfiniteData,
 } from "@tanstack/react-query";
-import { RefreshCw, Loader2 } from "lucide-react";
+import { RefreshCw, Loader2, CheckCheck } from "lucide-react";
 import { VirtuosoGrid } from "react-virtuoso";
 import log from "electron-log/renderer";
 import { cn } from "../../lib/utils";
@@ -16,6 +16,7 @@ import { PostCard } from "../../features/artists/components/PostCard";
 import type { Post } from "../../../main/db/schema";
 import { useDownloadAllWithFilters } from "../../hooks/useDownloadAll";
 import { DownloadAllButton } from "../downloads/DownloadAllButton";
+import { Button } from "../ui/button";
 
 // --- Constants ---
 const POSTS_PER_PAGE = 50;
@@ -277,6 +278,28 @@ export const Updates = () => {
     },
   });
 
+  const markAllMutation = useMutation({
+    mutationFn: () => window.api.markAllPostsAsViewed(),
+    onSuccess: () => {
+      queryClient.setQueriesData<InfiniteData<Post[]>>(
+        { queryKey: ["posts", "updates"] },
+        (old) => {
+          if (!old) return old;
+          return {
+            ...old,
+            pages: old.pages.map((page) =>
+              page.map((post) => ({ ...post, isViewed: true }))
+            ),
+          };
+        }
+      );
+    },
+    onError: (err) => {
+      const errorMessage = err instanceof Error ? err.message : String(err);
+      log.error("[Updates] Failed to mark all as viewed:", errorMessage);
+    },
+  });
+
   const handleLoadMore = async () => {
     if (hasNextPage && !isFetchingNextPage) {
       log.info("[Updates] Viewer requested more posts. Fetching...");
@@ -382,6 +405,17 @@ export const Updates = () => {
           canDownload={canDownload || allPosts.length > 0}
           totalLabel={downloadTotalCount || allPosts.length}
         />
+        <Button
+          variant="outline"
+          size="sm"
+          onClick={() => markAllMutation.mutate()}
+          disabled={allPosts.length === 0 || markAllMutation.isPending}
+          aria-label="Mark all posts as read"
+          className="ml-2"
+        >
+          <CheckCheck className="w-4 h-4 mr-2" />
+          Mark all read
+        </Button>
       </div>
 
       {/* Grid Content */}


### PR DESCRIPTION
- Changed the command for verifying unused imports from `npm run typecheck` to `npm run validate` to ensure consistency in code quality checks.
- This update reinforces the importance of maintaining clean code and reducing technical debt.