### PR TITLE
feat: add video proxy URL functionality

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -286,6 +286,9 @@ interface IpcBridge {
   exportPlaylist: (playlistId: number) => Promise<{ success: boolean; path?: string; error?: string }>;
   importPlaylist: () => Promise<{ success: boolean; playlistId?: number; error?: string }>;
 
+  // Video (localhost proxy; see architecture docs for cache and host allowlist)
+  getVideoProxyUrl: (fileUrl: string) => Promise<string>;
+
   // Updater
   checkForUpdates: () => Promise<void>;
   quitAndInstall: () => Promise<void>;
@@ -333,6 +336,16 @@ return <div>Version: {version}</div>;
 ```
 
 **IPC Channel:** `app:get-version`
+
+---
+
+### `getVideoProxyUrl(fileUrl: string)`
+
+Returns a `http://127.0.0.1` URL served by the main-process `VideoProxyServer` that forwards Range requests to the original HTTPS CDN and caches full responses under `{userData}/video-cache/`. The renderer should use the returned value as the `<video src>` (with a temporary fallback to the direct CDN URL while this promise resolves). Input is validated with `z.string().url()`. Only the same host allowlist enforced by the proxy is permitted; other URLs are rejected with HTTP 400 if passed through the proxy.
+
+**Returns:** `Promise<string>`
+
+**IPC Channel:** `video-proxy:get-url`
 
 ---
 

--- a/src/main/bridge.ts
+++ b/src/main/bridge.ts
@@ -193,6 +193,8 @@ export interface IpcBridge {
   getPlaylistsContainingPost: (postId: number, rule34PostId?: number) => Promise<number[]>;
   exportPlaylist: (playlistId: number) => Promise<{ success: boolean; path?: string; error?: string }>;
   importPlaylist: () => Promise<{ success: boolean; playlistId?: number; error?: string }>;
+
+  getVideoProxyUrl: (fileUrl: string) => Promise<string>;
 }
 
 const ipcBridge: IpcBridge = {
@@ -415,6 +417,9 @@ const ipcBridge: IpcBridge = {
     ipcRenderer.invoke(IPC_CHANNELS.DB.EXPORT_PLAYLIST, playlistId),
   importPlaylist: () =>
     ipcRenderer.invoke(IPC_CHANNELS.DB.IMPORT_PLAYLIST),
+
+  getVideoProxyUrl: (fileUrl: string) =>
+    ipcRenderer.invoke(IPC_CHANNELS.VIDEO_PROXY.GET_URL, fileUrl),
 };
 
 contextBridge.exposeInMainWorld("api", ipcBridge);

--- a/src/main/ipc/channels.ts
+++ b/src/main/ipc/channels.ts
@@ -84,4 +84,7 @@ export const IPC_CHANNELS = {
   STATS: {
     GET_EXTENDED: "stats:get-extended",
   },
+  VIDEO_PROXY: {
+    GET_URL: "video-proxy:get-url",
+  },
 } as const;

--- a/src/main/ipc/controllers/VideoProxyController.ts
+++ b/src/main/ipc/controllers/VideoProxyController.ts
@@ -1,0 +1,38 @@
+import { type IpcMainInvokeEvent } from "electron";
+import log from "electron-log";
+import { z } from "zod";
+import { BaseController } from "../../core/ipc/BaseController";
+import { VideoProxyServer } from "../../services/video-proxy-server";
+import { IPC_CHANNELS } from "../channels";
+
+export class VideoProxyController extends BaseController {
+  private readonly videoProxyServer: VideoProxyServer;
+
+  constructor(videoProxyServer: VideoProxyServer) {
+    super();
+    this.videoProxyServer = videoProxyServer;
+  }
+
+  public setup(): void {
+    this.handle(
+      IPC_CHANNELS.VIDEO_PROXY.GET_URL,
+      z.tuple([z.string().url()]),
+      this.getVideoProxyUrl.bind(this),
+      { isIdempotent: true },
+    );
+
+    log.info("[VideoProxyController] All handlers registered");
+  }
+
+  private getVideoProxyUrl(
+    _event: IpcMainInvokeEvent,
+    fileUrl: unknown,
+  ): string {
+    if (typeof fileUrl !== "string") {
+      const message = "[VideoProxyController] getVideoProxyUrl: expected string";
+      log.error(message);
+      throw new Error(message);
+    }
+    return this.videoProxyServer.getProxyUrl(fileUrl);
+  }
+}

--- a/src/main/ipc/index.ts
+++ b/src/main/ipc/index.ts
@@ -12,9 +12,11 @@ import { FileController } from "./controllers/FileController";
 import { SearchController } from "./controllers/SearchController";
 import { PlaylistController } from "./controllers/PlaylistController";
 import { StatsController } from "./controllers/StatsController";
+import { VideoProxyController } from "./controllers/VideoProxyController";
 import { registerUpdatesHandlers } from "./handlers/updates";
 import { SyncService } from "../services/sync-service";
 import { UpdaterService } from "../services/updater-service";
+import { VideoProxyServer } from "../services/video-proxy-server";
 import { getDb } from "../db/client";
 import { container, DI_TOKENS } from "../core/di/Container";
 
@@ -26,7 +28,9 @@ import { container, DI_TOKENS } from "../core/di/Container";
  * 
  * @returns Object with controllers that need window reference
  */
-export function setupIpc(): { maintenanceController: MaintenanceController; fileController: FileController; playlistController: PlaylistController } {
+export function setupIpc(
+  videoProxyServer: VideoProxyServer,
+): { maintenanceController: MaintenanceController; fileController: FileController; playlistController: PlaylistController } {
   log.info("[IPC] Setting up IPC handlers...");
 
   // Register database in DI container (using type-safe tokens)
@@ -35,6 +39,9 @@ export function setupIpc(): { maintenanceController: MaintenanceController; file
   log.info("[IPC] Database registered in DI container");
 
   // Register core controllers
+  const videoProxyController = new VideoProxyController(videoProxyServer);
+  videoProxyController.setup();
+
   const systemController = new SystemController();
   systemController.setup();
 
@@ -106,12 +113,13 @@ export function setControllerWindows(
 export const registerAllHandlers = (
   syncService: SyncService,
   _updaterService: UpdaterService,
-  mainWindow: BrowserWindow
+  mainWindow: BrowserWindow,
+  videoProxyServer: VideoProxyServer,
 ) => {
   log.info("[IPC] Registering all handlers...");
 
   // Initialize all controllers
-  const controllers = setupIpc();
+  const controllers = setupIpc(videoProxyServer);
   registerServices(syncService);
   setControllerWindows(controllers, mainWindow);
 

--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -90,6 +90,7 @@ import { eq } from "drizzle-orm";
 import { settings, SETTINGS_ID } from "./db/schema";
 import { container, DI_TOKENS } from "./core/di/Container";
 import { reloadProxyFromSettings } from "./lib/proxy";
+import { VideoProxyServer } from "./services/video-proxy-server";
 
 logger.info("🚀 Application starting...");
 
@@ -140,6 +141,12 @@ function configureUserDataPath(): void {
 }
 
 configureUserDataPath();
+
+const videoProxyServer = new VideoProxyServer();
+
+app.on("before-quit", () => {
+  videoProxyServer.stop();
+});
 
 process.env.USER_DATA_PATH = app.getPath("userData");
 
@@ -312,7 +319,14 @@ function buildCspPolicy(): string {
     `https://*.${domain}`,
     `http://*.${domain}`,
   ]);
-  const mediaOrigins = ["'self'", "data:", "blob:", ...providerOrigins].join(" ");
+  const localVideoProxyOrigins = ["http://127.0.0.1:*", "http://localhost:*"];
+  const mediaOrigins = [
+    "'self'",
+    "data:",
+    "blob:",
+    ...providerOrigins,
+    ...localVideoProxyOrigins,
+  ].join(" ");
   const connectOrigins = ["'self'", ...providerOrigins];
   const devOrigins = ["http://localhost:*", "http://127.0.0.1:*"];
 
@@ -363,6 +377,7 @@ async function initializeAppAndWindow() {
   let loadingWindow: BrowserWindow | null = null;
 
   try {
+    await videoProxyServer.start();
     configureDynamicCspHeaders();
     const isDev = process.env.NODE_ENV === "development";
     logger.info(`Main: CSP configured from provider registry (${isDev ? "development" : "production"} mode)`);
@@ -480,7 +495,7 @@ async function initializeAppAndWindow() {
     if (isTestMode) {
       logger.info("[Main] Test mode: Skipping ready-to-show listener, initializing IPC immediately");
       // Initialize IPC immediately so tests can interact with the app
-      registerAllHandlers(syncService, updaterService, mainWindow);
+      registerAllHandlers(syncService, updaterService, mainWindow, videoProxyServer);
       reloadProxyFromSettings();
       
       // Log window state for debugging
@@ -508,7 +523,7 @@ async function initializeAppAndWindow() {
 
           // Initialize IPC architecture (controllers + legacy handlers)
           // setupIpc is called inside registerAllHandlers now
-          registerAllHandlers(syncService, updaterService, window);
+          registerAllHandlers(syncService, updaterService, window, videoProxyServer);
           reloadProxyFromSettings();
 
           // Auto-sync on startup

--- a/src/main/services/video-proxy-server.ts
+++ b/src/main/services/video-proxy-server.ts
@@ -1,0 +1,437 @@
+import http from "node:http";
+import https from "node:https";
+import fs from "node:fs";
+import path from "node:path";
+import crypto from "node:crypto";
+import { URL } from "node:url";
+import { PassThrough } from "node:stream";
+import { app } from "electron";
+import log from "electron-log";
+import type { AddressInfo } from "node:net";
+
+const VIDEO_PATH = "/video";
+const PROXY_HOST = "127.0.0.1";
+const GELBOORU_IMG_HOSTS = new Set<string>(["img2.gelbooru.com", "img3.gelbooru.com", "img4.gelbooru.com"]);
+
+const VIDEO_CONTENT_TYPE = "video/mp4";
+
+function toTcpAddress(
+  value: string | AddressInfo | null,
+): AddressInfo {
+  if (value === null || typeof value === "string") {
+    throw new Error("[VideoProxy] Server is not bound to a TCP address");
+  }
+  return value;
+}
+
+function getListeningPort(server: http.Server): number {
+  return toTcpAddress(server.address()).port;
+}
+
+function isAllowedCdnUrl(urlString: string): boolean {
+  let parsed: URL;
+  try {
+    parsed = new URL(urlString);
+  } catch {
+    return false;
+  }
+
+  if (parsed.protocol !== "https:") {
+    return false;
+  }
+
+  const host = parsed.hostname;
+  if (GELBOORU_IMG_HOSTS.has(host)) {
+    return true;
+  }
+  if (host === "rule34.xxx" || host.endsWith(".rule34.xxx")) {
+    return true;
+  }
+  return false;
+}
+
+type RangeResult =
+  | { kind: "full" }
+  | { kind: "partial"; start: number; end: number }
+  | { kind: "unsatisfiable" }
+  | { kind: "invalid" };
+
+function parseRangeHeader(rangeHeader: string | undefined, fileSize: number): RangeResult {
+  if (rangeHeader === undefined || rangeHeader === "") {
+    return { kind: "full" };
+  }
+  if (fileSize === 0) {
+    return { kind: "unsatisfiable" };
+  }
+  if (rangeHeader.includes(",")) {
+    return { kind: "invalid" };
+  }
+  const m = /^bytes=(\d+)-(\d*)$/.exec(rangeHeader);
+  if (!m) {
+    return { kind: "invalid" };
+  }
+  const start = Number(m[1]);
+  const endPart = m[2];
+  let end: number;
+  if (endPart === "") {
+    end = fileSize - 1;
+  } else {
+    end = Number(endPart);
+  }
+  if (Number.isNaN(start) || Number.isNaN(end) || start > end) {
+    return { kind: "unsatisfiable" };
+  }
+  if (start >= fileSize) {
+    return { kind: "unsatisfiable" };
+  }
+  if (end >= fileSize) {
+    end = fileSize - 1;
+  }
+  return { kind: "partial", start, end };
+}
+
+function forwardNumberHeader(value: string | string[] | undefined): string | undefined {
+  if (value === undefined) {
+    return undefined;
+  }
+  if (Array.isArray(value)) {
+    return value[0];
+  }
+  return value;
+}
+
+export class VideoProxyServer {
+  private server: http.Server | null = null;
+  private port = 0;
+  private readonly cacheDir: string;
+
+  constructor() {
+    this.cacheDir = path.join(app.getPath("userData"), "video-cache");
+  }
+
+  getListenPort(): number {
+    return this.port;
+  }
+
+  start(): Promise<number> {
+    if (this.server) {
+      return Promise.resolve(this.port);
+    }
+
+    return new Promise((resolve, reject) => {
+      try {
+        fs.mkdirSync(this.cacheDir, { recursive: true });
+      } catch (err) {
+        reject(err);
+        return;
+      }
+
+      const srv = http.createServer((req, res) => {
+        this.handleRequest(req, res);
+      });
+      this.server = srv;
+      srv.once("error", reject);
+      srv.listen(0, PROXY_HOST, () => {
+        srv.removeListener("error", reject);
+        try {
+          this.port = getListeningPort(srv);
+        } catch (err) {
+          reject(err);
+          return;
+        }
+        log.info(`[VideoProxy] Started on port ${this.port}`);
+        resolve(this.port);
+      });
+    });
+  }
+
+  stop(): void {
+    this.server?.close();
+    this.server = null;
+    this.port = 0;
+    log.info("[VideoProxy] Stopped");
+  }
+
+  getProxyUrl(fileUrl: string): string {
+    return `http://${PROXY_HOST}:${this.port}${VIDEO_PATH}?url=${encodeURIComponent(fileUrl)}`;
+  }
+
+  private handleRequest(req: http.IncomingMessage, res: http.ServerResponse): void {
+    if (req.method !== "GET" && req.method !== "HEAD") {
+      res.writeHead(405, { "Content-Type": "text/plain; charset=utf-8" });
+      res.end("Method Not Allowed");
+      return;
+    }
+
+    if (req.url === undefined) {
+      res.writeHead(400, { "Content-Type": "text/plain; charset=utf-8" });
+      res.end("Invalid URL");
+      return;
+    }
+
+    let requestUrl: URL;
+    try {
+      requestUrl = new URL(req.url, `http://${PROXY_HOST}`);
+    } catch {
+      res.writeHead(400, { "Content-Type": "text/plain; charset=utf-8" });
+      res.end("Invalid URL");
+      return;
+    }
+
+    if (requestUrl.pathname !== VIDEO_PATH) {
+      res.writeHead(404, { "Content-Type": "text/plain; charset=utf-8" });
+      res.end("Not Found");
+      return;
+    }
+
+    const urlParam = requestUrl.searchParams.get("url");
+    if (urlParam === null || urlParam === "" || !isAllowedCdnUrl(urlParam)) {
+      res.writeHead(400, { "Content-Type": "text/plain; charset=utf-8" });
+      res.end("Invalid URL");
+      return;
+    }
+
+    const cacheKey = crypto.createHash("md5").update(urlParam).digest("hex");
+    const cachePath = path.join(this.cacheDir, `${cacheKey}.bin`);
+
+    if (fs.existsSync(cachePath)) {
+      this.serveFromDisk(req, res, cachePath);
+      return;
+    }
+
+    this.proxyFromCdn(req, res, urlParam, cachePath);
+  }
+
+  private serveFromDisk(
+    req: http.IncomingMessage,
+    res: http.ServerResponse,
+    filePath: string,
+  ): void {
+    let stat: fs.Stats;
+    try {
+      stat = fs.statSync(filePath);
+    } catch (err) {
+      log.error("[VideoProxy] stat cache failed", err);
+      if (!res.headersSent) {
+        res.writeHead(500, { "Content-Type": "text/plain; charset=utf-8" });
+        res.end("Cache read error");
+      }
+      return;
+    }
+
+    const fileSize = stat.size;
+    const rangeResult = parseRangeHeader(req.headers.range, fileSize);
+
+    if (rangeResult.kind === "invalid") {
+      res.writeHead(400, { "Content-Type": "text/plain; charset=utf-8" });
+      res.end("Invalid Range");
+      return;
+    }
+
+    if (rangeResult.kind === "unsatisfiable") {
+      res.writeHead(416, {
+        "Content-Range": `bytes */${fileSize}`,
+        "Content-Type": "text/plain; charset=utf-8",
+      });
+      res.end("Range Not Satisfiable");
+      return;
+    }
+
+    if (req.method === "HEAD") {
+      if (rangeResult.kind === "full") {
+        res.writeHead(200, {
+          "Content-Type": VIDEO_CONTENT_TYPE,
+          "Content-Length": String(fileSize),
+          "Accept-Ranges": "bytes",
+        });
+        res.end();
+        return;
+      }
+      const { start, end } = rangeResult;
+      const partLength = end - start + 1;
+      res.writeHead(206, {
+        "Content-Type": VIDEO_CONTENT_TYPE,
+        "Content-Range": `bytes ${start}-${end}/${fileSize}`,
+        "Content-Length": String(partLength),
+        "Accept-Ranges": "bytes",
+      });
+      res.end();
+      return;
+    }
+
+    if (rangeResult.kind === "full") {
+      res.writeHead(200, {
+        "Content-Type": VIDEO_CONTENT_TYPE,
+        "Content-Length": String(fileSize),
+        "Accept-Ranges": "bytes",
+        "Cache-Control": "no-store",
+      });
+      const stream = fs.createReadStream(filePath);
+      this.pipeStreamToResponseWithCleanup(stream, res);
+      return;
+    }
+
+    const { start, end } = rangeResult;
+    const partLength = end - start + 1;
+    res.writeHead(206, {
+      "Content-Type": VIDEO_CONTENT_TYPE,
+      "Content-Range": `bytes ${start}-${end}/${fileSize}`,
+      "Content-Length": String(partLength),
+      "Accept-Ranges": "bytes",
+      "Cache-Control": "no-store",
+    });
+    const stream = fs.createReadStream(filePath, { start, end });
+    this.pipeStreamToResponseWithCleanup(stream, res);
+  }
+
+  private pipeStreamToResponseWithCleanup(
+    fileStream: fs.ReadStream,
+    res: http.ServerResponse,
+  ): void {
+    res.on("close", () => {
+      if (!fileStream.destroyed) {
+        fileStream.destroy();
+      }
+    });
+    fileStream.on("error", (err) => {
+      log.error("[VideoProxy] read cache file failed", err);
+      if (!res.headersSent) {
+        res.writeHead(500, { "Content-Type": "text/plain; charset=utf-8" });
+        res.end("Read error");
+        return;
+      }
+      if (!res.writableEnded) {
+        res.destroy();
+      }
+    });
+    fileStream.pipe(res);
+  }
+
+  private proxyFromCdn(
+    req: http.IncomingMessage,
+    res: http.ServerResponse,
+    targetUrl: string,
+    cachePath: string,
+  ): void {
+    const proxyHeaders: http.OutgoingHttpHeaders = {
+      "User-Agent": "Mozilla/5.0",
+    };
+    if (req.headers.range !== undefined) {
+      proxyHeaders.range = req.headers.range;
+    }
+
+    const method = req.method === "HEAD" ? "HEAD" : "GET";
+
+    const cdnReq = https.request(
+      targetUrl,
+      { method, headers: proxyHeaders },
+      (cdnRes) => {
+        const statusCode = cdnRes.statusCode ?? 200;
+        const isOkStatus = statusCode === 200 || statusCode === 206;
+        const shouldCache =
+          method === "GET" && req.headers.range === undefined && statusCode === 200;
+        if (!isOkStatus) {
+          cdnRes.resume();
+          if (!res.headersSent) {
+            res.writeHead(502, { "Content-Type": "text/plain; charset=utf-8" });
+            res.end("Bad Gateway");
+          }
+          return;
+        }
+        if (res.headersSent) {
+          cdnRes.resume();
+          return;
+        }
+        if (res.destroyed) {
+          cdnRes.destroy();
+          return;
+        }
+        if (res.writableFinished) {
+          cdnRes.destroy();
+          return;
+        }
+
+        const outHeaders: http.OutgoingHttpHeaders = {
+          "Accept-Ranges": "bytes",
+          "Cache-Control": "no-store",
+        };
+        const ct = forwardNumberHeader(cdnRes.headers["content-type"]);
+        if (ct !== undefined) {
+          outHeaders["Content-Type"] = ct;
+        } else {
+          outHeaders["Content-Type"] = VIDEO_CONTENT_TYPE;
+        }
+        const cl = forwardNumberHeader(cdnRes.headers["content-length"]);
+        if (cl !== undefined) {
+          outHeaders["Content-Length"] = cl;
+        }
+        const cr = forwardNumberHeader(cdnRes.headers["content-range"]);
+        if (cr !== undefined) {
+          outHeaders["Content-Range"] = cr;
+        }
+
+        if (req.method === "HEAD") {
+          cdnRes.resume();
+          res.writeHead(statusCode, outHeaders);
+          res.end();
+          return;
+        }
+
+        if (!shouldCache) {
+          res.writeHead(statusCode, outHeaders);
+          cdnRes.pipe(res);
+          return;
+        }
+
+        if (res.destroyed) {
+          cdnRes.destroy();
+          return;
+        }
+        if (res.writableFinished) {
+          cdnRes.destroy();
+          return;
+        }
+
+        res.writeHead(statusCode, outHeaders);
+        const pass = new PassThrough();
+        cdnRes.pipe(pass);
+        pass.pipe(res);
+
+        const writeStream = fs.createWriteStream(cachePath);
+        pass.pipe(writeStream);
+
+        writeStream.on("error", (err) => {
+          log.error("[VideoProxy] cache write failed", err);
+          fs.unlink(cachePath, (unlinkErr) => {
+            if (unlinkErr) {
+              log.error("[VideoProxy] failed to remove partial cache", unlinkErr);
+            }
+          });
+        });
+
+        cdnRes.on("error", (err) => {
+          log.error("[VideoProxy] CDN body error during cache", err);
+          fs.unlink(cachePath, (unlinkErr) => {
+            if (unlinkErr) {
+              log.error("[VideoProxy] failed to remove partial cache", unlinkErr);
+            }
+          });
+        });
+      },
+    );
+
+    cdnReq.on("error", (err) => {
+      log.error("[VideoProxy] CDN request failed:", err.message);
+      if (!res.headersSent) {
+        res.writeHead(502, { "Content-Type": "text/plain; charset=utf-8" });
+        res.end("Proxy error");
+      }
+    });
+
+    req.on("close", () => {
+      cdnReq.destroy();
+    });
+
+    cdnReq.end();
+  }
+}

--- a/src/renderer.d.ts
+++ b/src/renderer.d.ts
@@ -158,6 +158,8 @@ export interface IpcApi extends IpcBridge {
   getPlaylistsContainingPost: (postId: number) => Promise<number[]>;
   exportPlaylist: (playlistId: number) => Promise<{ success: boolean; path?: string; error?: string }>;
   importPlaylist: () => Promise<{ success: boolean; playlistId?: number; error?: string }>;
+
+  getVideoProxyUrl: (fileUrl: string) => Promise<string>;
 }
 
 declare global {

--- a/src/renderer/features/artists/components/PostCard.tsx
+++ b/src/renderer/features/artists/components/PostCard.tsx
@@ -6,6 +6,7 @@ import { useSafeModeStore, shouldBlurPost, getEffectiveBlurAmount } from "../../
 import { useSearchStore } from "../../../store/searchStore";
 import { isVideoPost } from "../../../lib/filter-utils";
 import { isVideoUrl } from "../../../../shared/utils/media";
+import { useVideoProxyUrl } from "../../../lib/hooks/useVideoProxyUrl";
 import { QuickAddToPlaylistMenu } from "../../../components/playlists/QuickAddToPlaylistMenu";
 
 const loadedSampleUrls = new Set<string>();
@@ -54,6 +55,10 @@ export const PostCard: React.FC<PostCardProps> = ({
   const videoPreviewUrl = isVid
     ? (post.sampleUrl && isVideoUrl(post.sampleUrl) ? post.sampleUrl : post.fileUrl)
     : null;
+
+  const videoProxySrc = useVideoProxyUrl(
+    isVid && videoPreviewUrl ? videoPreviewUrl : null,
+  );
 
   // IntersectionObserver: only initialize video when card is in viewport
   useEffect(() => {
@@ -225,7 +230,7 @@ export const PostCard: React.FC<PostCardProps> = ({
             <video
               key={videoKey}
               ref={videoRef}
-              src={videoPreviewUrl}
+              src={videoProxySrc ?? videoPreviewUrl}
               muted
               loop
               playsInline

--- a/src/renderer/features/viewer/ViewerDialog.tsx
+++ b/src/renderer/features/viewer/ViewerDialog.tsx
@@ -66,6 +66,7 @@ import { useSearchStore } from "../../store/searchStore";
 import { useSafeModeStore, shouldBlurPost, getEffectiveBlurAmount } from "../../store/safeModeStore";
 import { cn } from "../../lib/utils";
 import { isVideoPost } from "../../lib/filter-utils";
+import { useVideoProxyUrl } from "../../lib/hooks/useVideoProxyUrl";
 import { useViewerController } from "./hooks/useViewerController";
 import { QuickAddToPlaylistMenu } from "../../components/playlists/QuickAddToPlaylistMenu";
 
@@ -525,6 +526,9 @@ const ViewerMedia = ({
   const effectiveBlur = getEffectiveBlurAmount(safeMode, panicMode, blurAmount);
 
   const isVideo = isVideoPost(post.fileUrl);
+  const videoProxySrc = useVideoProxyUrl(
+    isVideo && post.fileUrl ? post.fileUrl : null,
+  );
 
   const resetImageZoom = useCallback(() => {
     transformRef.current?.resetTransform();
@@ -613,7 +617,7 @@ const ViewerMedia = ({
             }}
           >
             <video
-              src={post.fileUrl}
+              src={videoProxySrc ?? post.fileUrl}
               className="object-contain max-w-full max-h-full outline-none focus:outline-none"
               autoPlay={isVideoPlaying}
               loop

--- a/src/renderer/lib/hooks/useVideoProxyUrl.ts
+++ b/src/renderer/lib/hooks/useVideoProxyUrl.ts
@@ -1,0 +1,49 @@
+import { useEffect, useState } from "react";
+import log from "electron-log/renderer";
+
+type ProxyEntry = { fileUrl: string; proxy: string };
+
+/**
+ * Resolves a localhost video proxy URL for Range-aware playback and disk cache.
+ * Returns null while the URL does not match a resolved entry (use `result ?? fileUrl` for src).
+ */
+export function useVideoProxyUrl(
+  fileUrl: string | null | undefined,
+): string | null {
+  const [entry, setEntry] = useState<ProxyEntry | null>(null);
+
+  useEffect(() => {
+    if (fileUrl === null || fileUrl === undefined || fileUrl === "") {
+      return;
+    }
+
+    let cancelled = false;
+    void window.api
+      .getVideoProxyUrl(fileUrl)
+      .then((proxy) => {
+        if (!cancelled) {
+          setEntry({ fileUrl, proxy });
+        }
+      })
+      .catch((err: unknown) => {
+        log.error("[useVideoProxyUrl] getVideoProxyUrl failed", err);
+        if (!cancelled) {
+          setEntry(null);
+        }
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [fileUrl]);
+
+  if (fileUrl === null || fileUrl === undefined || fileUrl === "") {
+    return null;
+  }
+
+  if (entry !== null && entry.fileUrl === fileUrl) {
+    return entry.proxy;
+  }
+
+  return null;
+}


### PR DESCRIPTION
- Introduced `getVideoProxyUrl` method in the IPC bridge to retrieve a proxied video URL from the main process, enhancing video handling capabilities.
- Updated relevant interfaces and documentation to reflect the new method and its usage.
- Integrated the video proxy URL in the `PostCard` and `ViewerDialog` components for improved video source management.
- Ensured input validation using Zod for the new method and maintained strict type safety throughout the updates.