### PR TITLE
feat: implement playlist entry reordering functionality

### DIFF
--- a/drizzle/0020_add_playlist_entry_position.sql
+++ b/drizzle/0020_add_playlist_entry_position.sql
@@ -1,0 +1,10 @@
+ALTER TABLE playlist_entries ADD COLUMN position INTEGER NOT NULL DEFAULT 0;
+
+-- Initialize positions based on current addedAt order
+UPDATE playlist_entries
+SET position = (
+  SELECT COUNT(*)
+  FROM playlist_entries pe2
+  WHERE pe2.playlist_id = playlist_entries.playlist_id
+    AND pe2.added_at <= playlist_entries.added_at
+) - 1;

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -134,6 +134,13 @@
       "when": 1776859402171,
       "tag": "0019_add_proxy_url",
       "breakpoints": true
+    },
+    {
+      "idx": 20,
+      "version": "6",
+      "when": 1776859402172,
+      "tag": "0020_add_playlist_entry_position",
+      "breakpoints": true
     }
   ]
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,9 @@
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {
+        "@dnd-kit/core": "^6.3.1",
+        "@dnd-kit/sortable": "^10.0.0",
+        "@dnd-kit/utilities": "^3.2.2",
         "@headlessui/react": "^2.2.9",
         "@heroicons/react": "^2.2.0",
         "@hookform/resolvers": "^5.2.2",
@@ -483,6 +486,59 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/webpack"
+      }
+    },
+    "node_modules/@dnd-kit/accessibility": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/accessibility/-/accessibility-3.1.1.tgz",
+      "integrity": "sha512-2P+YgaXF+gRsIihwwY1gCsQSYnu9Zyj2py8kY5fFvUM1qm2WA2u639R6YNVfU4GWr+ZM5mqEsfHZZLoRONbemw==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0"
+      }
+    },
+    "node_modules/@dnd-kit/core": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/core/-/core-6.3.1.tgz",
+      "integrity": "sha512-xkGBRQQab4RLwgXxoqETICr6S5JlogafbhNsidmrkVv2YRs5MLwpjoF2qpiGjQt8S9AoxtIV603s0GIUpY5eYQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@dnd-kit/accessibility": "^3.1.1",
+        "@dnd-kit/utilities": "^3.2.2",
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0",
+        "react-dom": ">=16.8.0"
+      }
+    },
+    "node_modules/@dnd-kit/sortable": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/sortable/-/sortable-10.0.0.tgz",
+      "integrity": "sha512-+xqhmIIzvAYMGfBYYnbKuNicfSsk4RksY2XdmJhT+HAC01nix6fHCztU68jooFiMUB01Ky3F0FyOvhG/BZrWkg==",
+      "license": "MIT",
+      "dependencies": {
+        "@dnd-kit/utilities": "^3.2.2",
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "@dnd-kit/core": "^6.3.0",
+        "react": ">=16.8.0"
+      }
+    },
+    "node_modules/@dnd-kit/utilities": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/utilities/-/utilities-3.2.2.tgz",
+      "integrity": "sha512-+MKAJEOfaBe5SmV6t34p80MMKhjvUz0vRrvVJbPT0WElzaOJ/1xs+D+KDv+tD/NE5ujfrChEcshd4fLn0wpiqg==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0"
       }
     },
     "node_modules/@electron/asar": {

--- a/package.json
+++ b/package.json
@@ -101,6 +101,9 @@
     "vitest": "^4.0.16"
   },
   "dependencies": {
+    "@dnd-kit/core": "^6.3.1",
+    "@dnd-kit/sortable": "^10.0.0",
+    "@dnd-kit/utilities": "^3.2.2",
     "@headlessui/react": "^2.2.9",
     "@heroicons/react": "^2.2.0",
     "@hookform/resolvers": "^5.2.2",

--- a/src/main/bridge.ts
+++ b/src/main/bridge.ts
@@ -18,6 +18,7 @@ import type {
   RemovePostsFromPlaylistRequest,
   GetPlaylistPostsRequest,
   ResolvePlaylistPostsRequest,
+  ReorderPlaylistEntriesRequest,
 } from "../shared/schemas/playlist";
 import type { DatabaseStats } from "../shared/schemas/stats";
 
@@ -183,6 +184,7 @@ export interface IpcBridge {
   deletePlaylist: (playlistId: number) => Promise<boolean>;
   addPostsToPlaylist: (data: AddPostsToPlaylistRequest) => Promise<number>;
   removePostsFromPlaylist: (data: RemovePostsFromPlaylistRequest) => Promise<number>;
+  reorderPlaylistEntries: (params: ReorderPlaylistEntriesRequest) => Promise<void>;
   getPlaylistPosts: (params: GetPlaylistPostsRequest) => Promise<Post[]>;
   resolvePlaylistPosts: (params: ResolvePlaylistPostsRequest) => Promise<Post[]>;
   getPlaylistsContainingPost: (postId: number, rule34PostId?: number) => Promise<number[]>;
@@ -391,6 +393,8 @@ const ipcBridge: IpcBridge = {
     ipcRenderer.invoke(IPC_CHANNELS.DB.ADD_POSTS_TO_PLAYLIST, data),
   removePostsFromPlaylist: (data: RemovePostsFromPlaylistRequest) =>
     ipcRenderer.invoke(IPC_CHANNELS.DB.REMOVE_POSTS_FROM_PLAYLIST, data),
+  reorderPlaylistEntries: (params: ReorderPlaylistEntriesRequest) =>
+    ipcRenderer.invoke(IPC_CHANNELS.DB.REORDER_PLAYLIST_ENTRIES, params),
   getPlaylistPosts: (params: GetPlaylistPostsRequest) =>
     ipcRenderer.invoke(IPC_CHANNELS.DB.GET_PLAYLIST_POSTS, params),
   resolvePlaylistPosts: (params: ResolvePlaylistPostsRequest) =>

--- a/src/main/db/schema.ts
+++ b/src/main/db/schema.ts
@@ -183,6 +183,7 @@ export const playlistEntries = sqliteTable(
     addedAt: integer("added_at", { mode: "timestamp" })
       .notNull()
       .$defaultFn(() => new Date()),
+    position: integer("position").notNull().default(0),
   },
   (t) => ({
     // Composite primary key: (playlist_id, post_id)

--- a/src/main/ipc/channels.ts
+++ b/src/main/ipc/channels.ts
@@ -41,6 +41,7 @@ export const IPC_CHANNELS = {
     DELETE_PLAYLIST: "db:delete-playlist",
     ADD_POSTS_TO_PLAYLIST: "db:add-posts-to-playlist",
     REMOVE_POSTS_FROM_PLAYLIST: "db:remove-posts-from-playlist",
+    REORDER_PLAYLIST_ENTRIES: "db:reorder-playlist-entries",
     GET_PLAYLIST_POSTS: "db:get-playlist-posts",
     RESOLVE_PLAYLIST_POSTS: "db:resolve-playlist-posts",
     GET_PLAYLISTS_CONTAINING_POST: "db:get-playlists-containing-post",

--- a/src/main/ipc/controllers/PlaylistController.ts
+++ b/src/main/ipc/controllers/PlaylistController.ts
@@ -18,12 +18,14 @@ import {
   RemovePostsFromPlaylistSchema,
   GetPlaylistPostsSchema,
   ResolvePlaylistPostsSchema,
+  ReorderPlaylistEntriesSchema,
   type CreatePlaylistRequest,
   type UpdatePlaylistRequest,
   type AddPostsToPlaylistRequest,
   type RemovePostsFromPlaylistRequest,
   type GetPlaylistPostsRequest,
   type ResolvePlaylistPostsRequest,
+  type ReorderPlaylistEntriesRequest,
   type SmartPlaylistQuery,
 } from "../../../shared/schemas/playlist";
 import {
@@ -224,6 +226,15 @@ export class PlaylistController extends BaseController {
       IPC_CHANNELS.DB.GET_PLAYLIST_POSTS,
       z.tuple([GetPlaylistPostsSchema]),
       this.getPlaylistPosts.bind(this) as (
+        event: IpcMainInvokeEvent,
+        ...args: unknown[]
+      ) => Promise<unknown>
+    );
+
+    this.handle(
+      IPC_CHANNELS.DB.REORDER_PLAYLIST_ENTRIES,
+      z.tuple([ReorderPlaylistEntriesSchema]),
+      this.reorderPlaylistEntries.bind(this) as (
         event: IpcMainInvokeEvent,
         ...args: unknown[]
       ) => Promise<unknown>
@@ -1001,7 +1012,7 @@ export class PlaylistController extends BaseController {
     _event: IpcMainInvokeEvent,
     params: GetPlaylistPostsRequest
   ): Promise<IpcPost[]> {
-    const { playlistId, page, filters, limit, isRandom } = params;
+    const { playlistId, page, filters, limit, sortOrder = "desc", isRandom } = params;
     const offset = (page - 1) * limit;
 
     try {
@@ -1054,7 +1065,17 @@ export class PlaylistController extends BaseController {
 
       const result = isRandom
         ? queryBuilder.orderBy(sql`RANDOM()`).limit(limit).offset(offset).all()
-        : queryBuilder.orderBy(desc(posts.publishedAt)).limit(limit).offset(offset).all();
+        : queryBuilder
+            .orderBy(
+              sortOrder === "position"
+                ? asc(playlistEntries.position)
+                : sortOrder === "asc"
+                  ? asc(posts.publishedAt)
+                  : desc(posts.publishedAt)
+            )
+            .limit(limit)
+            .offset(offset)
+            .all();
 
       log.info(
         `[PlaylistController] Retrieved ${result.length} posts from playlist ${playlistId} (page ${page})`
@@ -1065,6 +1086,29 @@ export class PlaylistController extends BaseController {
       log.error(`[PlaylistController] Failed to get playlist posts for ${playlistId}:`, error);
       throw error;
     }
+  }
+
+  private async reorderPlaylistEntries(
+    _event: IpcMainInvokeEvent,
+    params: ReorderPlaylistEntriesRequest
+  ): Promise<void> {
+    const { playlistId, orderedPostIds } = params;
+    const sqlite = getSqliteInstance();
+
+    const stmt = sqlite.prepare(
+      "UPDATE playlist_entries SET position = ? WHERE playlist_id = ? AND post_id = ?"
+    );
+
+    const updateMany = sqlite.transaction((ids: number[]) => {
+      ids.forEach((postId, index) => {
+        stmt.run(index, playlistId, postId);
+      });
+    });
+
+    updateMany(orderedPostIds);
+    log.info(
+      `[PlaylistController] Reordered ${orderedPostIds.length} entries in playlist ${playlistId}`
+    );
   }
 
   /**
@@ -1203,7 +1247,17 @@ export class PlaylistController extends BaseController {
 
         const result = isRandom
           ? queryBuilder.orderBy(sql`RANDOM()`).limit(limit).offset(offset).all()
-          : queryBuilder.orderBy(sortOrder === "asc" ? asc(playlistEntries.addedAt) : desc(playlistEntries.addedAt)).limit(limit).offset(offset).all();
+          : queryBuilder
+              .orderBy(
+                sortOrder === "position"
+                  ? asc(playlistEntries.position)
+                  : sortOrder === "asc"
+                    ? asc(playlistEntries.addedAt)
+                    : desc(playlistEntries.addedAt)
+              )
+              .limit(limit)
+              .offset(offset)
+              .all();
 
         log.info(
           `[PlaylistController] Resolved ${result.length} posts from static playlist ${playlistId} (page ${page})`
@@ -1217,6 +1271,7 @@ export class PlaylistController extends BaseController {
         log.warn(`[PlaylistController] Smart playlist ${playlistId} has no query_json, returning empty result`);
         return [];
       }
+      const smartSortOrder = sortOrder === "position" ? "desc" : sortOrder;
 
       // Parse and validate queryJson via versioned smart-query resolver
       const parsedQuery = parseSmartQuery(
@@ -1318,7 +1373,13 @@ export class PlaylistController extends BaseController {
 
             const result = isRandom
               ? queryBuilder.orderBy(sql`RANDOM()`).limit(limit).offset(offset).all()
-              : queryBuilder.orderBy(sortOrder === "asc" ? asc(posts.publishedAt) : desc(posts.publishedAt)).limit(limit).offset(offset).all();
+              : queryBuilder
+                  .orderBy(
+                    smartSortOrder === "asc" ? asc(posts.publishedAt) : desc(posts.publishedAt)
+                  )
+                  .limit(limit)
+                  .offset(offset)
+                  .all();
             log.info(
               `[PlaylistController] Local DB query returned ${result.length} posts for smart playlist ${playlistId}`
             );
@@ -1331,7 +1392,15 @@ export class PlaylistController extends BaseController {
         // Remote API query
         (async () => {
           try {
-            return await this.resolveRemotePlaylistPosts(playlistId, query, page, limit, filters, sortOrder, isRandom);
+            return await this.resolveRemotePlaylistPosts(
+              playlistId,
+              query,
+              page,
+              limit,
+              filters,
+              smartSortOrder,
+              isRandom
+            );
           } catch (error) {
             log.error(`[PlaylistController] Remote API query failed for smart playlist ${playlistId}:`, error);
             return []; // Return empty array on error, continue with local results
@@ -1372,7 +1441,7 @@ export class PlaylistController extends BaseController {
       } else {
         // Sort by publishedAt
         mergedPosts.sort((a, b) => {
-          if (sortOrder === "asc") {
+          if (smartSortOrder === "asc") {
             return a.publishedAt - b.publishedAt;
           } else {
             return b.publishedAt - a.publishedAt;

--- a/src/renderer.d.ts
+++ b/src/renderer.d.ts
@@ -15,6 +15,7 @@ import type {
   RemovePostsFromPlaylistRequest,
   GetPlaylistPostsRequest,
   ResolvePlaylistPostsRequest,
+  ReorderPlaylistEntriesRequest,
 } from "./shared/schemas/playlist";
 import type { DatabaseStats } from "./shared/schemas/stats";
 
@@ -146,6 +147,7 @@ export interface IpcApi extends IpcBridge {
   deletePlaylist: (playlistId: number) => Promise<boolean>;
   addPostsToPlaylist: (data: AddPostsToPlaylistRequest) => Promise<number>;
   removePostsFromPlaylist: (data: RemovePostsFromPlaylistRequest) => Promise<number>;
+  reorderPlaylistEntries: (params: ReorderPlaylistEntriesRequest) => Promise<void>;
   getPlaylistPosts: (params: GetPlaylistPostsRequest) => Promise<Post[]>;
   resolvePlaylistPosts: (params: ResolvePlaylistPostsRequest) => Promise<Post[]>;
   getPlaylistsContainingPost: (postId: number) => Promise<number[]>;

--- a/src/renderer/components/pages/PlaylistsPage.tsx
+++ b/src/renderer/components/pages/PlaylistsPage.tsx
@@ -1,4 +1,4 @@
-import React, { forwardRef, useCallback, useMemo, useState } from "react";
+import React, { forwardRef, useCallback, useEffect, useMemo, useState } from "react";
 import {
   useQueryClient,
   useInfiniteQuery,
@@ -6,6 +6,23 @@ import {
 import { ArrowLeft, Loader2, List, Sparkles, Plus, Trash2, X, Check, Minus, Pencil } from "lucide-react";
 import { VirtuosoGrid } from "react-virtuoso";
 import log from "electron-log/renderer";
+import {
+  DndContext,
+  closestCenter,
+  KeyboardSensor,
+  PointerSensor,
+  useSensor,
+  useSensors,
+  type DragEndEvent,
+} from "@dnd-kit/core";
+import {
+  SortableContext,
+  sortableKeyboardCoordinates,
+  rectSortingStrategy,
+  useSortable,
+  arrayMove,
+} from "@dnd-kit/sortable";
+import { CSS } from "@dnd-kit/utilities";
 import { Button } from "../../components/ui/button";
 import type { Playlist, Post } from "../../../main/db/schema";
 import { cn } from "../../lib/utils";
@@ -85,6 +102,35 @@ interface PlaylistGalleryProps {
   onBack: () => void;
 }
 
+interface SortablePostCardProps {
+  post: Post;
+  onClick: () => void;
+  onRemove?: () => void;
+  preserveAspect?: boolean;
+}
+
+function SortablePostCard({ post, onClick, onRemove, preserveAspect }: SortablePostCardProps) {
+  const { attributes, listeners, setNodeRef, transform, transition, isDragging } = useSortable({
+    id: post.id,
+  });
+  const style: React.CSSProperties = {
+    transform: CSS.Transform.toString(transform),
+    transition,
+    opacity: isDragging ? 0.5 : 1,
+  };
+
+  return (
+    <div ref={setNodeRef} style={style} {...attributes} {...listeners}>
+      <PostCard
+        post={post}
+        onClick={onClick}
+        preserveAspect={preserveAspect}
+        onRemoveFromPlaylist={onRemove}
+      />
+    </div>
+  );
+}
+
 const PlaylistGallery: React.FC<PlaylistGalleryProps> = ({ playlist, onBack }) => {
   // Use atomic selector instead of useShallow for single value
   const openViewer = useViewerStore((state) => state.open);
@@ -159,6 +205,25 @@ const PlaylistGallery: React.FC<PlaylistGalleryProps> = ({ playlist, onBack }) =
 
     return posts;
   }, [data, filters.aiFilter]);
+  const [localPosts, setLocalPosts] = useState<Post[]>([]);
+  const sensors = useSensors(
+    useSensor(PointerSensor, {
+      activationConstraint: {
+        distance: 8,
+      },
+    }),
+    useSensor(KeyboardSensor, {
+      coordinateGetter: sortableKeyboardCoordinates,
+    })
+  );
+
+  useEffect(() => {
+    if (!playlist.isSmart) {
+      setLocalPosts(allPosts);
+    }
+  }, [allPosts, playlist.isSmart]);
+
+  const displayedPosts = playlist.isSmart ? allPosts : localPosts;
 
   const {
     downloadAll,
@@ -169,7 +234,7 @@ const PlaylistGallery: React.FC<PlaylistGalleryProps> = ({ playlist, onBack }) =
     isPaused,
     progress: downloadAllProgress,
     canDownload,
-  } = useDownloadAll(allPosts);
+  } = useDownloadAll(displayedPosts);
 
   const handleLoadMore = () => {
     if (hasNextPage && !isFetchingNextPage) {
@@ -179,7 +244,7 @@ const PlaylistGallery: React.FC<PlaylistGalleryProps> = ({ playlist, onBack }) =
 
   const handlePostClick = (index: number) => {
     // For remote posts (id=0), use postId as identifier; for local posts, use id
-    const postIds = allPosts.map((p) => (p.id === 0 && p.postId ? p.postId : p.id));
+    const postIds = displayedPosts.map((p) => (p.id === 0 && p.postId ? p.postId : p.id));
     
     // CRITICAL: Extract provider from playlist queryJson for shadow insert operations
     // Provider must match the actual source of posts to prevent 404 or invalid data
@@ -205,7 +270,7 @@ const PlaylistGallery: React.FC<PlaylistGalleryProps> = ({ playlist, onBack }) =
       ids: postIds,
       initialIndex: index,
       listKey: `playlist-${playlist.id}`,
-      hasNextPage: hasNextPage && allPosts.length < (data?.pages.length ?? 0) * 50,
+      hasNextPage: hasNextPage && displayedPosts.length < (data?.pages.length ?? 0) * 50,
       onLoadMore: handleLoadMore,
     });
   };
@@ -235,6 +300,9 @@ const PlaylistGallery: React.FC<PlaylistGalleryProps> = ({ playlist, onBack }) =
       return;
     }
 
+    const previousPosts = localPosts;
+    setLocalPosts((currentPosts) => currentPosts.filter((post) => post.id !== postId));
+
     try {
       await window.api.removePostsFromPlaylist({
         playlistId: playlist.id,
@@ -248,8 +316,46 @@ const PlaylistGallery: React.FC<PlaylistGalleryProps> = ({ playlist, onBack }) =
       queryClient.invalidateQueries({ queryKey: ["playlist-entries", postId] });
     } catch (error) {
       log.error("[PlaylistGallery] Failed to remove post from playlist:", error);
+      setLocalPosts(previousPosts);
     }
   };
+
+  const handleDragEnd = useCallback(
+    (event: DragEndEvent) => {
+      if (playlist.isSmart) {
+        return;
+      }
+
+      const { active, over } = event;
+      if (!over || active.id === over.id) {
+        return;
+      }
+
+      const activeId = Number(active.id);
+      const overId = Number(over.id);
+      const oldIndex = localPosts.findIndex((post) => post.id === activeId);
+      const newIndex = localPosts.findIndex((post) => post.id === overId);
+
+      if (oldIndex < 0 || newIndex < 0) {
+        return;
+      }
+
+      const previousPosts = localPosts;
+      const newOrder = arrayMove(localPosts, oldIndex, newIndex);
+      setLocalPosts(newOrder);
+
+      window.api
+        .reorderPlaylistEntries({
+          playlistId: playlist.id,
+          orderedPostIds: newOrder.map((post) => post.id),
+        })
+        .catch((error: unknown) => {
+          log.error("[PlaylistsPage] Reorder failed:", error);
+          setLocalPosts(previousPosts);
+        });
+    },
+    [localPosts, playlist.id, playlist.isSmart]
+  );
 
   const ListComponent = useMemo(() => createVirtuosoList(viewType), [viewType]);
   const ItemComponent = useMemo(() => createItemContainer(viewType), [viewType]);
@@ -275,9 +381,9 @@ const PlaylistGallery: React.FC<PlaylistGalleryProps> = ({ playlist, onBack }) =
                   Smart Collection
                 </p>
               )}
-              {allPosts.length > 0 && (
+              {displayedPosts.length > 0 && (
                 <p className="text-sm text-muted-foreground mt-0.5">
-                  Total: {allPosts.length}
+                  Total: {displayedPosts.length}
                 </p>
               )}
             </div>
@@ -293,21 +399,21 @@ const PlaylistGallery: React.FC<PlaylistGalleryProps> = ({ playlist, onBack }) =
             isPaused={isPaused}
             progress={downloadAllProgress}
             canDownload={canDownload}
-            totalLabel={allPosts.length}
+            totalLabel={displayedPosts.length}
           />
         </div>
       </div>
 
       {/* Grid Content */}
       <div className="flex-1 min-h-0">
-        {isLoading && allPosts.length === 0 ? (
+        {isLoading && displayedPosts.length === 0 ? (
           <div className="flex justify-center items-center h-full text-muted-foreground">
             <Loader2 className="w-8 h-8 animate-spin" />
           </div>
         ) : viewType === "masonry" ? (
           <div className="overflow-auto h-full" onScroll={handleMasonryScroll}>
             <GridContainer viewType="masonry">
-              {allPosts.map((post, index) => (
+              {displayedPosts.map((post, index) => (
                 <div key={`${post.id}-${post.postId ?? index}`} className="w-full mb-4 break-inside-avoid">
                   <PostCard
                     post={post}
@@ -326,10 +432,34 @@ const PlaylistGallery: React.FC<PlaylistGalleryProps> = ({ playlist, onBack }) =
               </div>
             )}
           </div>
+        ) : !playlist.isSmart ? (
+          <div className="overflow-auto h-full">
+            <DndContext
+              sensors={sensors}
+              collisionDetection={closestCenter}
+              onDragEnd={handleDragEnd}
+            >
+              <SortableContext
+                items={displayedPosts.map((post) => post.id)}
+                strategy={rectSortingStrategy}
+              >
+                <div className="grid grid-cols-2 gap-4 p-4 pb-32 md:grid-cols-3 lg:grid-cols-4 xl:grid-cols-5">
+                  {displayedPosts.map((post, index) => (
+                    <SortablePostCard
+                      key={post.id}
+                      post={post}
+                      onClick={() => handlePostClick(index)}
+                      onRemove={() => handleRemovePost(post.id)}
+                    />
+                  ))}
+                </div>
+              </SortableContext>
+            </DndContext>
+          </div>
         ) : (
           <VirtuosoGrid
             style={{ height: "100%" }}
-            totalCount={allPosts.length}
+            totalCount={displayedPosts.length}
             endReached={handleEndReached}
             increaseViewportBy={600}
             components={{
@@ -343,7 +473,7 @@ const PlaylistGallery: React.FC<PlaylistGalleryProps> = ({ playlist, onBack }) =
                 ) : null,
             }}
             itemContent={(index) => {
-              const post = allPosts[index];
+              const post = displayedPosts[index];
               if (!post) return null;
 
               return (

--- a/src/renderer/components/playlists/QuickAddToPlaylistMenu.tsx
+++ b/src/renderer/components/playlists/QuickAddToPlaylistMenu.tsx
@@ -21,12 +21,22 @@ interface QuickAddToPlaylistMenuProps {
   post: { id: number; postId: number };
   trigger?: React.ReactNode;
   onSuccess?: () => void;
+  open?: boolean;
+  onOpenChange?: (open: boolean) => void;
+  contentAlign?: "start" | "center" | "end";
+  contentSide?: "top" | "right" | "bottom" | "left";
+  contentSideOffset?: number;
 }
 
 export const QuickAddToPlaylistMenu: React.FC<QuickAddToPlaylistMenuProps> = ({
   post,
   trigger,
   onSuccess,
+  open,
+  onOpenChange,
+  contentAlign = "end",
+  contentSide = "bottom",
+  contentSideOffset = 4,
 }) => {
   const postId = post.id;
   const [selectedPlaylistIds, setSelectedPlaylistIds] = useState<Set<number>>(new Set());
@@ -35,6 +45,8 @@ export const QuickAddToPlaylistMenu: React.FC<QuickAddToPlaylistMenuProps> = ({
   const [isDialogOpen, setIsDialogOpen] = useState(false);
   const [isMenuOpen, setIsMenuOpen] = useState(false);
   const queryClient = useQueryClient();
+  const effectiveIsMenuOpen = open ?? isMenuOpen;
+  const setEffectiveIsMenuOpen = onOpenChange ?? setIsMenuOpen;
 
   // Fetch all playlists - only when menu is opened (lazy loading)
   const { data: allPlaylists = [], isLoading } = usePlaylists({ enabled: isMenuOpen });
@@ -178,11 +190,20 @@ export const QuickAddToPlaylistMenu: React.FC<QuickAddToPlaylistMenuProps> = ({
   return (
     <>
       {/* modal={false} allows menu to stay open when clicking outside; verify A11y with screen reader */}
-      <DropdownMenu open={isMenuOpen} onOpenChange={setIsMenuOpen} modal={false}>
+      <DropdownMenu
+        open={effectiveIsMenuOpen}
+        onOpenChange={setEffectiveIsMenuOpen}
+        modal={false}
+      >
         <DropdownMenuTrigger asChild>
           {trigger || defaultTrigger}
         </DropdownMenuTrigger>
-        <DropdownMenuContent align="end" className="w-56">
+        <DropdownMenuContent
+          align={contentAlign}
+          side={contentSide}
+          sideOffset={contentSideOffset}
+          className="w-56"
+        >
           <DropdownMenuLabel>Add to Playlist</DropdownMenuLabel>
           <DropdownMenuSeparator />
           {isLoading ? (

--- a/src/renderer/features/artists/components/PostCard.tsx
+++ b/src/renderer/features/artists/components/PostCard.tsx
@@ -42,6 +42,11 @@ export const PostCard: React.FC<PostCardProps> = ({
   const [sampleLoaded, setSampleLoaded] = useState(false);
   const [sampleSrc, setSampleSrc] = useState<string | null>(null);
   const [videoError, setVideoError] = useState(false);
+  const [isPlaylistMenuOpen, setIsPlaylistMenuOpen] = useState(false);
+  const [contextMenuPosition, setContextMenuPosition] = useState<{
+    x: number;
+    y: number;
+  } | null>(null);
   const cardRef = useRef<HTMLButtonElement>(null);
   const videoRef = useRef<HTMLVideoElement>(null);
 
@@ -165,6 +170,12 @@ export const PostCard: React.FC<PostCardProps> = ({
       }}
       onMouseEnter={() => setIsHovered(true)}
       onMouseLeave={() => setIsHovered(false)}
+      onContextMenu={(e) => {
+        e.preventDefault();
+        e.stopPropagation();
+        setContextMenuPosition({ x: e.clientX, y: e.clientY });
+        setIsPlaylistMenuOpen(true);
+      }}
       aria-label={`View post ${post.id}. Rating: ${post.rating}. ${
         isVid ? "Video" : "Image"
       }.`}
@@ -265,10 +276,10 @@ export const PostCard: React.FC<PostCardProps> = ({
         </div>
       )}
 
-      {/* 1.5. Playlist Menu (Top Right, below video indicator if present) */}
+      {/* 1.5. Playlist actions (Top Right, below video indicator if present) */}
       <div
         className={cn(
-          "absolute right-2 z-20 opacity-0 transition-opacity duration-200 group-hover:opacity-100",
+          "absolute right-2 z-20 flex flex-col gap-2 opacity-0 transition-opacity duration-200 group-hover:opacity-100",
           isVid ? "top-12" : "top-2"
         )}
         onClick={(e) => e.stopPropagation()}
@@ -281,9 +292,27 @@ export const PostCard: React.FC<PostCardProps> = ({
       >
         <QuickAddToPlaylistMenu
           post={{ id: post.id, postId: post.postId }}
+          open={isPlaylistMenuOpen}
+          onOpenChange={(open) => {
+            setIsPlaylistMenuOpen(open);
+            if (!open) {
+              setContextMenuPosition(null);
+            }
+          }}
+          contentAlign={contextMenuPosition ? "start" : "end"}
+          contentSide={contextMenuPosition ? "bottom" : "bottom"}
+          contentSideOffset={contextMenuPosition ? 0 : 4}
           trigger={
             <span
-              className="inline-flex items-center justify-center rounded-full bg-black/50 p-1.5 backdrop-blur-sm hover:bg-black/70 transition-colors cursor-pointer"
+              className={cn(
+                "inline-flex items-center justify-center rounded-full bg-black/50 p-1.5 backdrop-blur-sm hover:bg-black/70 transition-colors cursor-pointer",
+                contextMenuPosition && "fixed w-0 h-0 overflow-hidden p-0 opacity-0 pointer-events-none"
+              )}
+              style={
+                contextMenuPosition
+                  ? { left: contextMenuPosition.x, top: contextMenuPosition.y }
+                  : undefined
+              }
               role="button"
               tabIndex={0}
               aria-label="Add to playlist"
@@ -291,6 +320,7 @@ export const PostCard: React.FC<PostCardProps> = ({
               onClick={(e) => {
                 e.preventDefault();
                 e.stopPropagation();
+                setContextMenuPosition(null);
               }}
               onMouseDown={(e) => {
                 e.preventDefault();
@@ -307,16 +337,7 @@ export const PostCard: React.FC<PostCardProps> = ({
             </span>
           }
         />
-      </div>
-
-      {/* 1.6. Remove from Playlist Button (Top Left, below indicators) */}
-      {onRemoveFromPlaylist && (
-        <div
-          className="absolute left-2 z-20 opacity-0 transition-opacity duration-200 group-hover:opacity-100"
-          style={{ top: post.isFavorited || post.isViewed ? "3.5rem" : "0.5rem" }}
-          onClick={(e) => e.stopPropagation()}
-          onMouseDown={(e) => e.stopPropagation()}
-        >
+        {onRemoveFromPlaylist && (
           <span
             className="inline-flex items-center justify-center rounded-full bg-red-500/90 p-1.5 backdrop-blur-sm hover:bg-red-600 transition-colors cursor-pointer"
             role="button"
@@ -342,8 +363,8 @@ export const PostCard: React.FC<PostCardProps> = ({
           >
             <Trash2 className="w-3 h-3 text-white" />
           </span>
-        </div>
-      )}
+        )}
+      </div>
 
       {/* 2. Viewed & Favorite Indicator (Top Left/Top Right) */}
       <div className="flex absolute top-2 left-2 z-10 gap-1 items-center">

--- a/src/shared/schemas/playlist.ts
+++ b/src/shared/schemas/playlist.ts
@@ -124,6 +124,7 @@ export const GetPlaylistPostsSchema = z.object({
     mediaType: z.enum(["all", "images", "videos"]).optional(),
   }).optional(),
   limit: z.number().int().min(1).max(1000).default(50), // Increased max limit to 1000 for larger gallery views
+  sortOrder: z.enum(["asc", "desc", "position"]).optional().default("desc"),
   isRandom: z.boolean().optional().default(false),
 });
 
@@ -149,9 +150,16 @@ export const ResolvePlaylistPostsSchema = z.object({
     rating: z.enum(["s", "q", "e"]).optional(),
     mediaType: z.enum(["all", "images", "videos"]).optional(),
   }).optional(),
-  sortOrder: z.enum(["asc", "desc"]).optional().default("desc"),
+  sortOrder: z.enum(["asc", "desc", "position"]).optional().default("desc"),
   isRandom: z.boolean().optional().default(false),
 });
+
+export const ReorderPlaylistEntriesSchema = z.object({
+  playlistId: z.number().int().positive(),
+  orderedPostIds: z.array(z.number().int()).min(1),
+});
+
+export type ReorderPlaylistEntriesRequest = z.infer<typeof ReorderPlaylistEntriesSchema>;
 
 /**
  * Resolve Playlist Posts Request Type


### PR DESCRIPTION
- Added support for reordering playlist entries via drag-and-drop using @dnd-kit.
- Introduced new IPC channel for reordering entries and updated the PlaylistController to handle the new request.
- Enhanced the PlaylistGallery component to manage local state for reordered posts and integrate with the new API.
- Updated schemas to include sorting options and validation for reordering requests.
- Cleaned up unused imports and ensured strict type safety throughout the changes.