### PR TITLE
feat: add sync interval setting for background synchronization

### DIFF
--- a/drizzle/0018_add_sync_interval.sql
+++ b/drizzle/0018_add_sync_interval.sql
@@ -1,0 +1,1 @@
+ALTER TABLE settings ADD COLUMN sync_interval_minutes INTEGER NOT NULL DEFAULT 0;

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -120,6 +120,13 @@
       "when": 1776854844796,
       "tag": "0017_add_auto_sync_startup",
       "breakpoints": true
+    },
+    {
+      "idx": 18,
+      "version": "6",
+      "when": 1776855287553,
+      "tag": "0018_add_sync_interval",
+      "breakpoints": true
     }
   ]
 }

--- a/src/main/core/di/Container.ts
+++ b/src/main/core/di/Container.ts
@@ -3,6 +3,7 @@ import { Token } from "./Token";
 import type { BetterSQLite3Database } from "drizzle-orm/better-sqlite3";
 import type * as schema from "../../db/schema";
 import type { SyncService } from "../../services/sync-service";
+import type { SyncScheduler } from "../../services/sync-scheduler";
 
 // Type aliases for cleaner token definitions
 type AppDatabase = BetterSQLite3Database<typeof schema>;
@@ -19,6 +20,7 @@ type AppDatabase = BetterSQLite3Database<typeof schema>;
 export const DI_TOKENS = {
   DB: new Token<AppDatabase>("Database", "SQLite database instance"),
   SYNC_SERVICE: new Token<SyncService>("SyncService", "Artist synchronization service"),
+  SYNC_SCHEDULER: new Token<SyncScheduler>("SyncScheduler", "Periodic synchronization scheduler"),
 } as const;
 
 /**

--- a/src/main/db/schema.ts
+++ b/src/main/db/schema.ts
@@ -135,6 +135,7 @@ export const settings = sqliteTable("settings", {
   autoSyncOnStartup: integer("auto_sync_on_startup", { mode: "boolean" })
     .default(false)
     .notNull(),
+  syncIntervalMinutes: integer("sync_interval_minutes").default(0).notNull(),
 });
 
 export const tagMetadata = sqliteTable(

--- a/src/main/ipc/controllers/SettingsController.ts
+++ b/src/main/ipc/controllers/SettingsController.ts
@@ -35,6 +35,7 @@ const DEFAULT_IPC_SETTINGS: IpcSettings = {
   downloadFolderStructure: "flat",
   theme: "system",
   autoSyncOnStartup: false,
+  syncIntervalMinutes: 0,
 };
 
 /**
@@ -87,6 +88,7 @@ function mapSettingsToIpc(
       (dbSettings.downloadFolderStructure as "flat" | "{artist_id}") || "flat",
     theme: (dbSettings.theme as ThemePreference) || "system",
     autoSyncOnStartup: !!dbSettings.autoSyncOnStartup,
+    syncIntervalMinutes: dbSettings.syncIntervalMinutes ?? 0,
   };
 }
 
@@ -304,6 +306,7 @@ export class SettingsController extends BaseController {
               tosAcceptedAt: existing.tosAcceptedAt ?? null,
               theme: existing.theme ?? "system",
               autoSyncOnStartup: data.autoSyncOnStartup ?? false,
+              syncIntervalMinutes: data.syncIntervalMinutes ?? 0,
             })
             .where(eq(settings.id, targetId))
             .run();
@@ -320,6 +323,7 @@ export class SettingsController extends BaseController {
               tosAcceptedAt: null,
               theme: "system",
               autoSyncOnStartup: data.autoSyncOnStartup ?? false,
+              syncIntervalMinutes: data.syncIntervalMinutes ?? 0,
             })
             .run();
         }
@@ -355,6 +359,8 @@ export class SettingsController extends BaseController {
 
       // Invalidate cache after saving settings
       this.settingsCache = null;
+      const scheduler = container.resolve(DI_TOKENS.SYNC_SCHEDULER);
+      scheduler.restart(data.syncIntervalMinutes ?? 0);
 
       return true;
     } catch (error) {

--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -84,10 +84,12 @@ import { initializeDatabase, closeDatabase, getDb } from "./db/client";
 import { logger } from "./lib/logger";
 import { updaterService } from "./services/updater-service";
 import { syncService } from "./services/sync-service";
+import { SyncScheduler } from "./services/sync-scheduler";
 import { USER_DATA_DIR_NAME } from "./db/paths";
 import { getAllProviderDomains } from "./providers";
 import { eq } from "drizzle-orm";
 import { settings, SETTINGS_ID } from "./db/schema";
+import { container, DI_TOKENS } from "./core/di/Container";
 
 logger.info("🚀 Application starting...");
 
@@ -143,6 +145,8 @@ process.env.USER_DATA_PATH = app.getPath("userData");
 
 let mainWindow: BrowserWindow | null = null;
 let tray: Tray | null = null;
+const syncScheduler = new SyncScheduler(syncService);
+container.register(DI_TOKENS.SYNC_SCHEDULER, syncScheduler);
 
 // In test mode, skip single instance lock to allow multiple test instances
 // Each test uses a unique --user-data-dir, so there's no conflict
@@ -517,6 +521,20 @@ async function initializeAppAndWindow() {
             }
           }, 2000); // 2s delay: let UI settle before starting sync
 
+          try {
+            const db = getDb();
+            const currentSettings = db
+              .select()
+              .from(settings)
+              .where(eq(settings.id, SETTINGS_ID))
+              .limit(1)
+              .all()[0];
+            const intervalMinutes = currentSettings?.syncIntervalMinutes ?? 0;
+            syncScheduler.restart(intervalMinutes);
+          } catch (error) {
+            logger.error("[Main] Failed to start sync scheduler:", error);
+          }
+
           // Create system tray
           createTray(window);
 
@@ -534,6 +552,7 @@ async function initializeAppAndWindow() {
 
     // Clean up tray and database when app quits
     app.on("before-quit", () => {
+      syncScheduler.stop();
       if (tray) {
         tray.destroy();
         tray = null;

--- a/src/main/services/sync-scheduler.ts
+++ b/src/main/services/sync-scheduler.ts
@@ -1,0 +1,47 @@
+import log from "electron-log";
+import type { SyncService } from "./sync-service";
+
+const MIN_INTERVAL_MINUTES = 5;
+
+export class SyncScheduler {
+  private timer: ReturnType<typeof setInterval> | null = null;
+  private syncService: SyncService;
+
+  constructor(syncService: SyncService) {
+    this.syncService = syncService;
+  }
+
+  /** Start or restart the scheduler with the given interval.
+   *  Pass 0 or negative to disable. */
+  public restart(intervalMinutes: number): void {
+    this.stop();
+    if (intervalMinutes < MIN_INTERVAL_MINUTES) {
+      log.info(`[SyncScheduler] Disabled (interval=${intervalMinutes})`);
+      return;
+    }
+    const ms = intervalMinutes * 60 * 1000;
+    log.info(`[SyncScheduler] Started with interval=${intervalMinutes}min`);
+    this.timer = setInterval(() => {
+      this.runSync();
+    }, ms);
+  }
+
+  public stop(): void {
+    if (this.timer !== null) {
+      clearInterval(this.timer);
+      this.timer = null;
+      log.info("[SyncScheduler] Stopped");
+    }
+  }
+
+  private runSync(): void {
+    if (this.syncService.getIsSyncing()) {
+      log.info("[SyncScheduler] Skipping scheduled sync - already syncing");
+      return;
+    }
+    log.info("[SyncScheduler] Running scheduled sync");
+    this.syncService.syncAllArtists().catch((error) => {
+      log.error("[SyncScheduler] Scheduled sync failed:", error);
+    });
+  }
+}

