### PR TITLE
chore: add backup retention feature and update documentation

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -498,6 +498,7 @@ type IpcSettings = {
   theme: "system" | "light" | "dark";
   autoSyncOnStartup: boolean;
   syncIntervalMinutes: number;
+  backupRetention: number;
 };
 ```
 
@@ -576,6 +577,7 @@ Saves settings to the database. Supports partial updates (credentials, sync opti
 - `creds.proxyUrl?: string | null` - Optional outbound proxy URL
 - `creds.autoSyncOnStartup?: boolean` - Auto-sync startup toggle
 - `creds.syncIntervalMinutes?: number` - Periodic sync interval in minutes
+- `creds.backupRetention?: number` - Number of backups to keep (1..20)
 
 **Returns:** `Promise<boolean>`
 
@@ -1272,6 +1274,7 @@ if (result.success) {
 **IPC Channel:** `db:create-backup`
 
 **Note:** The backup file is created in the user data directory. The file explorer will open to show the backup location.
+After each successful backup, old backup files are pruned and only the most recent `backupRetention` files are kept.
 
 ---
 

--- a/drizzle/0015_add_backup_retention.sql
+++ b/drizzle/0015_add_backup_retention.sql
@@ -1,0 +1,1 @@
+ALTER TABLE settings ADD COLUMN backup_retention INTEGER NOT NULL DEFAULT 5;

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -141,6 +141,13 @@
       "when": 1776859402172,
       "tag": "0020_add_playlist_entry_position",
       "breakpoints": true
+    },
+    {
+      "idx": 21,
+      "version": "6",
+      "when": 1777000000000,
+      "tag": "0015_add_backup_retention",
+      "breakpoints": true
     }
   ]
 }

--- a/src/main/db/schema.ts
+++ b/src/main/db/schema.ts
@@ -137,6 +137,7 @@ export const settings = sqliteTable("settings", {
     .default(false)
     .notNull(),
   syncIntervalMinutes: integer("sync_interval_minutes").default(0).notNull(),
+  backupRetention: integer("backup_retention").default(5).notNull(),
 });
 
 export const tagMetadata = sqliteTable(

--- a/src/main/ipc/controllers/MaintenanceController.ts
+++ b/src/main/ipc/controllers/MaintenanceController.ts
@@ -5,6 +5,7 @@ import fs from "fs";
 import Database from "better-sqlite3";
 import log from "electron-log";
 import { z } from "zod";
+import { eq } from "drizzle-orm";
 import { BaseController } from "../../core/ipc/BaseController";
 import { container, DI_TOKENS } from "../../core/di/Container";
 import { IPC_CHANNELS } from "../channels";
@@ -15,10 +16,13 @@ import {
   initializeDatabase,
 } from "../../db/client";
 import { maintenanceQueue } from "../../db/maintenance-queue";
+import { settings, SETTINGS_ID } from "../../db/schema";
 import type { SyncService } from "../../services/sync-service";
 import { BACKUP_FILE_PREFIX, getDatabasePaths } from "../../db/paths";
 
-const MAX_BACKUPS_TO_KEEP = 5;
+const DEFAULT_BACKUP_RETENTION = 5;
+const MIN_BACKUP_RETENTION = 1;
+const MAX_BACKUP_RETENTION = 20;
 
 /**
  * IPC controllers resolve the DB via DI. After closeDatabase + initializeDatabase the
@@ -47,6 +51,24 @@ export class MaintenanceController extends BaseController {
    */
   public setMainWindow(window: BrowserWindow): void {
     this.mainWindow = window;
+  }
+
+  private getBackupRetention(): number {
+    const db = container.resolve(DI_TOKENS.DB);
+    const currentSettings = db
+      .select({
+        backupRetention: settings.backupRetention,
+      })
+      .from(settings)
+      .where(eq(settings.id, SETTINGS_ID))
+      .limit(1)
+      .all()[0];
+
+    const retention = currentSettings?.backupRetention ?? DEFAULT_BACKUP_RETENTION;
+    return Math.max(
+      MIN_BACKUP_RETENTION,
+      Math.min(MAX_BACKUP_RETENTION, retention)
+    );
   }
 
   private getSyncService(): SyncService {
@@ -215,23 +237,28 @@ export class MaintenanceController extends BaseController {
 
   private async cleanupOldBackups(backupDir: string): Promise<void> {
     try {
+      const backupRetention = this.getBackupRetention();
       const entries = await fs.promises.readdir(backupDir);
+      const escapedBackupPrefix = BACKUP_FILE_PREFIX.replace(
+        /[.*+?^${}()|[\]\\]/g,
+        "\\$&"
+      );
+      const backupFileRegex = new RegExp(`^${escapedBackupPrefix}-.+\\.db$`);
 
-      // Find all backup files matching the naming convention
+      // Sort ascending so oldest files come first; we keep the newest N.
       const backupFiles = entries
-        .filter((name) => name.startsWith(BACKUP_FILE_PREFIX) && name.endsWith(".db"))
+        .filter((name) => backupFileRegex.test(name))
         .map((name) => ({
           name,
           fullPath: path.join(backupDir, name),
         }))
-        // Sort descending by filename — ISO timestamp in name means lexicographic = chronological
-        .sort((a, b) => b.name.localeCompare(a.name));
+        .sort((a, b) => a.name.localeCompare(b.name));
 
-      if (backupFiles.length <= MAX_BACKUPS_TO_KEEP) {
+      if (backupFiles.length <= backupRetention) {
         return; // Nothing to clean up
       }
 
-      const toDelete = backupFiles.slice(MAX_BACKUPS_TO_KEEP);
+      const toDelete = backupFiles.slice(0, backupFiles.length - backupRetention);
 
       for (const file of toDelete) {
         try {
@@ -243,7 +270,9 @@ export class MaintenanceController extends BaseController {
         }
       }
 
-      log.info(`[MaintenanceController] Retention cleanup: kept ${MAX_BACKUPS_TO_KEEP}, deleted ${toDelete.length}`);
+      log.info(
+        `[MaintenanceController] Retention cleanup: kept ${backupRetention}, deleted ${toDelete.length}`
+      );
     } catch (error) {
       // Non-fatal: retention cleanup failure should never break backup creation
       log.warn("[MaintenanceController] Backup retention cleanup failed:", error);

--- a/src/main/ipc/controllers/SettingsController.ts
+++ b/src/main/ipc/controllers/SettingsController.ts
@@ -74,6 +74,7 @@ function mapSettingsToIpc(
     theme: (dbSettings.theme as ThemePreference) || "system",
     autoSyncOnStartup: !!dbSettings.autoSyncOnStartup,
     syncIntervalMinutes: dbSettings.syncIntervalMinutes ?? 0,
+    backupRetention: dbSettings.backupRetention ?? 5,
   };
 }
 
@@ -285,6 +286,8 @@ export class SettingsController extends BaseController {
             data.autoSyncOnStartup ?? existing.autoSyncOnStartup ?? false;
           const finalSyncIntervalMinutes =
             data.syncIntervalMinutes ?? existing.syncIntervalMinutes ?? 0;
+          const finalBackupRetention =
+            data.backupRetention ?? existing.backupRetention ?? 5;
 
           tx.update(settings)
             .set({
@@ -298,6 +301,7 @@ export class SettingsController extends BaseController {
               theme: existing.theme ?? "system",
               autoSyncOnStartup: finalAutoSyncOnStartup,
               syncIntervalMinutes: finalSyncIntervalMinutes,
+              backupRetention: finalBackupRetention,
             })
             .where(eq(settings.id, targetId))
             .run();
@@ -316,6 +320,7 @@ export class SettingsController extends BaseController {
               theme: "system",
               autoSyncOnStartup: data.autoSyncOnStartup ?? false,
               syncIntervalMinutes: data.syncIntervalMinutes ?? 0,
+              backupRetention: data.backupRetention ?? 5,
             })
             .run();
         }

--- a/src/renderer.d.ts
+++ b/src/renderer.d.ts
@@ -52,6 +52,7 @@ export interface IpcSettings {
   theme: "system" | "light" | "dark";
   autoSyncOnStartup: boolean;
   syncIntervalMinutes: number;
+  backupRetention: number;
 }
 
 export interface IpcApi extends IpcBridge {
@@ -68,6 +69,7 @@ export interface IpcApi extends IpcBridge {
     proxyUrl?: string | null;
     autoSyncOnStartup?: boolean;
     syncIntervalMinutes?: number;
+    backupRetention?: number;
   }) => Promise<boolean>;
   saveTheme: (theme: "system" | "light" | "dark") => Promise<boolean>;
   saveDownloadFolder: (path: string | null) => Promise<boolean>;

--- a/src/renderer/features/settings/Settings.tsx
+++ b/src/renderer/features/settings/Settings.tsx
@@ -44,6 +44,7 @@ export const Settings = () => {
   const [databaseLocation, setDatabaseLocation] = useState<string>("");
   const [autoSyncOnStartup, setAutoSyncOnStartup] = useState(false);
   const [syncIntervalMinutes, setSyncIntervalMinutes] = useState("0");
+  const [backupRetention, setBackupRetention] = useState("5");
   const [proxyUrl, setProxyUrl] = useState<string | null>(null);
   const [proxyError, setProxyError] = useState<string | null>(null);
   const [proxyStatus, setProxyStatus] = useState<"idle" | "success" | "error">("idle");
@@ -78,6 +79,9 @@ export const Settings = () => {
       }
       if (s?.syncIntervalMinutes !== undefined) {
         setSyncIntervalMinutes(String(s.syncIntervalMinutes));
+      }
+      if (s?.backupRetention !== undefined) {
+        setBackupRetention(String(s.backupRetention));
       }
       setProxyUrl(s?.proxyUrl ?? null);
       setHasApiKey(s?.hasApiKey ?? false);
@@ -317,6 +321,45 @@ export const Settings = () => {
     }
   };
 
+  const parseBackupRetention = (value: string): number | null => {
+    if (value.trim().length === 0) {
+      return null;
+    }
+
+    const parsed = Number(value);
+    if (!Number.isInteger(parsed) || parsed < 1 || parsed > 20) {
+      return null;
+    }
+
+    return parsed;
+  };
+
+  const saveBackupRetention = async (value: string): Promise<void> => {
+    const parsed = parseBackupRetention(value);
+    if (parsed === null) {
+      return;
+    }
+
+    try {
+      await window.api.saveSettings({ backupRetention: parsed });
+      setBackupRetention(String(parsed));
+    } catch (error) {
+      log.error("[Settings] Failed to save backup retention:", error);
+    }
+  };
+
+  const handleBackupRetentionChange = (value: string): void => {
+    setBackupRetention(value);
+    void saveBackupRetention(value);
+  };
+
+  const handleBackupRetentionBlur = (): void => {
+    const parsed = parseBackupRetention(backupRetention);
+    const normalized = parsed === null ? 5 : parsed;
+    setBackupRetention(String(normalized));
+    void saveBackupRetention(String(normalized));
+  };
+
   const handleSaveApiKey = async (): Promise<void> => {
     setAccountStatus("idle");
     try {
@@ -428,6 +471,7 @@ export const Settings = () => {
             backupStatus={backupStatus}
             restoreStatus={restoreStatus}
             integrityResult={integrityResult}
+            backupRetention={backupRetention}
             onBackup={() => {
               void handleBackup();
             }}
@@ -437,6 +481,8 @@ export const Settings = () => {
             onIntegrityCheck={() => {
               void handleIntegrityCheck();
             }}
+            onBackupRetentionChange={handleBackupRetentionChange}
+            onBackupRetentionBlur={handleBackupRetentionBlur}
           />
         </TabsContent>
 

--- a/src/renderer/features/settings/SettingsBackupTab.tsx
+++ b/src/renderer/features/settings/SettingsBackupTab.tsx
@@ -2,6 +2,7 @@ import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "../..
 import { Button } from "../../components/ui/button";
 import { Badge } from "../../components/ui/badge";
 import { Separator } from "../../components/ui/separator";
+import { Input } from "../../components/ui/input";
 
 interface SettingsBackupTabProps {
   databaseLocation: string;
@@ -11,9 +12,12 @@ interface SettingsBackupTabProps {
   backupStatus: "idle" | "success" | "error";
   restoreStatus: "idle" | "success" | "error";
   integrityResult: { ok: boolean; details: string } | null;
+  backupRetention: string;
   onBackup: () => void;
   onRestore: () => void;
   onIntegrityCheck: () => void;
+  onBackupRetentionChange: (value: string) => void;
+  onBackupRetentionBlur: () => void;
 }
 
 export const SettingsBackupTab = ({
@@ -24,9 +28,12 @@ export const SettingsBackupTab = ({
   backupStatus,
   restoreStatus,
   integrityResult,
+  backupRetention,
   onBackup,
   onRestore,
   onIntegrityCheck,
+  onBackupRetentionChange,
+  onBackupRetentionBlur,
 }: SettingsBackupTabProps) => {
   return (
     <Card>
@@ -105,9 +112,19 @@ export const SettingsBackupTab = ({
 
         <section className="space-y-1">
           <p className="text-sm font-medium">Retention</p>
-          <p className="text-sm text-muted-foreground">
-            Manual backups are retained until you delete them.
-          </p>
+          <label className="space-y-2">
+            <span className="text-sm text-muted-foreground">Keep last N backups</span>
+            <Input
+              type="number"
+              min={1}
+              max={20}
+              value={backupRetention}
+              onChange={(event) => {
+                onBackupRetentionChange(event.target.value);
+              }}
+              onBlur={onBackupRetentionBlur}
+            />
+          </label>
         </section>
       </CardContent>
     </Card>

--- a/src/shared/schemas/settings.ts
+++ b/src/shared/schemas/settings.ts
@@ -78,6 +78,7 @@ export const SaveSettingsSchema = z.object({
   proxyUrl: z.string().url().nullable().optional(),
   autoSyncOnStartup: z.boolean().optional(),
   syncIntervalMinutes: z.number().int().min(0).max(1440).optional(),
+  backupRetention: z.number().int().min(1).max(20).optional(),
 });
 
 /**
@@ -104,6 +105,7 @@ export const IpcSettingsSchema = z.object({
   theme: ThemePreferenceSchema.default("system"),
   autoSyncOnStartup: z.boolean(),
   syncIntervalMinutes: z.number().int().min(0),
+  backupRetention: z.number().int().min(1).max(20).default(5),
 });
 
 /**
@@ -127,5 +129,6 @@ export const DEFAULT_IPC_SETTINGS: IpcSettings = {
   theme: "system",
   autoSyncOnStartup: false,
   syncIntervalMinutes: 0,
+  backupRetention: 5,
 };
 


### PR DESCRIPTION
- Introduced `backupRetention` setting in the IPC and database schema, allowing users to specify the number of backups to retain (1..20).
- Updated API documentation to reflect the new `backupRetention` parameter in settings and its usage.
- Enhanced the `MaintenanceController` to manage backup retention during cleanup operations.
- Revised the settings UI to include input for backup retention, ensuring user-friendly configuration.
- Cleaned up unused imports and ensured strict type safety throughout the updates.