### PR TITLE
refactor: standardize ID validation across controllers and schemas

### DIFF
--- a/src/main/ipc/controllers/ArtistsController.ts
+++ b/src/main/ipc/controllers/ArtistsController.ts
@@ -21,6 +21,7 @@ import {
   EXTERNAL_ARTIST_TAG_PREFIX,
 } from "../../../shared/constants";
 import { AddArtistSchema, type AddArtistRequest } from "../../../shared/schemas/artist";
+import { IdSchema } from "../../../shared/schemas/ipc";
 
 type AppDatabase = BetterSQLite3Database<typeof schema>;
 // Use Drizzle's type inference instead of manual imports for type safety
@@ -83,7 +84,7 @@ export class ArtistsController extends BaseController {
     );
     this.handle(
       IPC_CHANNELS.DB.DELETE_ARTIST,
-      z.tuple([z.number().int().positive()]),
+      z.tuple([IdSchema]),
       this.deleteArtist.bind(this) as (
         event: IpcMainInvokeEvent,
         ...args: unknown[]

--- a/src/main/ipc/controllers/MaintenanceController.ts
+++ b/src/main/ipc/controllers/MaintenanceController.ts
@@ -19,6 +19,7 @@ import { maintenanceQueue } from "../../db/maintenance-queue";
 import { settings, SETTINGS_ID } from "../../db/schema";
 import type { SyncService } from "../../services/sync-service";
 import { BACKUP_FILE_PREFIX, getDatabasePaths } from "../../db/paths";
+import { IdSchema } from "../../../shared/schemas/ipc";
 
 const DEFAULT_BACKUP_RETENTION = 5;
 const MIN_BACKUP_RETENTION = 1;
@@ -86,7 +87,7 @@ export class MaintenanceController extends BaseController {
     );
     this.handle(
       IPC_CHANNELS.SYNC.REPAIR,
-      z.tuple([z.number().int().positive()]),
+      z.tuple([IdSchema]),
       // Type assertion is safe: BaseController validates args with Zod schema before calling handler
       this.repairArtist.bind(this) as (event: IpcMainInvokeEvent, ...args: unknown[]) => Promise<unknown>
     );

--- a/src/main/ipc/controllers/PlaylistController.ts
+++ b/src/main/ipc/controllers/PlaylistController.ts
@@ -40,6 +40,7 @@ import { getSqliteInstance } from "../../db/client";
 import { getProvider } from "../../providers";
 import { settings, SETTINGS_ID } from "../../db/schema";
 import { safeStorage } from "electron";
+import { IdSchema, OptionalIdSchema } from "../../../shared/schemas/ipc";
 
 type AppDatabase = BetterSQLite3Database<typeof schema>;
 type UnknownRecord = Record<string, unknown>;
@@ -225,7 +226,7 @@ export class PlaylistController extends BaseController {
 
     this.handle(
       IPC_CHANNELS.DB.GET_PLAYLIST,
-      z.tuple([z.number().int().positive()]),
+      z.tuple([IdSchema]),
       this.getPlaylist.bind(this) as (
         event: IpcMainInvokeEvent,
         ...args: unknown[]
@@ -234,7 +235,7 @@ export class PlaylistController extends BaseController {
 
     this.handle(
       IPC_CHANNELS.DB.UPDATE_PLAYLIST,
-      z.tuple([z.number().int().positive(), UpdatePlaylistSchema]),
+      z.tuple([IdSchema, UpdatePlaylistSchema]),
       this.updatePlaylist.bind(this) as (
         event: IpcMainInvokeEvent,
         ...args: unknown[]
@@ -243,7 +244,7 @@ export class PlaylistController extends BaseController {
 
     this.handle(
       IPC_CHANNELS.DB.DELETE_PLAYLIST,
-      z.tuple([z.number().int().positive()]),
+      z.tuple([IdSchema]),
       this.deletePlaylist.bind(this) as (
         event: IpcMainInvokeEvent,
         ...args: unknown[]
@@ -297,7 +298,7 @@ export class PlaylistController extends BaseController {
 
     this.handle(
       IPC_CHANNELS.DB.GET_PLAYLISTS_CONTAINING_POST,
-      z.tuple([z.number().int(), z.number().int().positive().optional()]),
+      z.tuple([z.number().int(), OptionalIdSchema]),
       this.getPlaylistsContainingPost.bind(this) as (
         event: IpcMainInvokeEvent,
         ...args: unknown[]
@@ -306,7 +307,7 @@ export class PlaylistController extends BaseController {
 
     this.handle(
       IPC_CHANNELS.DB.EXPORT_PLAYLIST,
-      z.tuple([z.number().int().positive()]),
+      z.tuple([IdSchema]),
       this.exportPlaylist.bind(this) as (
         event: IpcMainInvokeEvent,
         ...args: unknown[]

--- a/src/main/ipc/controllers/PostsController.ts
+++ b/src/main/ipc/controllers/PostsController.ts
@@ -41,6 +41,7 @@ import { getProvider, type ProviderId } from "../../providers";
 import { safeStorage } from "electron";
 import { settings, SETTINGS_ID } from "../../db/schema";
 import { ShadowInsertRequestSchema } from "../../../shared/schemas/shadow-insert";
+import { IdSchema } from "../../../shared/schemas/ipc";
 
 type AppDatabase = BetterSQLite3Database<typeof schema>;
 
@@ -219,7 +220,7 @@ export class PostsController extends BaseController {
     );
     this.handle(
       IPC_CHANNELS.DB.RESET_POST_CACHE,
-      z.tuple([z.number().int().positive()]),
+      z.tuple([IdSchema]),
       // Type assertion is safe: BaseController validates args with Zod schema before calling handler
       this.resetPostCache.bind(this) as (
         event: IpcMainInvokeEvent,

--- a/src/shared/schemas/ipc.ts
+++ b/src/shared/schemas/ipc.ts
@@ -1,0 +1,18 @@
+import { z } from "zod";
+
+export const IdSchema = z.number().int().positive();
+export const OptionalIdSchema = IdSchema.optional();
+
+export const PageSchema = z.number().int().min(1);
+export const LimitSchema = z.number().int().min(1);
+export const PaginationSchema = z.object({
+  page: PageSchema,
+  limit: LimitSchema,
+});
+
+export const RatingSchema = z.enum(["s", "q", "e"]);
+export const MediaTypeSchema = z.enum(["all", "images", "videos"]);
+export const PostFiltersSchema = z.object({
+  rating: RatingSchema.optional(),
+  mediaType: MediaTypeSchema.optional(),
+});

--- a/src/shared/schemas/playlist.ts
+++ b/src/shared/schemas/playlist.ts
@@ -1,5 +1,11 @@
 import { z } from "zod";
 import {
+  IdSchema,
+  PageSchema,
+  LimitSchema,
+  PostFiltersSchema,
+} from "./ipc";
+import {
   SmartQueryTagSchema,
   type SmartQueryV1,
   parseSmartQuery,
@@ -82,7 +88,7 @@ export type UpdatePlaylistRequest = z.infer<typeof UpdatePlaylistSchema>;
  * Supports adding multiple posts to multiple playlists simultaneously.
  */
 export const AddPostsToPlaylistSchema = z.object({
-  playlistIds: z.array(z.number().int().positive()).min(1, "At least one playlist required"),
+  playlistIds: z.array(IdSchema).min(1, "At least one playlist required"),
   postIds: z.array(z.number().int()).min(1, "At least one post required"),
 });
 
@@ -99,7 +105,7 @@ export type AddPostsToPlaylistRequest = z.infer<typeof AddPostsToPlaylistSchema>
  * Single source of truth for removing posts from playlists validation and typing.
  */
 export const RemovePostsFromPlaylistSchema = z.object({
-  playlistId: z.number().int().positive(),
+  playlistId: IdSchema,
   postIds: z.array(z.number().int()).min(1, "At least one post required"),
 });
 
@@ -117,13 +123,10 @@ export type RemovePostsFromPlaylistRequest = z.infer<typeof RemovePostsFromPlayl
  * Supports playlist-scoped filtering by rating and media type.
  */
 export const GetPlaylistPostsSchema = z.object({
-  playlistId: z.number().int().positive(),
-  page: z.number().int().min(1).default(1),
-  filters: z.object({
-    rating: z.enum(["s", "q", "e"]).optional(),
-    mediaType: z.enum(["all", "images", "videos"]).optional(),
-  }).optional(),
-  limit: z.number().int().min(1).max(1000).default(50), // Increased max limit to 1000 for larger gallery views
+  playlistId: IdSchema,
+  page: PageSchema.default(1),
+  filters: PostFiltersSchema.optional(),
+  limit: LimitSchema.max(1000).default(50), // Increased max limit to 1000 for larger gallery views
   sortOrder: z.enum(["asc", "desc", "position"]).optional().default("desc"),
   isRandom: z.boolean().optional().default(false),
 });
@@ -143,19 +146,16 @@ export type GetPlaylistPostsRequest = z.infer<typeof GetPlaylistPostsSchema>;
  * Includes optional rating and mediaType filters from renderer state.
  */
 export const ResolvePlaylistPostsSchema = z.object({
-  playlistId: z.number().int().positive(),
-  page: z.number().int().min(1).default(1),
-  limit: z.number().int().min(1).max(1000).default(50), // Increased max limit to 1000 for larger gallery views
-  filters: z.object({
-    rating: z.enum(["s", "q", "e"]).optional(),
-    mediaType: z.enum(["all", "images", "videos"]).optional(),
-  }).optional(),
+  playlistId: IdSchema,
+  page: PageSchema.default(1),
+  limit: LimitSchema.max(1000).default(50), // Increased max limit to 1000 for larger gallery views
+  filters: PostFiltersSchema.optional(),
   sortOrder: z.enum(["asc", "desc", "position"]).optional().default("desc"),
   isRandom: z.boolean().optional().default(false),
 });
 
 export const ReorderPlaylistEntriesSchema = z.object({
-  playlistId: z.number().int().positive(),
+  playlistId: IdSchema,
   orderedPostIds: z.array(z.number().int()).min(1),
 });
 

--- a/src/shared/schemas/post.ts
+++ b/src/shared/schemas/post.ts
@@ -1,4 +1,12 @@
 import { z } from "zod";
+import {
+  IdSchema,
+  OptionalIdSchema,
+  PageSchema,
+  LimitSchema,
+  RatingSchema,
+  MediaTypeSchema,
+} from "./ipc";
 
 /**
  * Post Data Schema
@@ -10,12 +18,12 @@ import { z } from "zod";
  * to markPostAsViewed and togglePostFavorite IPC methods for external posts.
  */
 export const PostDataSchema = z.object({
-  postId: z.number().int().positive(),
+  postId: IdSchema,
   artistId: z.number().int().nonnegative(),
   fileUrl: z.string().min(1),
   previewUrl: z.string().min(1),
   sampleUrl: z.string().optional(),
-  rating: z.enum(["s", "q", "e"]).optional(),
+  rating: RatingSchema.optional(),
   tags: z.string().optional(),
   publishedAt: z.number().int().nonnegative().optional(),
 }).strict(); // Strict mode: reject unknown properties
@@ -41,12 +49,12 @@ export type PostData = z.infer<typeof PostDataSchema>;
 export const PostFilterSchema = z
   .object({
     tags: z.string().optional(),
-    rating: z.enum(["s", "q", "e"]).optional(),
+    rating: RatingSchema.optional(),
     isFavorited: z.boolean().optional(),
     isViewed: z.boolean().optional(),
     sinceTracking: z.boolean().optional(),
     aiFilter: z.enum(["all", "hide", "only"]).optional(),
-    mediaType: z.enum(["all", "images", "videos"]).optional(),
+    mediaType: MediaTypeSchema.optional(),
   })
   .partial();
 
@@ -67,11 +75,11 @@ export type PostFilterRequest = z.infer<typeof PostFilterSchema>;
  * Use this schema in Renderer for form validation before sending to Main process.
  */
 export const GetPostsSchema = z.object({
-  artistId: z.number().int().positive().optional(),
-  page: z.number().int().min(1).default(1),
+  artistId: OptionalIdSchema,
+  page: PageSchema.default(1),
   sortOrder: z.enum(["asc", "desc"]).optional(),
   filters: PostFilterSchema.optional(),
-  limit: z.number().int().min(1).max(100).default(50),
+  limit: LimitSchema.max(100).default(50),
   isRandom: z.boolean().optional().default(false),
 });
 
@@ -84,7 +92,7 @@ export const GetPostsSchema = z.object({
 export type GetPostsRequest = z.infer<typeof GetPostsSchema>;
 
 export const GetPostsCountSchema = z.object({
-  artistId: z.number().int().positive().optional(),
+  artistId: OptionalIdSchema,
   filters: PostFilterSchema.optional(),
 });
 

--- a/src/shared/schemas/search.ts
+++ b/src/shared/schemas/search.ts
@@ -1,4 +1,5 @@
 import { z } from "zod";
+import { PageSchema, LimitSchema } from "./ipc";
 
 /**
  * Search Posts Schema
@@ -9,8 +10,8 @@ import { z } from "zod";
 export const SearchPostsSchema = z.object({
   tags: z.array(z.string().trim().min(1)),
   // Empty array is allowed - means show all posts (API omits tags parameter)
-  page: z.number().int().positive(),
-  limit: z.number().int().positive().max(100).optional(),
+  page: PageSchema,
+  limit: LimitSchema.max(100).optional(),
   isRandom: z.boolean().optional().default(false),
 });
 

--- a/src/shared/schemas/shadow-insert.ts
+++ b/src/shared/schemas/shadow-insert.ts
@@ -1,4 +1,5 @@
 import { z } from "zod";
+import { IdSchema } from "./ipc";
 
 /**
  * Shadow Insert Request Schema
@@ -7,7 +8,7 @@ import { z } from "zod";
  * Main process will fetch full post data from API to ensure data integrity.
  */
 export const ShadowInsertRequestSchema = z.object({
-  postId: z.number().int().positive(),
+  postId: IdSchema,
   provider: z.enum(["rule34", "gelbooru"]),
 }).strict();
 


### PR DESCRIPTION
- Replaced direct number validation with a centralized IdSchema in ArtistsController, MaintenanceController, PlaylistController, PostsController, and various schemas to ensure consistent ID handling.
- Updated related schemas in shared/schemas to utilize IdSchema, OptionalIdSchema, PageSchema, and LimitSchema for improved type safety and maintainability.
- Cleaned up unused imports and ensured strict type safety throughout the updates.