### PR TITLE
Feat/cdn-selector

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ This project is **unofficial** and **not affiliated** with any external website 
 | **💾 Local Metadata Database**    | Uses **SQLite** via **Drizzle ORM** (TypeScript mandatory). Direct synchronous access via `better-sqlite3` in Main Process. Stores artists, posts metadata (tags, ratings, URLs, sample URLs), and settings. WAL mode enabled for concurrent reads.                                                                                                    |
 | **🖼️ Artist Gallery**             | View cached posts for each tracked artist in a responsive grid layout. Shows preview images, ratings, and metadata. Click to open external link to Rule34.xxx. Supports pagination and artist repair/resync functionality. Mark posts as viewed for better organization.                                                                               |
 | **🎨 Progressive Image Loading**  | Stills: `PostCard` loads **preview** first, then upgrades to **sample** when the card is in the viewport. Viewer uses file URL for full quality. Video posts use sample/file for hover preview as applicable.                                                                                                                                       |
+| **🌍 Rule34 CDN Selection**       | Main Process probes Rule34 CDN hosts on startup (`rule34.xxx`, `us.rule34.xxx`, `wimg.rule34.xxx`, `api-cdn.rule34.xxx`) and rewrites Rule34 media URLs to the fastest reachable host. Probing is non-blocking and safely falls back to `rule34.xxx` if selection has not completed or fails.                                                        |
 | **📊 Post Metadata**              | Cached posts include file URLs, preview URLs, sample URLs, tags, ratings, and publication timestamps. Enables offline browsing and fast filtering.                                                                                                                                                                                                     |
 | **🔧 Artist Repair**              | Repair/resync functionality to update low-quality previews or fix synchronization issues. Resets artist's last post ID and re-fetches initial pages.                                                                                                                                                                                                   |
 | **💾 Backup & Restore**           | Manual database backup and restore. Timestamped backups in the user data directory; after each successful backup, older files are pruned to keep the **last five** copies. Restore replaces the live DB (with checks) and reloads the app.                                                                                                          |
@@ -77,6 +78,7 @@ This is the secure Node.js environment. It handles all I/O, persistence, and sec
 - **Data Layer:** **Drizzle ORM** (TypeScript type-safety for queries, raw SQL timestamps in milliseconds).
 - **Security:** **Secure Storage** using Electron's `safeStorage` API for encrypting API credentials at rest.
 - **API:** Custom wrapper based on `axios` with retry and backoff logic.
+- **CDN Routing (Rule34 media):** `CdnSelectorService` probes Rule34 CDN nodes in background and rewrites only Rule34 media URLs (`fileUrl`, `sampleUrl`, `previewUrl`) to the selected host.
 - **Background Jobs:** Node.js timers and asynchronous operations.
 
 ### 2. Renderer (The Face - UI Process)
