### PR TITLE
feat: integrate maintenance scheduler into main process

### DIFF
--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -85,6 +85,7 @@ import { logger } from "./lib/logger";
 import { updaterService } from "./services/updater-service";
 import { syncService } from "./services/sync-service";
 import { SyncScheduler } from "./services/sync-scheduler";
+import { MaintenanceScheduler } from "./services/maintenance-scheduler";
 import { USER_DATA_DIR_NAME } from "./db/paths";
 import { getAllProviderDomains } from "./providers";
 import { eq } from "drizzle-orm";
@@ -146,6 +147,7 @@ process.env.USER_DATA_PATH = app.getPath("userData");
 let mainWindow: BrowserWindow | null = null;
 let tray: Tray | null = null;
 const syncScheduler = new SyncScheduler(syncService);
+const maintenanceScheduler = new MaintenanceScheduler();
 container.register(DI_TOKENS.SYNC_SCHEDULER, syncScheduler);
 
 // In test mode, skip single instance lock to allow multiple test instances
@@ -538,9 +540,8 @@ async function initializeAppAndWindow() {
           // Create system tray
           createTray(window);
 
-          setTimeout(() => {
-            logger.info("Main: DB maintenance skipped for now (direct DB mode)");
-          }, 3000);
+          maintenanceScheduler.start();
+          logger.info("[Main] Maintenance scheduler started");
         }
       });
     }
@@ -553,6 +554,7 @@ async function initializeAppAndWindow() {
     // Clean up tray and database when app quits
     app.on("before-quit", () => {
       syncScheduler.stop();
+      maintenanceScheduler.stop();
       if (tray) {
         tray.destroy();
         tray = null;

--- a/src/main/services/maintenance-scheduler.ts
+++ b/src/main/services/maintenance-scheduler.ts
@@ -1,0 +1,45 @@
+import log from "electron-log";
+import { getSqliteInstance } from "../db/client";
+
+const STARTUP_DELAY_MS = 10_000;
+const DAILY_INTERVAL_MS = 24 * 60 * 60 * 1000;
+
+export class MaintenanceScheduler {
+  private startupTimer: ReturnType<typeof setTimeout> | null = null;
+  private dailyTimer: ReturnType<typeof setInterval> | null = null;
+
+  public start(): void {
+    this.startupTimer = setTimeout(() => {
+      this.runMaintenance("startup");
+      this.dailyTimer = setInterval(() => {
+        this.runMaintenance("scheduled");
+      }, DAILY_INTERVAL_MS);
+    }, STARTUP_DELAY_MS);
+  }
+
+  public stop(): void {
+    if (this.startupTimer !== null) {
+      clearTimeout(this.startupTimer);
+      this.startupTimer = null;
+    }
+
+    if (this.dailyTimer !== null) {
+      clearInterval(this.dailyTimer);
+      this.dailyTimer = null;
+    }
+  }
+
+  private runMaintenance(trigger: "startup" | "scheduled"): void {
+    // Yield to event loop to keep startup/UI responsive.
+    setImmediate(() => {
+      try {
+        const sqlite = getSqliteInstance();
+        sqlite.exec("PRAGMA wal_checkpoint(PASSIVE);");
+        sqlite.exec("PRAGMA optimize;");
+        log.info(`[MaintenanceScheduler] Maintenance complete (trigger=${trigger})`);
+      } catch (error) {
+        log.error("[MaintenanceScheduler] Maintenance failed:", error);
+      }
+    });
+  }
+}


### PR DESCRIPTION
- Added MaintenanceScheduler to manage periodic database maintenance tasks.
- Initialized maintenance scheduler in the main process and started it during app initialization.
- Implemented stopping of the maintenance scheduler on app quit to ensure proper resource management.
- Enhanced logging to indicate when the maintenance scheduler starts, improving traceability.