--- a/src/renderer.d.ts
+++ b/src/renderer.d.ts
@@ -48,6 +48,7 @@ export interface IpcSettings {
   downloadFolderStructure: "flat" | "{artist_id}";
   theme: "system" | "light" | "dark";
   autoSyncOnStartup: boolean;
+  syncIntervalMinutes: number;
 }
 
 export interface IpcApi extends IpcBridge {
@@ -62,6 +63,7 @@ export interface IpcApi extends IpcBridge {
     userId?: string;
     apiKey?: string;
     autoSyncOnStartup?: boolean;
+    syncIntervalMinutes?: number;
   }) => Promise<boolean>;
   saveTheme: (theme: "system" | "light" | "dark") => Promise<boolean>;
   saveDownloadFolder: (path: string | null) => Promise<boolean>;

--- a/src/renderer/features/settings/Settings.tsx
+++ b/src/renderer/features/settings/Settings.tsx
@@ -43,6 +43,7 @@ export const Settings = () => {
   >("flat");
   const [databaseLocation, setDatabaseLocation] = useState<string>("");
   const [autoSyncOnStartup, setAutoSyncOnStartup] = useState(false);
+  const [syncIntervalMinutes, setSyncIntervalMinutes] = useState("0");
 
   useEffect(() => {
     window.api.getSettings().then((s) => {
@@ -51,6 +52,9 @@ export const Settings = () => {
       if (s?.downloadFolderStructure) setDownloadFolderStructure(s.downloadFolderStructure);
       if (s?.autoSyncOnStartup !== undefined) {
         setAutoSyncOnStartup(s.autoSyncOnStartup);
+      }
+      if (s?.syncIntervalMinutes !== undefined) {
+        setSyncIntervalMinutes(String(s.syncIntervalMinutes));
       }
     });
     window.api.getDatabaseLocation().then((location) => {
@@ -264,7 +268,7 @@ export const Settings = () => {
           <CardTitle>Sync</CardTitle>
           <CardDescription>Control startup synchronization behavior.</CardDescription>
         </CardHeader>
-        <CardContent>
+        <CardContent className="space-y-4">
           <div className="flex justify-between items-start p-4 rounded-lg border">
             <div className="space-y-1 pr-4">
               <Label htmlFor="auto-sync-on-startup" className="text-sm font-medium">
@@ -288,6 +292,40 @@ export const Settings = () => {
                 }
               }}
             />
+          </div>
+          <div className="space-y-2 p-4 rounded-lg border">
+            <Label htmlFor="sync-interval" className="text-sm font-medium">
+              Sync interval
+            </Label>
+            <p className="text-sm text-muted-foreground">
+              How often to automatically sync in the background
+            </p>
+            <Select
+              value={syncIntervalMinutes}
+              onValueChange={async (value) => {
+                const previousValue = syncIntervalMinutes;
+                setSyncIntervalMinutes(value);
+                try {
+                  await window.api.saveSettings({
+                    syncIntervalMinutes: Number(value),
+                  });
+                } catch (error) {
+                  log.error("[Settings] Failed to save sync interval:", error);
+                  setSyncIntervalMinutes(previousValue);
+                }
+              }}
+            >
+              <SelectTrigger id="sync-interval">
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value="0">Disabled</SelectItem>
+                <SelectItem value="15">Every 15 minutes</SelectItem>
+                <SelectItem value="30">Every 30 minutes</SelectItem>
+                <SelectItem value="60">Every hour</SelectItem>
+                <SelectItem value="120">Every 2 hours</SelectItem>
+              </SelectContent>
+            </Select>
           </div>
         </CardContent>
       </Card>

--- a/src/shared/schemas/settings.ts
+++ b/src/shared/schemas/settings.ts
@@ -76,6 +76,7 @@ export const SaveSettingsSchema = z.object({
     .refine((val) => val.trim().length > 0, "API key cannot be whitespace only")
     .optional(),
   autoSyncOnStartup: z.boolean().optional(),
+  syncIntervalMinutes: z.number().int().min(0).max(1440).optional(),
 });
 
 /**
@@ -100,6 +101,7 @@ export const IpcSettingsSchema = z.object({
   downloadFolderStructure: z.enum(["flat", "{artist_id}"]).default("flat"),
   theme: ThemePreferenceSchema.default("system"),
   autoSyncOnStartup: z.boolean(),
+  syncIntervalMinutes: z.number().int().min(0),
 });
 
 /**


### PR DESCRIPTION
- Introduced a new setting for sync interval in minutes, allowing users to specify how often the application should automatically sync in the background.
- Updated the settings schema and validation to include the new syncIntervalMinutes field, ensuring proper type checking and constraints.
- Enhanced the Settings component to provide a dropdown for selecting the sync interval, improving user experience and flexibility.
- Implemented logic in the main process to restart the sync scheduler based on the user's selected interval, ensuring timely synchronization.
- Cleaned up related type definitions and ensured consistent handling of the new setting across the application.