@@ -278,6 +280,7 @@ The application is stable and production-ready (see **`package.json`** → `vers
 - ✅ **Credential Verification:** Verify API credentials before saving and during sync operations
 - ✅ **Age Gate Component:** Fully implemented with legal confirmation (`AgeGate.tsx` component and `confirmLegal` IPC method)
 - ✅ **Content Security Policy:** Strict CSP with support for Rule34.xxx and Gelbooru.com media sources
+- ✅ **Rule34 CDN Selector:** Startup probe and runtime URL rewrite for Rule34 media with fallback to `rule34.xxx`
 - ✅ **Safe Mode / NSFW blur:** When Safe Mode is enabled, gallery cards and the full-screen viewer apply configurable blur to sensitive ratings (`PostCard`, `ViewerDialog`, `safeModeStore`)
 
 ---

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -582,15 +582,23 @@ const posts = await db.query.posts.findMany({
    - `IBooruProvider` interface for standardized booru operations
    - Implementations: `Rule34Provider`, `GelbooruProvider`
    - Methods: `checkAuth`, `fetchPosts`, `searchTags`, `formatTag`
+   - Rule34 media URLs (`fileUrl`, `sampleUrl`, `previewUrl`) are rewritten by Main Process CDN selector to the currently selected Rule34 CDN host
 
-8. **Updater Service** (`src/main/services/updater-service.ts`)
+8. **CDN Selector Service** (`src/main/services/cdn-selector.ts`)
+
+   - Probes Rule34 CDN hosts (`rule34.xxx`, `us.rule34.xxx`, `wimg.rule34.xxx`, `api-cdn.rule34.xxx`) on startup using non-blocking `HEAD` checks
+   - Selects the fastest reachable host and keeps `rule34.xxx` as fallback
+   - Triggers re-probe on repeated request failures or slow responses
+   - Rewrites only Rule34 media hosts, leaving non-Rule34 URLs unchanged
+
+9. **Updater Service** (`src/main/services/updater-service.ts`)
 
    - Manages automatic update checking via `electron-updater`
    - Handles update download and installation
    - Emits IPC events for update status and progress
    - User-controlled download (manual download trigger)
 
-9. **Secure Storage** (`src/main/services/secure-storage.ts`)
+10. **Secure Storage** (`src/main/services/secure-storage.ts`)
 
    - Encrypts and decrypts sensitive data using Electron's `safeStorage` API
    - Static class with `encrypt()` and `decrypt()` methods
@@ -598,18 +606,19 @@ const posts = await db.query.posts.findMany({
    - Decryption only occurs in Main Process when needed for API calls
    - Uses platform keychain (Windows Credential Manager, macOS Keychain, Linux libsecret)
 
-10. **Bridge** (`src/main/bridge.ts`)
+11. **Bridge** (`src/main/bridge.ts`)
 
 - Defines the IPC interface
 - Exposed via preload script
 - Type-safe communication contract
 - Event listener management for real-time updates
 
-11. **Main Entry** (`src/main/main.ts`)
+12. **Main Entry** (`src/main/main.ts`)
     - Application initialization
     - Window creation
     - Security configuration
     - Database initialization and migrations
+    - Non-blocking initial Rule34 CDN probe before sync startup
 
 ### Renderer Process (The Face)
 
@@ -1530,6 +1539,7 @@ src/
 │   │   └── index.ts               # Provider registry
 │   ├── services/                  # Background services
 │   │   ├── secure-storage.ts       # Secure storage for API credentials
+│   │   ├── cdn-selector.ts         # Rule34 CDN probe + media URL rewrite
 │   │   ├── sync-service.ts        # Rule34.xxx API synchronization
 │   │   └── updater-service.ts     # Auto-updater service
 │   ├── lib/                       # Utilities

--- a/docs/development.md
+++ b/docs/development.md
@@ -267,6 +267,7 @@ Opens web interface at `http://localhost:4983` (default port).
 │   │   │   └── index.ts               # Provider registry
 │   │   ├── services/                  # Background services
 │   │   │   ├── secure-storage.ts      # Secure storage for credentials
+│   │   │   ├── cdn-selector.ts        # Rule34 CDN probe and URL rewrite
 │   │   │   ├── sync-service.ts        # API synchronization
 │   │   │   └── updater-service.ts     # Auto-updater
 │   │   ├── lib/                        # Utilities

--- a/docs/rule34-api-reference.md
+++ b/docs/rule34-api-reference.md
@@ -180,6 +180,17 @@ https://api.rule34.xxx/autocomplete.php?q=char
 
 ## Best Practices and Cautions
 
+### CDN Hostnames and Media URLs
+
+Rule34 serves media files from multiple hostnames that share the same path format. In practice, switching CDN node means replacing only the hostname while keeping the rest of the URL unchanged.
+
+- `rule34.xxx` (default/fallback)
+- `us.rule34.xxx` (USA)
+- `wimg.rule34.xxx` (EU)
+- `api-cdn.rule34.xxx` (API-CDN)
+
+If your client optimizes media delivery by selecting a faster host, keep a safe fallback to `rule34.xxx` and rewrite only media URLs (not API endpoint URLs such as `api.rule34.xxx`).
+
 ### Rate Limiting
 
 - Implement exponential backoff for rate limit errors

--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -91,6 +91,7 @@ import { settings, SETTINGS_ID } from "./db/schema";
 import { container, DI_TOKENS } from "./core/di/Container";
 import { reloadProxyFromSettings } from "./lib/proxy";
 import { VideoProxyServer } from "./services/video-proxy-server";
+import { cdnSelector } from "./services/cdn-selector";
 
 logger.info("🚀 Application starting...");
 
@@ -377,6 +378,10 @@ async function initializeAppAndWindow() {
   let loadingWindow: BrowserWindow | null = null;
 
   try {
+    cdnSelector.probe().catch((error: unknown) => {
+      log.error("[CdnSelector] Initial probe failed:", error);
+    });
+
     await videoProxyServer.start();
     configureDynamicCspHeaders();
     const isDev = process.env.NODE_ENV === "development";

--- a/src/main/providers/rule34-provider.ts
+++ b/src/main/providers/rule34-provider.ts
@@ -23,6 +23,7 @@ import { MAX_RANDOM_PAGES } from "../../shared/constants";
 import { z } from "zod";
 import { ProviderThrottle, pickRandomUA } from "./provider-throttle";
 import { getProxyAgent } from "../lib/proxy";
+import { cdnSelector } from "../services/cdn-selector";
 
 interface R34AutocompleteItem {
   label: string;
@@ -38,6 +39,8 @@ export class Rule34Provider implements IBooruProvider {
     "api.rule34.xxx",
     "img.rule34.xxx",
     "wimg.rule34.xxx",
+    "us.rule34.xxx",
+    "api-cdn.rule34.xxx",
   ];
   private readonly baseUrl = "https://api.rule34.xxx/index.php";
   private readonly throttle = new ProviderThrottle();
@@ -244,13 +247,24 @@ export class Rule34Provider implements IBooruProvider {
     const jsonUrl = this.buildUrl({ tags, page: apiPage, settings, json: 1 });
 
     try {
-      const response = await axios.get<string>(jsonUrl, {
-        timeout: REQUEST_TIMEOUT,
-        headers: this.getHeaders(),
-        responseType: "text",
-        validateStatus: (status) => status < 500,
-        httpsAgent: getProxyAgent(),
-      });
+      const requestStart = Date.now();
+      const response = await axios
+        .get<string>(jsonUrl, {
+          timeout: REQUEST_TIMEOUT,
+          headers: this.getHeaders(),
+          responseType: "text",
+          validateStatus: (status) => status < 500,
+          httpsAgent: getProxyAgent(),
+        })
+        .then((result) => {
+          cdnSelector.reportSuccess();
+          cdnSelector.reportSlowRequest(Date.now() - requestStart);
+          return result;
+        })
+        .catch((error: unknown) => {
+          cdnSelector.reportFailure();
+          throw error;
+        });
 
       const text = response.data;
 
@@ -286,13 +300,24 @@ export class Rule34Provider implements IBooruProvider {
       // Step 2: FALLBACK TO XML
       try {
         const xmlUrl = this.buildUrl({ tags, page: apiPage, settings, json: 0 });
-        const xmlResponse = await axios.get<string>(xmlUrl, {
-          timeout: REQUEST_TIMEOUT,
-          headers: this.getHeaders(),
-          responseType: "text",
-          validateStatus: (status) => status < 500,
-          httpsAgent: getProxyAgent(),
-        });
+        const requestStart = Date.now();
+        const xmlResponse = await axios
+          .get<string>(xmlUrl, {
+            timeout: REQUEST_TIMEOUT,
+            headers: this.getHeaders(),
+            responseType: "text",
+            validateStatus: (status) => status < 500,
+            httpsAgent: getProxyAgent(),
+          })
+          .then((result) => {
+            cdnSelector.reportSuccess();
+            cdnSelector.reportSlowRequest(Date.now() - requestStart);
+            return result;
+          })
+          .catch((error: unknown) => {
+            cdnSelector.reportFailure();
+            throw error;
+          });
 
         const xmlText = xmlResponse.data;
         const posts = this.parsePostXml(xmlText);
@@ -391,9 +416,12 @@ export class Rule34Provider implements IBooruProvider {
       }) || fileUrl; // Fallback to fileUrl if selectBestPreview returns empty
 
     const sampleUrl = String(post.sample_url || fileUrl).trim();
+    const rewrittenFileUrl = cdnSelector.rewriteUrl(fileUrl);
+    const rewrittenSampleUrl = cdnSelector.rewriteUrl(sampleUrl);
 
     // Ensure previewUrl is never empty (critical for UI display)
     const finalPreviewUrl = previewUrl.trim() || fileUrl;
+    const rewrittenPreviewUrl = cdnSelector.rewriteUrl(finalPreviewUrl);
     if (!finalPreviewUrl) return null; // Skip if still empty
 
     // Parse tags: split by space and filter empty strings
@@ -444,9 +472,9 @@ export class Rule34Provider implements IBooruProvider {
     // Build BooruPost object with strict camelCase mapping
     return {
       id: id,
-      fileUrl: fileUrl,
-      previewUrl: finalPreviewUrl,
-      sampleUrl: sampleUrl,
+      fileUrl: rewrittenFileUrl,
+      previewUrl: rewrittenPreviewUrl,
+      sampleUrl: rewrittenSampleUrl,
       tags: tags,
       rating: rating,
       score: isNaN(score) ? 0 : score,
@@ -476,6 +504,10 @@ export class Rule34Provider implements IBooruProvider {
     // selectBestPreview should always return a valid URL if file_url exists
     // But we check anyway for safety - if empty, use file_url as fallback
     const finalPreview = preview && preview.trim() !== "" ? preview : fileUrl;
+    const sampleUrl = (raw.sample_url || raw.file_url).trim();
+    const rewrittenFileUrl = cdnSelector.rewriteUrl(fileUrl);
+    const rewrittenSampleUrl = cdnSelector.rewriteUrl(sampleUrl);
+    const rewrittenPreviewUrl = cdnSelector.rewriteUrl(finalPreview);
 
     if (!finalPreview || finalPreview.trim() === "") {
       logger.warn(
@@ -503,9 +535,9 @@ export class Rule34Provider implements IBooruProvider {
 
     return {
       id: raw.id,
-      fileUrl: fileUrl,
-      sampleUrl: (raw.sample_url || raw.file_url).trim(),
-      previewUrl: finalPreview,
+      fileUrl: rewrittenFileUrl,
+      sampleUrl: rewrittenSampleUrl,
+      previewUrl: rewrittenPreviewUrl,
       tags: raw.tags.split(" ").filter(Boolean),
       rating: rating,
       score: raw.score ?? 0,

--- a/src/main/services/cdn-selector.ts
+++ b/src/main/services/cdn-selector.ts
@@ -1,0 +1,138 @@
+import https from "node:https";
+import log from "electron-log";
+import {
+  RULE34_CDN_HOSTS,
+  CDN_PROBE_TIMEOUT_MS,
+  CDN_SLOW_THRESHOLD_MS,
+  CDN_MAX_FAILURES_BEFORE_REPROBE,
+  CDN_PROBE_PATH,
+} from "../../shared/constants/cdn";
+
+interface ProbeResult {
+  host: string;
+  ttfbMs: number;
+  ok: boolean;
+}
+
+function isRule34CdnHost(hostname: string): boolean {
+  return RULE34_CDN_HOSTS.some((host) => host === hostname);
+}
+
+export class CdnSelectorService {
+  private selectedHost: string = RULE34_CDN_HOSTS[0];
+  private failureCount = 0;
+  private isProbing = false;
+
+  async probe(): Promise<void> {
+    if (this.isProbing) {
+      return;
+    }
+
+    this.isProbing = true;
+    try {
+      const results = await Promise.allSettled(
+        RULE34_CDN_HOSTS.map((host) => this.measureTtfb(host))
+      );
+
+      const successful = results
+        .filter(
+          (result): result is PromiseFulfilledResult<ProbeResult> =>
+            result.status === "fulfilled" && result.value.ok
+        )
+        .map((result) => result.value)
+        .sort((a, b) => a.ttfbMs - b.ttfbMs);
+
+      if (successful.length === 0) {
+        log.warn("[CdnSelector] All CDN hosts unreachable, keeping default");
+        return;
+      }
+
+      const fastest = successful[0];
+      this.selectedHost = fastest.host;
+      log.info(
+        `[CdnSelector] Selected CDN: ${this.selectedHost} (${fastest.ttfbMs}ms)`
+      );
+      log.info(
+        `[CdnSelector] All results: ${successful
+          .map((result) => `${result.host}=${result.ttfbMs}ms`)
+          .join(", ")}`
+      );
+    } finally {
+      this.isProbing = false;
+    }
+  }
+
+  rewriteUrl(originalUrl: string): string {
+    if (!originalUrl) {
+      return originalUrl;
+    }
+
+    try {
+      const url = new URL(originalUrl);
+      if (!isRule34CdnHost(url.hostname)) {
+        return originalUrl;
+      }
+      url.hostname = this.selectedHost;
+      return url.toString();
+    } catch {
+      return originalUrl;
+    }
+  }
+
+  reportSuccess(): void {
+    this.failureCount = 0;
+  }
+
+  reportFailure(): void {
+    this.failureCount += 1;
+    if (this.failureCount >= CDN_MAX_FAILURES_BEFORE_REPROBE) {
+      log.warn(`[CdnSelector] ${this.failureCount} failures, re-probing CDN`);
+      this.failureCount = 0;
+      this.probe().catch((error: unknown) => {
+        log.error("[CdnSelector] Re-probe failed:", error);
+      });
+    }
+  }
+
+  reportSlowRequest(ttfbMs: number): void {
+    if (ttfbMs > CDN_SLOW_THRESHOLD_MS) {
+      log.warn(`[CdnSelector] Slow CDN response (${ttfbMs}ms), re-probing`);
+      this.probe().catch((error: unknown) => {
+        log.error("[CdnSelector] Re-probe failed:", error);
+      });
+    }
+  }
+
+  private measureTtfb(host: string): Promise<ProbeResult> {
+    return new Promise((resolve) => {
+      const start = Date.now();
+      const timeout = setTimeout(() => {
+        resolve({ host, ttfbMs: CDN_PROBE_TIMEOUT_MS, ok: false });
+      }, CDN_PROBE_TIMEOUT_MS);
+
+      const req = https.request(
+        {
+          hostname: host,
+          path: CDN_PROBE_PATH,
+          method: "HEAD",
+          headers: { "User-Agent": "Mozilla/5.0" },
+        },
+        (res) => {
+          clearTimeout(timeout);
+          const ttfbMs = Date.now() - start;
+          res.resume();
+          resolve({ host, ttfbMs, ok: (res.statusCode ?? 0) < 500 });
+        }
+      );
+
+      req.on("error", () => {
+        clearTimeout(timeout);
+        resolve({ host, ttfbMs: CDN_PROBE_TIMEOUT_MS, ok: false });
+      });
+
+      req.end();
+    });
+  }
+}
+
+export const cdnSelector = new CdnSelectorService();

--- a/src/shared/constants/cdn.ts
+++ b/src/shared/constants/cdn.ts
@@ -1,0 +1,13 @@
+export const RULE34_CDN_HOSTS = [
+  "rule34.xxx",
+  "us.rule34.xxx",
+  "wimg.rule34.xxx",
+  "api-cdn.rule34.xxx",
+] as const;
+
+export const CDN_PROBE_TIMEOUT_MS = 3000;
+export const CDN_SLOW_THRESHOLD_MS = 5000;
+export const CDN_MAX_FAILURES_BEFORE_REPROBE = 3;
+
+export const CDN_PROBE_PATH =
+  "/thumbnails/1/thumbnail_0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f.jpg";


### PR DESCRIPTION
- Added details about the new Rule34 CDN selection feature in the README, including its non-blocking probing mechanism and URL rewriting capabilities.
- Updated architecture documentation to reflect the introduction of the `CdnSelectorService`, outlining its role in managing CDN host selection and media URL rewriting.
- Enhanced the development documentation to include the new `cdn-selector.ts` service, ensuring clarity on its purpose and functionality.
- Included best practices for handling Rule34 media URLs in the API reference documentation.