### PR TITLE
feat: enhance playlist management with new manual playlist features

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17,6 +17,7 @@
         "@heroicons/react": "^2.2.0",
         "@hookform/resolvers": "^5.2.2",
         "@kazekaze93/repo-inquisitor": "github:KazeKaze93/repo-inquisitor",
+        "@radix-ui/react-alert-dialog": "^1.1.15",
         "@radix-ui/react-checkbox": "^1.3.3",
         "@radix-ui/react-dialog": "^1.1.15",
         "@radix-ui/react-dropdown-menu": "^2.1.16",
@@ -3654,6 +3655,34 @@
       "resolved": "https://registry.npmjs.org/@radix-ui/primitive/-/primitive-1.1.3.tgz",
       "integrity": "sha512-JTF99U/6XIjCBo0wqkU5sK10glYe27MRRsfwoiq5zzOEZLHU3A3KCMa5X/azekYRCJ0HlwI0crAXS/5dEHTzDg==",
       "license": "MIT"
+    },
+    "node_modules/@radix-ui/react-alert-dialog": {
+      "version": "1.1.15",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-alert-dialog/-/react-alert-dialog-1.1.15.tgz",
+      "integrity": "sha512-oTVLkEw5GpdRe29BqJ0LSDFWI3qu0vR1M0mUkOQWDIUnY/QIkLpgDMWuKxP94c2NAC2LGcgVhG1ImF3jkZ5wXw==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.3",
+        "@radix-ui/react-compose-refs": "1.1.2",
+        "@radix-ui/react-context": "1.1.2",
+        "@radix-ui/react-dialog": "1.1.15",
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-slot": "1.2.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
     },
     "node_modules/@radix-ui/react-arrow": {
       "version": "1.1.7",

--- a/package.json
+++ b/package.json
@@ -110,6 +110,7 @@
     "@heroicons/react": "^2.2.0",
     "@hookform/resolvers": "^5.2.2",
     "@kazekaze93/repo-inquisitor": "github:KazeKaze93/repo-inquisitor",
+    "@radix-ui/react-alert-dialog": "^1.1.15",
     "@radix-ui/react-checkbox": "^1.3.3",
     "@radix-ui/react-dialog": "^1.1.15",
     "@radix-ui/react-dropdown-menu": "^2.1.16",

--- a/src/main/bridge.ts
+++ b/src/main/bridge.ts
@@ -19,6 +19,10 @@ import type {
   GetPlaylistPostsRequest,
   ResolvePlaylistPostsRequest,
   ReorderPlaylistEntriesRequest,
+  GetManualPlaylistMembershipForPostsRequest,
+  SyncManualPlaylistMembershipRequest,
+  ClearManualPlaylistRequest,
+  MovePostsBetweenManualPlaylistsRequest,
 } from "../shared/schemas/playlist";
 import type { ExtendedStats } from "../shared/schemas/stats";
 
@@ -205,6 +209,14 @@ export interface IpcBridge {
   getPlaylistPosts: (params: GetPlaylistPostsRequest) => Promise<Post[]>;
   resolvePlaylistPosts: (params: ResolvePlaylistPostsRequest) => Promise<Post[]>;
   getPlaylistsContainingPost: (postId: number, rule34PostId?: number) => Promise<number[]>;
+  getManualPlaylistMembershipForPosts: (
+    data: GetManualPlaylistMembershipForPostsRequest
+  ) => Promise<{ playlistId: number; matchCount: number }[]>;
+  syncManualPlaylistMembership: (data: SyncManualPlaylistMembershipRequest) => Promise<void>;
+  clearManualPlaylist: (data: ClearManualPlaylistRequest) => Promise<void>;
+  movePostsBetweenManualPlaylists: (
+    data: MovePostsBetweenManualPlaylistsRequest
+  ) => Promise<void>;
   exportPlaylist: (playlistId: number) => Promise<{ success: boolean; path?: string; error?: string }>;
   importPlaylist: () => Promise<{ success: boolean; playlistId?: number; error?: string }>;
 
@@ -445,6 +457,14 @@ const ipcBridge: IpcBridge = {
     ipcRenderer.invoke(IPC_CHANNELS.DB.RESOLVE_PLAYLIST_POSTS, params),
   getPlaylistsContainingPost: (postId: number, rule34PostId?: number) =>
     ipcRenderer.invoke(IPC_CHANNELS.DB.GET_PLAYLISTS_CONTAINING_POST, postId, rule34PostId),
+  getManualPlaylistMembershipForPosts: (data: GetManualPlaylistMembershipForPostsRequest) =>
+    ipcRenderer.invoke(IPC_CHANNELS.DB.GET_MANUAL_PLAYLIST_MEMBERSHIP_FOR_POSTS, data),
+  syncManualPlaylistMembership: (data: SyncManualPlaylistMembershipRequest) =>
+    ipcRenderer.invoke(IPC_CHANNELS.DB.SYNC_MANUAL_PLAYLIST_MEMBERSHIP, data),
+  clearManualPlaylist: (data: ClearManualPlaylistRequest) =>
+    ipcRenderer.invoke(IPC_CHANNELS.DB.CLEAR_MANUAL_PLAYLIST, data),
+  movePostsBetweenManualPlaylists: (data: MovePostsBetweenManualPlaylistsRequest) =>
+    ipcRenderer.invoke(IPC_CHANNELS.DB.MOVE_POSTS_BETWEEN_MANUAL_PLAYLISTS, data),
   exportPlaylist: (playlistId: number) =>
     ipcRenderer.invoke(IPC_CHANNELS.DB.EXPORT_PLAYLIST, playlistId),
   importPlaylist: () =>

--- a/src/main/ipc/channels.ts
+++ b/src/main/ipc/channels.ts
@@ -52,6 +52,10 @@ export const IPC_CHANNELS = {
     EXPORT_PLAYLIST: "db:export-playlist",
     IMPORT_PLAYLIST: "db:import-playlist",
     GET_PLAYLISTS_CONTAINING_POST: "db:get-playlists-containing-post",
+    GET_MANUAL_PLAYLIST_MEMBERSHIP_FOR_POSTS: "db:get-manual-playlist-membership-for-posts",
+    SYNC_MANUAL_PLAYLIST_MEMBERSHIP: "db:sync-manual-playlist-membership",
+    CLEAR_MANUAL_PLAYLIST: "db:clear-manual-playlist",
+    MOVE_POSTS_BETWEEN_MANUAL_PLAYLISTS: "db:move-posts-between-manual-playlists",
     GET_PLAYLIST_DOWNLOAD_ITEMS: "db:get-playlist-download-items",
   },
   API: {

--- a/src/main/ipc/controllers/PlaylistController.ts
+++ b/src/main/ipc/controllers/PlaylistController.ts
@@ -29,6 +29,14 @@ import {
   type ReorderPlaylistEntriesRequest,
   type SmartPlaylistQuery,
   type PlaylistExport,
+  GetManualPlaylistMembershipForPostsSchema,
+  type GetManualPlaylistMembershipForPostsRequest,
+  SyncManualPlaylistMembershipSchema,
+  type SyncManualPlaylistMembershipRequest,
+  ClearManualPlaylistSchema,
+  type ClearManualPlaylistRequest,
+  MovePostsBetweenManualPlaylistsSchema,
+  type MovePostsBetweenManualPlaylistsRequest,
 } from "../../../shared/schemas/playlist";
 import {
   CURRENT_SMART_QUERY_SCHEMA_VERSION,
@@ -311,6 +319,42 @@ export class PlaylistController extends BaseController {
       IPC_CHANNELS.DB.GET_PLAYLISTS_CONTAINING_POST,
       z.tuple([z.number().int(), OptionalIdSchema]),
       this.getPlaylistsContainingPost.bind(this) as (
+        event: IpcMainInvokeEvent,
+        ...args: unknown[]
+      ) => Promise<unknown>
+    );
+
+    this.handle(
+      IPC_CHANNELS.DB.GET_MANUAL_PLAYLIST_MEMBERSHIP_FOR_POSTS,
+      GetManualPlaylistMembershipForPostsSchema,
+      this.getManualPlaylistMembershipForPosts.bind(this) as (
+        event: IpcMainInvokeEvent,
+        ...args: unknown[]
+      ) => Promise<unknown>
+    );
+
+    this.handle(
+      IPC_CHANNELS.DB.SYNC_MANUAL_PLAYLIST_MEMBERSHIP,
+      SyncManualPlaylistMembershipSchema,
+      this.syncManualPlaylistMembership.bind(this) as (
+        event: IpcMainInvokeEvent,
+        ...args: unknown[]
+      ) => Promise<unknown>
+    );
+
+    this.handle(
+      IPC_CHANNELS.DB.CLEAR_MANUAL_PLAYLIST,
+      ClearManualPlaylistSchema,
+      this.clearManualPlaylist.bind(this) as (
+        event: IpcMainInvokeEvent,
+        ...args: unknown[]
+      ) => Promise<unknown>
+    );
+
+    this.handle(
+      IPC_CHANNELS.DB.MOVE_POSTS_BETWEEN_MANUAL_PLAYLISTS,
+      MovePostsBetweenManualPlaylistsSchema,
+      this.movePostsBetweenManualPlaylists.bind(this) as (
         event: IpcMainInvokeEvent,
         ...args: unknown[]
       ) => Promise<unknown>
@@ -1127,6 +1171,227 @@ export class PlaylistController extends BaseController {
       log.error("[PlaylistController] Failed to remove posts from playlist:", error);
       throw error;
     }
+  }
+
+  /**
+   * Returns per–manual-playlist counts of how many of the given posts appear in each playlist.
+   */
+  private async getManualPlaylistMembershipForPosts(
+    _event: IpcMainInvokeEvent,
+    data: GetManualPlaylistMembershipForPostsRequest
+  ): Promise<{ playlistId: number; matchCount: number }[]> {
+    try {
+      const db = this.getDb();
+      const rows = db
+        .select({
+          playlistId: playlistEntries.playlistId,
+          matchCount: sql<number>`count(*)`.mapWith(Number),
+        })
+        .from(playlistEntries)
+        .innerJoin(playlists, eq(playlistEntries.playlistId, playlists.id))
+        .where(
+          and(eq(playlists.isSmart, false), inArray(playlistEntries.postId, data.postIds))
+        )
+        .groupBy(playlistEntries.playlistId)
+        .all();
+
+      return rows.map((r) => ({
+        playlistId: r.playlistId,
+        matchCount: r.matchCount,
+      }));
+    } catch (error) {
+      log.error("[PlaylistController] getManualPlaylistMembershipForPosts failed:", error);
+      throw error;
+    }
+  }
+
+  /**
+   * Set manual playlist membership for one or more posts: each post appears in exactly the
+   * chosen manual playlists and in no other manual playlist.
+   */
+  private async syncManualPlaylistMembership(
+    _event: IpcMainInvokeEvent,
+    data: SyncManualPlaylistMembershipRequest
+  ): Promise<void> {
+    const db = this.getDb();
+    const desired = new Set(data.manualPlaylistIds);
+    if (desired.size !== data.manualPlaylistIds.length) {
+      throw new Error("Duplicate playlist ids in manualPlaylistIds");
+    }
+
+    const allManualRows = db
+      .select({ id: playlists.id })
+      .from(playlists)
+      .where(eq(playlists.isSmart, false))
+      .all();
+    const allManualIds = allManualRows.map((r) => r.id);
+    const allManualSet = new Set(allManualIds);
+
+    for (const pid of data.manualPlaylistIds) {
+      if (!allManualSet.has(pid)) {
+        throw new Error(`Not a manual playlist: ${pid}`);
+      }
+    }
+
+    const postIdList = [...new Set(data.postIds)];
+    if (postIdList.length !== data.postIds.length) {
+      throw new Error("Duplicate post ids");
+    }
+
+    if (allManualIds.length === 0) {
+      return;
+    }
+
+    const toAdd: { playlistId: number; postId: number }[] = [];
+    const toRemovePlaylistIds: number[] = [];
+
+    for (const playlistId of allManualIds) {
+      if (desired.has(playlistId)) {
+        for (const postId of postIdList) {
+          toAdd.push({ playlistId, postId });
+        }
+      } else {
+        toRemovePlaylistIds.push(playlistId);
+      }
+    }
+
+    db.transaction((tx) => {
+      if (toAdd.length > 0) {
+        tx.insert(playlistEntries)
+          .values(
+            toAdd.map((row) => ({
+              playlistId: row.playlistId,
+              postId: row.postId,
+            }))
+          )
+          .onConflictDoNothing({
+            target: [playlistEntries.playlistId, playlistEntries.postId],
+          })
+          .run();
+      }
+
+      if (toRemovePlaylistIds.length > 0) {
+        tx.delete(playlistEntries)
+          .where(
+            and(
+              inArray(playlistEntries.playlistId, toRemovePlaylistIds),
+              inArray(playlistEntries.postId, postIdList)
+            )
+          )
+          .run();
+      }
+
+      const now = new Date();
+      tx.update(playlists)
+        .set({ updatedAt: now })
+        .where(inArray(playlists.id, allManualIds))
+        .run();
+    });
+
+    log.info(
+      `[PlaylistController] syncManualPlaylistMembership: ${postIdList.length} post(s), ${desired.size} desired playlist(s)`
+    );
+  }
+
+  /**
+   * Remove all post entries from a manual playlist (does not delete the playlist row).
+   */
+  private async clearManualPlaylist(
+    _event: IpcMainInvokeEvent,
+    data: ClearManualPlaylistRequest
+  ): Promise<void> {
+    const db = this.getDb();
+    const [row] = db
+      .select({ id: playlists.id, isSmart: playlists.isSmart })
+      .from(playlists)
+      .where(eq(playlists.id, data.playlistId))
+      .limit(1)
+      .all();
+
+    if (!row) {
+      throw new Error("Playlist not found");
+    }
+    if (row.isSmart) {
+      throw new Error("Clear is only supported for manual playlists");
+    }
+
+    db.transaction((tx) => {
+      tx.delete(playlistEntries)
+        .where(eq(playlistEntries.playlistId, data.playlistId))
+        .run();
+      tx.update(playlists)
+        .set({ updatedAt: new Date() })
+        .where(eq(playlists.id, data.playlistId))
+        .run();
+    });
+
+    log.info(`[PlaylistController] Cleared all posts from manual playlist ${data.playlistId}`);
+  }
+
+  /**
+   * Move posts from one manual playlist to another in one transaction.
+   */
+  private async movePostsBetweenManualPlaylists(
+    _event: IpcMainInvokeEvent,
+    data: MovePostsBetweenManualPlaylistsRequest
+  ): Promise<void> {
+    if (data.fromPlaylistId === data.toPlaylistId) {
+      throw new Error("Source and target playlist must differ");
+    }
+
+    const db = this.getDb();
+    const pair = db
+      .select({ id: playlists.id, isSmart: playlists.isSmart })
+      .from(playlists)
+      .where(inArray(playlists.id, [data.fromPlaylistId, data.toPlaylistId]))
+      .all();
+
+    if (pair.length !== 2) {
+      throw new Error("One or both playlists were not found");
+    }
+    for (const p of pair) {
+      if (p.isSmart) {
+        throw new Error("Move is only supported between manual playlists");
+      }
+    }
+
+    const postIds = [...new Set(data.postIds)];
+    if (postIds.length !== data.postIds.length) {
+      throw new Error("Duplicate post ids");
+    }
+
+    const now = new Date();
+
+    db.transaction((tx) => {
+      const rows = postIds.map((postId) => ({
+        playlistId: data.toPlaylistId,
+        postId,
+      }));
+      tx.insert(playlistEntries)
+        .values(rows)
+        .onConflictDoNothing({
+          target: [playlistEntries.playlistId, playlistEntries.postId],
+        })
+        .run();
+
+      tx.delete(playlistEntries)
+        .where(
+          and(
+            eq(playlistEntries.playlistId, data.fromPlaylistId),
+            inArray(playlistEntries.postId, postIds)
+          )
+        )
+        .run();
+
+      tx.update(playlists)
+        .set({ updatedAt: now })
+        .where(inArray(playlists.id, [data.fromPlaylistId, data.toPlaylistId]))
+        .run();
+    });
+
+    log.info(
+      `[PlaylistController] Moved ${postIds.length} post(s) from ${data.fromPlaylistId} to ${data.toPlaylistId}`
+    );
   }
 
   /**

--- a/src/renderer/components/BulkActionBar/BulkActionBar.tsx
+++ b/src/renderer/components/BulkActionBar/BulkActionBar.tsx
@@ -1,11 +1,12 @@
-import { useEffect, useMemo, useState } from "react";
-import { Download, ListPlus, Trash2, X, CheckCheck } from "lucide-react";
+import { useCallback, useEffect, useMemo, useState } from "react";
+import { Download, ListPlus, MoveRight, Trash2, X, CheckCheck } from "lucide-react";
 import { useQueryClient } from "@tanstack/react-query";
 import log from "electron-log/renderer";
 import { toast } from "sonner";
 import { Button } from "../ui/button";
 import { useBulkSelect } from "../../hooks/useBulkSelect";
 import type { Post } from "../../../main/db/schema";
+import { AddToPlaylistModal } from "../playlists/AddToPlaylistModal";
 import {
   Dialog,
   DialogContent,
@@ -23,13 +24,6 @@ import {
 } from "../ui/select";
 
 const ESCAPE_KEY = "Escape";
-type PlaylistOption = { id: number; name: string };
-
-interface BulkActionBarProps {
-  selectedPosts: Post[];
-  onRemoveSelected?: (posts: Post[]) => Promise<void>;
-  onSelectAll?: () => void;
-}
 
 const toDownloadItem = (post: Post): { url: string; filename: string } | null => {
   if (!post.fileUrl?.trim()) {
@@ -44,25 +38,65 @@ const toDownloadItem = (post: Post): { url: string; filename: string } | null =>
   };
 };
 
+interface BulkActionBarProps {
+  selectedPosts: Post[];
+  onRemoveSelected?: (posts: Post[]) => Promise<void>;
+  onSelectAll?: () => void;
+  /** When set with a manual playlist, shows "Move to…" in bulk mode */
+  currentPlaylistId?: number;
+  currentPlaylistIsSmart?: boolean;
+}
+
 export const BulkActionBar = ({
   selectedPosts,
   onRemoveSelected,
   onSelectAll,
+  currentPlaylistId,
+  currentPlaylistIsSmart = false,
 }: BulkActionBarProps) => {
   const selectedCount = useBulkSelect((state) => state.selectedIds.size);
   const isBulkMode = useBulkSelect((state) => state.isBulkMode);
   const deactivate = useBulkSelect((state) => state.deactivate);
   const clearSelection = useBulkSelect((state) => state.clearSelection);
   const queryClient = useQueryClient();
-  const [isPlaylistDialogOpen, setIsPlaylistDialogOpen] = useState(false);
-  const [playlists, setPlaylists] = useState<PlaylistOption[]>([]);
-  const [playlistId, setPlaylistId] = useState<string>("");
-  const [isSubmittingPlaylist, setIsSubmittingPlaylist] = useState(false);
+  const [isAddPlaylistOpen, setIsAddPlaylistOpen] = useState(false);
+  const [isMoveOpen, setIsMoveOpen] = useState(false);
+  const [moveTargets, setMoveTargets] = useState<{ id: number; name: string }[]>([]);
+  const [targetPlaylistId, setTargetPlaylistId] = useState<string>("");
+  const [isMoveSubmitting, setIsMoveSubmitting] = useState(false);
 
-  const selectedPlaylistName = useMemo(
-    () => playlists.find((item) => item.id === Number(playlistId))?.name ?? "",
-    [playlistId, playlists]
+  const inManualPlaylistView =
+    currentPlaylistId != null &&
+    currentPlaylistId > 0 &&
+    !currentPlaylistIsSmart;
+
+  const otherManualForMove = useMemo(
+    () => moveTargets.find((p) => p.id === Number(targetPlaylistId))?.name ?? "",
+    [moveTargets, targetPlaylistId]
   );
+
+  const openMoveDialog = useCallback(async () => {
+    if (!inManualPlaylistView) {
+      return;
+    }
+    try {
+      const available = await window.api.getPlaylists();
+      const options = available
+        .filter((item) => !item.isSmart && item.id !== currentPlaylistId)
+        .map((item) => ({ id: item.id, name: item.name }));
+      if (options.length === 0) {
+        toast.info("No other manual playlists to move to");
+        return;
+      }
+      setMoveTargets(options);
+      setTargetPlaylistId(String(options[0]!.id));
+      setIsMoveOpen(true);
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      log.error("[BulkActionBar] Failed to load playlists for move:", message);
+      toast.error("Failed to load playlists");
+    }
+  }, [currentPlaylistId, inManualPlaylistView]);
 
   useEffect(() => {
     if (!isBulkMode) {
@@ -81,9 +115,78 @@ export const BulkActionBar = ({
     };
   }, [deactivate, isBulkMode]);
 
+  // Must run on every render (including when selectedCount === 0); hooks cannot follow a conditional return.
+  const postRefs = useMemo(
+    () => selectedPosts.map((p) => ({ id: p.id, postId: p.postId })),
+    [selectedPosts]
+  );
+
   if (selectedCount === 0) {
     return null;
   }
+
+  const openAddToPlaylist = async () => {
+    try {
+      const available = await window.api.getPlaylists();
+      const hasManual = available.some((item) => !item.isSmart);
+      if (!hasManual) {
+        toast.info("No manual playlists available");
+        return;
+      }
+      setIsAddPlaylistOpen(true);
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      log.error("[BulkActionBar] Failed to load playlists:", message);
+      toast.error("Failed to load playlists");
+    }
+  };
+
+  const handleMoveConfirm = async () => {
+    if (!inManualPlaylistView) {
+      return;
+    }
+    const to = Number(targetPlaylistId);
+    if (!Number.isFinite(to) || to === currentPlaylistId) {
+      return;
+    }
+    setIsMoveSubmitting(true);
+    try {
+      const resolvedIds: number[] = [];
+      for (const post of selectedPosts) {
+        if (post.id > 0) {
+          resolvedIds.push(post.id);
+          continue;
+        }
+        const inserted = await window.api.shadowInsertPost({
+          postId: post.postId,
+          provider: "rule34",
+        });
+        resolvedIds.push(inserted.id);
+      }
+      if (resolvedIds.length === 0) {
+        toast.info("No posts to move");
+        return;
+      }
+      await window.api.movePostsBetweenManualPlaylists({
+        fromPlaylistId: currentPlaylistId,
+        toPlaylistId: to,
+        postIds: resolvedIds,
+      });
+      await queryClient.invalidateQueries({ queryKey: ["playlists"] });
+      await queryClient.invalidateQueries({ queryKey: ["playlist-posts", currentPlaylistId] });
+      await queryClient.invalidateQueries({ queryKey: ["playlist-posts", to] });
+      await queryClient.invalidateQueries({ queryKey: ["playlist-entries"] });
+      clearSelection();
+      setIsMoveOpen(false);
+      toast.success(`Moved ${resolvedIds.length} posts to "${otherManualForMove}"`);
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      log.error("[BulkActionBar] Move failed:", message);
+      toast.error("Failed to move posts");
+    } finally {
+      setIsMoveSubmitting(false);
+    }
+  };
 
   const handleDownloadSelected = async () => {
     const items = selectedPosts
@@ -101,69 +204,6 @@ export const BulkActionBar = ({
       const message = error instanceof Error ? error.message : String(error);
       log.error("[BulkActionBar] Failed to download selected posts:", message);
       toast.error("Failed to start bulk download");
-    }
-  };
-
-  const openAddToPlaylist = async () => {
-    try {
-      const available = await window.api.getPlaylists();
-      const options = available
-        .filter((item) => !item.isSmart)
-        .map((item) => ({ id: item.id, name: item.name }));
-      if (options.length === 0) {
-        toast.info("No manual playlists available");
-        return;
-      }
-      setPlaylists(options);
-      const firstId = options[0]?.id;
-      setPlaylistId(firstId ? String(firstId) : "");
-      setIsPlaylistDialogOpen(true);
-    } catch (error) {
-      const message = error instanceof Error ? error.message : String(error);
-      log.error("[BulkActionBar] Failed to load playlists:", message);
-      toast.error("Failed to load playlists");
-    }
-  };
-
-  const handleAddToPlaylist = async () => {
-    const selectedPlaylistId = Number(playlistId);
-    if (!Number.isFinite(selectedPlaylistId)) {
-      return;
-    }
-    setIsSubmittingPlaylist(true);
-    try {
-      const resolvedIds: number[] = [];
-      for (const post of selectedPosts) {
-        if (post.id > 0) {
-          resolvedIds.push(post.id);
-          continue;
-        }
-        const inserted = await window.api.shadowInsertPost({
-          postId: post.postId,
-          provider: "rule34",
-        });
-        resolvedIds.push(inserted.id);
-      }
-      if (resolvedIds.length === 0) {
-        toast.info("No posts to add");
-        return;
-      }
-      await window.api.addPostsToPlaylist({
-        playlistIds: [selectedPlaylistId],
-        postIds: resolvedIds,
-      });
-      await queryClient.invalidateQueries({ queryKey: ["playlists"] });
-      await queryClient.invalidateQueries({ queryKey: ["playlist-posts"] });
-      await queryClient.invalidateQueries({ queryKey: ["playlist-entries"] });
-      clearSelection();
-      setIsPlaylistDialogOpen(false);
-      toast.success(`Added ${resolvedIds.length} posts to "${selectedPlaylistName}"`);
-    } catch (error) {
-      const message = error instanceof Error ? error.message : String(error);
-      log.error("[BulkActionBar] Failed to add selected posts to playlist:", message);
-      toast.error("Failed to add selected posts to playlist");
-    } finally {
-      setIsSubmittingPlaylist(false);
     }
   };
 
@@ -203,6 +243,18 @@ export const BulkActionBar = ({
               <ListPlus className="h-4 w-4" />
               Add to Playlist
             </Button>
+            {inManualPlaylistView && (
+              <Button
+                type="button"
+                variant="outline"
+                size="sm"
+                className="gap-2"
+                onClick={() => void openMoveDialog()}
+              >
+                <MoveRight className="h-4 w-4" />
+                Move to…
+              </Button>
+            )}
             {onRemoveSelected && (
               <Button
                 type="button"
@@ -227,21 +279,30 @@ export const BulkActionBar = ({
           </div>
         </div>
       </div>
-      <Dialog open={isPlaylistDialogOpen} onOpenChange={setIsPlaylistDialogOpen}>
+      <AddToPlaylistModal
+        posts={postRefs}
+        open={isAddPlaylistOpen}
+        onOpenChange={setIsAddPlaylistOpen}
+        onSuccess={() => {
+          clearSelection();
+        }}
+        title="Add to playlist"
+      />
+      <Dialog open={isMoveOpen} onOpenChange={setIsMoveOpen}>
         <DialogContent>
           <DialogHeader>
-            <DialogTitle>Add selected posts to playlist</DialogTitle>
+            <DialogTitle>Move to playlist</DialogTitle>
             <DialogDescription>
-              Selected posts: {selectedCount}
+              Move {selectedCount} selected posts to another manual playlist.
             </DialogDescription>
           </DialogHeader>
           <div className="space-y-2">
-            <Select value={playlistId} onValueChange={setPlaylistId}>
+            <Select value={targetPlaylistId} onValueChange={setTargetPlaylistId}>
               <SelectTrigger>
                 <SelectValue placeholder="Select playlist" />
               </SelectTrigger>
               <SelectContent>
-                {playlists.map((item) => (
+                {moveTargets.map((item) => (
                   <SelectItem key={item.id} value={String(item.id)}>
                     {item.name}
                   </SelectItem>
@@ -250,15 +311,15 @@ export const BulkActionBar = ({
             </Select>
           </div>
           <DialogFooter>
-            <Button type="button" variant="outline" onClick={() => setIsPlaylistDialogOpen(false)}>
+            <Button type="button" variant="outline" onClick={() => setIsMoveOpen(false)} disabled={isMoveSubmitting}>
               Cancel
             </Button>
             <Button
               type="button"
-              onClick={() => void handleAddToPlaylist()}
-              disabled={isSubmittingPlaylist || playlistId.length === 0}
+              onClick={() => void handleMoveConfirm()}
+              disabled={isMoveSubmitting || targetPlaylistId.length === 0}
             >
-              Add
+              Move
             </Button>
           </DialogFooter>
         </DialogContent>

--- a/src/renderer/components/pages/PlaylistsPage.tsx
+++ b/src/renderer/components/pages/PlaylistsPage.tsx
@@ -3,7 +3,7 @@ import {
   useQueryClient,
   useInfiniteQuery,
 } from "@tanstack/react-query";
-import { ArrowLeft, Loader2, List, Sparkles, Plus, Trash2, X, Check, Minus, Pencil, Download, Upload, CheckSquare } from "lucide-react";
+import { ArrowLeft, Loader2, List, Sparkles, Plus, Trash2, X, Check, Minus, Pencil, Download, Upload, CheckSquare, Eraser } from "lucide-react";
 import { VirtuosoGrid } from "react-virtuoso";
 import log from "electron-log/renderer";
 import {
@@ -36,6 +36,15 @@ import { Input } from "../../components/ui/input";
 import { Label } from "../../components/ui/label";
 import { Badge } from "../../components/ui/badge";
 import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogFooter, DialogDescription } from "../../components/ui/dialog";
+import {
+  AlertDialog,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from "../../components/ui/alert-dialog";
 import { ToggleGroup, ToggleGroupItem } from "../../components/ui/toggle-group";
 import { AsyncAutocomplete } from "../../components/inputs/AsyncAutocomplete";
 import type { SmartPlaylistQuery, SmartPlaylistTag } from "../../../shared/schemas/playlist";
@@ -592,6 +601,8 @@ const PlaylistGallery: React.FC<PlaylistGalleryProps> = ({ playlist, onBack }) =
       </div>
       <BulkActionBar
         selectedPosts={selectedPosts}
+        currentPlaylistId={playlist.id}
+        currentPlaylistIsSmart={playlist.isSmart}
         onRemoveSelected={!playlist.isSmart ? handleBulkRemove : undefined}
         onSelectAll={() => {
           const selectableIds = displayedPosts.map((post) => getBulkSelectId(post));
@@ -625,12 +636,14 @@ export const PlaylistsPage: React.FC<PlaylistsPageProps> = ({ onBack }) => {
   const [playlistFilter, setPlaylistFilter] = useState<"all" | "smart" | "manual">("all");
   
   const [playlistToDelete, setPlaylistToDelete] = useState<PlaylistWithStats | null>(null);
+  const [playlistToClear, setPlaylistToClear] = useState<PlaylistWithStats | null>(null);
   const [isDeleting, setIsDeleting] = useState(false);
   const [playlistToEdit, setPlaylistToEdit] = useState<PlaylistWithStats | null>(null);
   const [isEditing, setIsEditing] = useState(false);
   const [isEditDialogOpen, setIsEditDialogOpen] = useState(false);
   const [isImporting, setIsImporting] = useState(false);
   const [exportingPlaylistId, setExportingPlaylistId] = useState<number | null>(null);
+  const [clearingPlaylistId, setClearingPlaylistId] = useState<number | null>(null);
   const queryClient = useQueryClient();
 
   // Use optimized usePlaylists hook with caching
@@ -786,6 +799,26 @@ export const PlaylistsPage: React.FC<PlaylistsPageProps> = ({ onBack }) => {
       log.error("[PlaylistsPage] Failed to delete playlist:", error);
     } finally {
       setIsDeleting(false);
+    }
+  };
+
+  const handleClearAllPostsInPlaylist = async (pl: PlaylistWithStats): Promise<boolean> => {
+    if (pl.isSmart) {
+      return false;
+    }
+    setClearingPlaylistId(pl.id);
+    try {
+      await window.api.clearManualPlaylist({ playlistId: pl.id });
+      await queryClient.invalidateQueries({ queryKey: ["playlists"] });
+      await queryClient.invalidateQueries({ queryKey: ["playlist-posts", pl.id] });
+      toast.success(`Removed all posts from "${pl.name}"`);
+      return true;
+    } catch (error) {
+      log.error("[PlaylistsPage] Failed to clear playlist posts:", error);
+      toast.error("Failed to clear playlist");
+      return false;
+    } finally {
+      setClearingPlaylistId(null);
     }
   };
 
@@ -978,8 +1011,9 @@ export const PlaylistsPage: React.FC<PlaylistsPageProps> = ({ onBack }) => {
                 <PlaylistCard
                   playlist={playlist}
                   onOpen={setSelectedPlaylist}
+                  actionPaddingClassName={playlist.isSmart ? "pr-32" : "pr-40"}
                 />
-                <div className="flex gap-2 absolute top-2 right-2 opacity-0 group-hover:opacity-100 transition-opacity">
+                <div className="flex gap-1 absolute top-2 right-2 opacity-0 group-hover:opacity-100 transition-opacity">
                   <Button
                     variant="ghost"
                     size="icon"
@@ -1024,6 +1058,25 @@ export const PlaylistsPage: React.FC<PlaylistsPageProps> = ({ onBack }) => {
                   >
                     <Pencil className="w-4 h-4" />
                   </Button>
+                  {!playlist.isSmart && (
+                    <Button
+                      variant="ghost"
+                      size="icon"
+                      className="h-8 w-8 text-muted-foreground hover:text-foreground hover:bg-muted/80"
+                      onClick={(e) => {
+                        e.stopPropagation();
+                        setPlaylistToClear(playlist);
+                      }}
+                      title="Clear all posts from playlist"
+                      disabled={clearingPlaylistId !== null}
+                    >
+                      {clearingPlaylistId === playlist.id ? (
+                        <Loader2 className="w-4 h-4 animate-spin" />
+                      ) : (
+                        <Eraser className="w-4 h-4" />
+                      )}
+                    </Button>
+                  )}
                   <Button
                     variant="ghost"
                     size="icon"
@@ -1042,6 +1095,44 @@ export const PlaylistsPage: React.FC<PlaylistsPageProps> = ({ onBack }) => {
           </div>
         )}
       </div>
+
+      <AlertDialog
+        open={!!playlistToClear}
+        onOpenChange={(o) => {
+          if (!o) {
+            setPlaylistToClear(null);
+          }
+        }}
+      >
+        <AlertDialogContent onClick={(e) => e.stopPropagation()}>
+          <AlertDialogHeader>
+            <AlertDialogTitle>Clear all posts?</AlertDialogTitle>
+            <AlertDialogDescription>
+              Remove all posts from {playlistToClear?.name ?? ""}? This cannot be undone.
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel disabled={clearingPlaylistId !== null}>Cancel</AlertDialogCancel>
+            <Button
+              variant="destructive"
+              disabled={clearingPlaylistId !== null}
+              onClick={async (e) => {
+                e.preventDefault();
+                if (!playlistToClear) {
+                  return;
+                }
+                const pl = playlistToClear;
+                const ok = await handleClearAllPostsInPlaylist(pl);
+                if (ok) {
+                  setPlaylistToClear(null);
+                }
+              }}
+            >
+              {clearingPlaylistId !== null ? "Clearing…" : "Clear all"}
+            </Button>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
 
       {/* Create Playlist Dialog */}
       <Dialog open={isDialogOpen} onOpenChange={(open) => {

--- a/src/renderer/components/playlists/AddToPlaylistModal.tsx
+++ b/src/renderer/components/playlists/AddToPlaylistModal.tsx
@@ -1,0 +1,464 @@
+import React, { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { Plus, Loader2 } from "lucide-react";
+import log from "electron-log/renderer";
+import { useQuery, useQueryClient } from "@tanstack/react-query";
+import { usePlaylists } from "../../lib/hooks/usePlaylists";
+import type { Playlist } from "../../../main/db/schema";
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogDescription,
+  DialogFooter,
+} from "../ui/dialog";
+import { Button } from "../ui/button";
+import { Input } from "../ui/input";
+import { Checkbox } from "../ui/checkbox";
+import { Label } from "../ui/label";
+import { cn } from "../../lib/utils";
+
+type PostRef = { id: number; postId: number };
+
+const invalidateAfterMembershipChange = (
+  queryClient: ReturnType<typeof useQueryClient>,
+  postIds: number[],
+  touchedPlaylistIds: number[]
+) => {
+  for (const pid of postIds) {
+    queryClient.invalidateQueries({ queryKey: ["playlist-entries", pid] });
+  }
+  queryClient.invalidateQueries({ queryKey: ["playlists"] });
+  queryClient.invalidateQueries({ queryKey: ["playlist-entries"] });
+  for (const pl of touchedPlaylistIds) {
+    queryClient.invalidateQueries({ queryKey: ["playlist-posts", pl] });
+  }
+  queryClient.invalidateQueries({ queryKey: ["playlist-posts"] });
+};
+
+export interface AddToPlaylistModalProps {
+  /** Posts to set manual playlist membership for (resolved to DB ids before save). */
+  posts: PostRef[];
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  onSuccess?: () => void;
+  /** If set, this element receives focus when the dialog closes (e.g. viewer toolbar). */
+  focusReturnRef?: React.RefObject<HTMLElement | null>;
+  title?: string;
+  description?: string;
+  className?: string;
+}
+
+/**
+ * Modal with checkboxes for all manual playlists. On confirm, syncs membership in one transaction.
+ */
+export const AddToPlaylistModal: React.FC<AddToPlaylistModalProps> = ({
+  posts,
+  open,
+  onOpenChange,
+  onSuccess,
+  focusReturnRef,
+  title = "Add to playlist",
+  description,
+  className,
+}) => {
+  const [resolvedPostIds, setResolvedPostIds] = useState<number[]>([]);
+  const [isResolvingPosts, setIsResolvingPosts] = useState(false);
+  const [selectedPlaylistIds, setSelectedPlaylistIds] = useState<Set<number>>(new Set());
+  const [isCreateOpen, setIsCreateOpen] = useState(false);
+  const [newPlaylistName, setNewPlaylistName] = useState("");
+  const [isCreating, setIsCreating] = useState(false);
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  const queryClient = useQueryClient();
+  const initSelectionRef = useRef(false);
+  const sessionKeyRef = useRef("");
+
+  const { data: allPlaylists = [], isLoading: isLoadingPlaylists } = usePlaylists({
+    enabled: open,
+  });
+  const manualPlaylists = allPlaylists.filter((p: Playlist) => !p.isSmart);
+  const manualIdSet = useMemo(() => new Set(manualPlaylists.map((p) => p.id)), [manualPlaylists]);
+
+  const isBulk = posts.length > 1;
+  const defaultDescription = isBulk
+    ? `Choose which playlists should contain all ${posts.length} selected posts.`
+    : "Choose which playlists should include this post.";
+
+  const resetLocalState = useCallback(() => {
+    setResolvedPostIds([]);
+    setSelectedPlaylistIds(new Set());
+    setIsCreateOpen(false);
+    setNewPlaylistName("");
+  }, []);
+
+  useEffect(() => {
+    if (!open) {
+      resetLocalState();
+      initSelectionRef.current = false;
+      sessionKeyRef.current = "";
+    }
+  }, [open, resetLocalState]);
+
+  useEffect(() => {
+    if (!open) {
+      return;
+    }
+
+    let cancelled = false;
+    setIsResolvingPosts(true);
+    void (async () => {
+      try {
+        const ids: number[] = [];
+        for (const p of posts) {
+          if (p.id > 0) {
+            ids.push(p.id);
+            continue;
+          }
+          if (p.postId > 0) {
+            const inserted = await window.api.shadowInsertPost({
+              postId: p.postId,
+              provider: "rule34",
+            });
+            ids.push(inserted.id);
+            continue;
+          }
+          log.error("[AddToPlaylistModal] Post has no valid id for playlist sync");
+        }
+        if (!cancelled) {
+          setResolvedPostIds(ids);
+        }
+      } catch (e) {
+        log.error("[AddToPlaylistModal] Failed to resolve post ids:", e);
+        if (!cancelled) {
+          setResolvedPostIds([]);
+        }
+      } finally {
+        if (!cancelled) {
+          setIsResolvingPosts(false);
+        }
+      }
+    })();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [open, posts]);
+
+  const n = resolvedPostIds.length;
+  const sortedKey = useMemo(
+    () => resolvedPostIds.slice().sort((a, b) => a - b).join(","),
+    [resolvedPostIds]
+  );
+
+  const { data: singleContaining = [], isFetching: isFetchingSingle } = useQuery({
+    queryKey: ["manual-plist-single", sortedKey] as const,
+    queryFn: async () => {
+      if (isBulk || n !== 1) {
+        return [] as number[];
+      }
+      const only = resolvedPostIds[0];
+      if (only == null) {
+        return [];
+      }
+      return await window.api.getPlaylistsContainingPost(only);
+    },
+    enabled: open && !isResolvingPosts && n === 1 && !isBulk,
+  });
+
+  const { data: bulkRows = [], isFetching: isFetchingBulk } = useQuery({
+    queryKey: ["manual-plist-bulk", sortedKey] as const,
+    queryFn: async () => {
+      if (!isBulk || n < 1) {
+        return [] as { playlistId: number; matchCount: number }[];
+      }
+      return await window.api.getManualPlaylistMembershipForPosts({
+        postIds: resolvedPostIds,
+      });
+    },
+    enabled: open && !isResolvingPosts && isBulk && n > 0,
+  });
+
+  const isFetchingMembership = isBulk ? isFetchingBulk : isFetchingSingle;
+
+  useEffect(() => {
+    if (!open || isResolvingPosts || n === 0 || isFetchingMembership) {
+      return;
+    }
+    const key = `${isBulk ? "B" : "S"}|${sortedKey}|${manualIdSet.size}`;
+    if (key !== sessionKeyRef.current) {
+      initSelectionRef.current = false;
+      sessionKeyRef.current = key;
+    }
+    if (initSelectionRef.current) {
+      return;
+    }
+    if (isBulk) {
+      const m = new Map(bulkRows.map((r) => [r.playlistId, r.matchCount] as const));
+      const next = new Set<number>();
+      for (const pl of manualPlaylists) {
+        const c = m.get(pl.id) ?? 0;
+        if (c === n) {
+          next.add(pl.id);
+        }
+      }
+      setSelectedPlaylistIds(next);
+    } else {
+      const inManual = new Set(
+        singleContaining.filter((pid) => manualIdSet.has(pid))
+      );
+      setSelectedPlaylistIds(inManual);
+    }
+    initSelectionRef.current = true;
+  }, [
+    open,
+    isResolvingPosts,
+    n,
+    isFetchingMembership,
+    isBulk,
+    sortedKey,
+    bulkRows,
+    manualPlaylists,
+    singleContaining,
+    manualIdSet,
+  ]);
+
+  const matchCount = useCallback(
+    (playlistId: number) => bulkRows.find((r) => r.playlistId === playlistId)?.matchCount ?? 0,
+    [bulkRows]
+  );
+
+  const getCheckboxState = (playlistId: number): boolean | "indeterminate" => {
+    if (!isBulk) {
+      return selectedPlaylistIds.has(playlistId);
+    }
+    const c = matchCount(playlistId);
+    if (selectedPlaylistIds.has(playlistId)) {
+      return true;
+    }
+    if (c > 0 && c < n) {
+      return "indeterminate";
+    }
+    return false;
+  };
+
+  const toggle = (playlistId: number) => {
+    setSelectedPlaylistIds((prev) => {
+      const next = new Set(prev);
+      if (!isBulk) {
+        if (next.has(playlistId)) {
+          next.delete(playlistId);
+        } else {
+          next.add(playlistId);
+        }
+        return next;
+      }
+      const c = matchCount(playlistId);
+      if (c > 0 && c < n) {
+        next.add(playlistId);
+        return next;
+      }
+      if (next.has(playlistId)) {
+        next.delete(playlistId);
+      } else {
+        next.add(playlistId);
+      }
+      return next;
+    });
+  };
+
+  const handleConfirm = async () => {
+    if (n === 0) {
+      return;
+    }
+    setIsSubmitting(true);
+    try {
+      const manualIds = [...selectedPlaylistIds].filter((id) => manualIdSet.has(id));
+      await window.api.syncManualPlaylistMembership({
+        postIds: resolvedPostIds,
+        manualPlaylistIds: manualIds,
+      });
+      const touched = new Set(manualPlaylists.map((p) => p.id));
+      invalidateAfterMembershipChange(queryClient, resolvedPostIds, [...touched]);
+      onSuccess?.();
+      onOpenChange(false);
+    } catch (e) {
+      log.error("[AddToPlaylistModal] syncManualPlaylistMembership failed:", e);
+    } finally {
+      setIsSubmitting(false);
+    }
+  };
+
+  const handleCreatePlaylist = async () => {
+    const name = newPlaylistName.trim();
+    if (!name) {
+      return;
+    }
+    setIsCreating(true);
+    try {
+      const created = await window.api.createPlaylist({
+        name,
+        isSmart: false,
+        queryJson: "",
+        iconName: "",
+      });
+      setNewPlaylistName("");
+      setIsCreateOpen(false);
+      const desired = [
+        ...new Set(
+          [...[...selectedPlaylistIds].filter((id) => manualIdSet.has(id)), created.id]
+        ),
+      ];
+      if (n > 0) {
+        await window.api.syncManualPlaylistMembership({
+          postIds: resolvedPostIds,
+          manualPlaylistIds: desired,
+        });
+      }
+      setSelectedPlaylistIds(new Set(desired));
+      await queryClient.invalidateQueries({ queryKey: ["playlists"] });
+      if (n > 0) {
+        const touched = [...new Set([...manualPlaylists.map((p) => p.id), created.id])];
+        invalidateAfterMembershipChange(queryClient, resolvedPostIds, touched);
+      }
+      onSuccess?.();
+    } catch (e) {
+      log.error("[AddToPlaylistModal] createPlaylist failed:", e);
+    } finally {
+      setIsCreating(false);
+    }
+  };
+
+  const showLoading =
+    isLoadingPlaylists || isResolvingPosts || (n > 0 && isFetchingMembership);
+  const canConfirm = n > 0 && !isSubmitting;
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent
+        className={cn("sm:max-w-md gap-3", className)}
+        onCloseAutoFocus={(e) => {
+          if (focusReturnRef?.current) {
+            e.preventDefault();
+            focusReturnRef.current.focus();
+          }
+        }}
+      >
+        <DialogHeader>
+          <DialogTitle>{title}</DialogTitle>
+          <DialogDescription>
+            {description ?? defaultDescription}
+          </DialogDescription>
+        </DialogHeader>
+
+        {showLoading ? (
+          <div className="flex justify-center py-8">
+            <Loader2 className="h-8 w-8 animate-spin text-muted-foreground" />
+          </div>
+        ) : n === 0 ? (
+          <p className="text-sm text-muted-foreground text-center py-4">
+            No valid posts to add to playlists.
+          </p>
+        ) : (
+          <div className="space-y-3 max-h-72 overflow-y-auto pr-1">
+            {manualPlaylists.length === 0 ? (
+              <p className="text-sm text-muted-foreground text-center py-2">
+                No manual playlists yet
+              </p>
+            ) : (
+              manualPlaylists.map((pl) => {
+                const state = getCheckboxState(pl.id);
+                return (
+                  <div key={pl.id} className="flex items-center gap-3">
+                    <Checkbox
+                      id={`pl-${pl.id}`}
+                      checked={state}
+                      onCheckedChange={() => toggle(pl.id)}
+                    />
+                    <Label
+                      htmlFor={`pl-${pl.id}`}
+                      className="text-sm font-normal leading-none flex-1 cursor-pointer"
+                    >
+                      {pl.name}
+                      {isBulk && (
+                        <span className="text-xs text-muted-foreground ml-2">
+                          ({matchCount(pl.id)}/{n})
+                        </span>
+                      )}
+                    </Label>
+                  </div>
+                );
+              })
+            )}
+
+            <Button
+              type="button"
+              variant="outline"
+              size="sm"
+              className="w-full"
+              onClick={() => setIsCreateOpen((v) => !v)}
+            >
+              <Plus className="mr-2 h-4 w-4" />
+              Create new playlist
+            </Button>
+
+            {isCreateOpen && (
+              <div className="flex flex-col gap-2 pt-1">
+                <Input
+                  placeholder="Playlist name"
+                  value={newPlaylistName}
+                  onChange={(e) => setNewPlaylistName(e.target.value)}
+                  onKeyDown={(e) => {
+                    if (e.key === "Enter" && !isCreating) {
+                      void handleCreatePlaylist();
+                    }
+                  }}
+                  disabled={isCreating}
+                />
+                <div className="flex gap-2 justify-end">
+                  <Button
+                    type="button"
+                    variant="ghost"
+                    size="sm"
+                    onClick={() => {
+                      setIsCreateOpen(false);
+                      setNewPlaylistName("");
+                    }}
+                    disabled={isCreating}
+                  >
+                    Cancel
+                  </Button>
+                  <Button
+                    type="button"
+                    size="sm"
+                    onClick={() => void handleCreatePlaylist()}
+                    disabled={isCreating || !newPlaylistName.trim()}
+                  >
+                    {isCreating ? <Loader2 className="h-4 w-4 animate-spin" /> : "Create and add"}
+                  </Button>
+                </div>
+              </div>
+            )}
+          </div>
+        )}
+
+        <DialogFooter>
+          <Button
+            type="button"
+            variant="outline"
+            onClick={() => onOpenChange(false)}
+            disabled={isSubmitting}
+          >
+            Cancel
+          </Button>
+          <Button
+            type="button"
+            onClick={() => void handleConfirm()}
+            disabled={!canConfirm}
+          >
+            {isSubmitting ? <Loader2 className="h-4 w-4 animate-spin" /> : "Confirm"}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+};

--- a/src/renderer/components/playlists/PlaylistCard.tsx
+++ b/src/renderer/components/playlists/PlaylistCard.tsx
@@ -1,13 +1,24 @@
 import { List, Sparkles } from "lucide-react";
 import type { PlaylistWithStats } from "../../../main/bridge";
 import { formatRelativeTime } from "../../lib/formatRelativeTime";
+import { cn } from "../../lib/utils";
 
 interface PlaylistCardProps {
   playlist: PlaylistWithStats;
   onOpen: (playlist: PlaylistWithStats) => void;
+  /** Wider when manual + 4 hover actions; narrower for smart (3 actions). */
+  actionPaddingClassName?: string;
 }
 
-export const PlaylistCard = ({ playlist, onOpen }: PlaylistCardProps) => {
+/**
+ * Title area only — PlaylistsPage places Export / Edit / (Clear) / Delete in a shared
+ * absolute action row; pr reserves space so the name does not run under the icons.
+ */
+export const PlaylistCard = ({
+  playlist,
+  onOpen,
+  actionPaddingClassName = "pr-32",
+}: PlaylistCardProps) => {
   const updatedAtMs =
     playlist.updatedAt instanceof Date
       ? playlist.updatedAt.getTime()
@@ -19,20 +30,24 @@ export const PlaylistCard = ({ playlist, onOpen }: PlaylistCardProps) => {
 
   return (
     <button
+      type="button"
       onClick={() => onOpen(playlist)}
-      className="flex flex-col items-start gap-2 w-full text-left"
+      className={cn(
+        "flex w-full min-w-0 flex-col items-start gap-2 text-left",
+        actionPaddingClassName
+      )}
     >
-      <div className="flex items-center gap-2 w-full">
+      <div className="flex w-full min-w-0 items-center gap-2">
         {playlist.isSmart ? (
-          <Sparkles className="w-5 h-5 text-primary" />
+          <Sparkles className="h-5 w-5 shrink-0 text-primary" />
         ) : (
-          <List className="w-5 h-5 text-primary" />
+          <List className="h-5 w-5 shrink-0 text-primary" />
         )}
-        <h3 className="font-semibold flex-1 truncate">{playlist.name}</h3>
+        <h3 className="min-w-0 flex-1 truncate font-semibold">{playlist.name}</h3>
       </div>
       <p className="text-xs text-muted-foreground">{subtitle}</p>
       {playlist.isSmart && (
-        <span className="text-xs text-primary font-medium">Smart Collection</span>
+        <span className="text-xs font-medium text-primary">Smart Collection</span>
       )}
     </button>
   );

--- a/src/renderer/components/playlists/QuickAddToPlaylistMenu.tsx
+++ b/src/renderer/components/playlists/QuickAddToPlaylistMenu.tsx
@@ -1,284 +1,61 @@
-import React, { useState, useEffect } from "react";
-import { List, Plus, Loader2 } from "lucide-react";
-import log from "electron-log/renderer";
-import {
-  DropdownMenu,
-  DropdownMenuTrigger,
-  DropdownMenuContent,
-  DropdownMenuItem,
-  DropdownMenuCheckboxItem,
-  DropdownMenuSeparator,
-  DropdownMenuLabel,
-} from "../../components/ui/dropdown-menu";
-import { Button } from "../../components/ui/button";
-import { Input } from "../../components/ui/input";
-import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogFooter } from "../../components/ui/dialog";
-import { useQuery, useQueryClient } from "@tanstack/react-query";
-import { usePlaylists } from "../../lib/hooks/usePlaylists";
-import type { Playlist } from "../../../main/db/schema";
+import React, { cloneElement, isValidElement } from "react";
+import { AddToPlaylistModal } from "./AddToPlaylistModal";
+
+type PostRef = { id: number; postId: number };
 
 interface QuickAddToPlaylistMenuProps {
-  post: { id: number; postId: number };
+  post: PostRef;
   trigger?: React.ReactNode;
   onSuccess?: () => void;
   open?: boolean;
-  onOpenChange?: (open: boolean) => void;
-  contentAlign?: "start" | "center" | "end";
-  contentSide?: "top" | "right" | "bottom" | "left";
-  contentSideOffset?: number;
+  onOpenChange: (open: boolean) => void;
 }
 
+/**
+ * Renders a trigger plus the Add to playlist modal. Composes the trigger's onClick to open the modal.
+ */
 export const QuickAddToPlaylistMenu: React.FC<QuickAddToPlaylistMenuProps> = ({
   post,
   trigger,
   onSuccess,
-  open,
+  open: controlledOpen,
   onOpenChange,
-  contentAlign = "end",
-  contentSide = "bottom",
-  contentSideOffset = 4,
 }) => {
-  const postId = post.id;
-  const [selectedPlaylistIds, setSelectedPlaylistIds] = useState<Set<number>>(new Set());
-  const [isCreating, setIsCreating] = useState(false);
-  const [newPlaylistName, setNewPlaylistName] = useState("");
-  const [isDialogOpen, setIsDialogOpen] = useState(false);
-  const [isMenuOpen, setIsMenuOpen] = useState(false);
-  const queryClient = useQueryClient();
-  const effectiveIsMenuOpen = open ?? isMenuOpen;
-  const setEffectiveIsMenuOpen = onOpenChange ?? setIsMenuOpen;
-
-  // Fetch all playlists - only when menu is opened (lazy loading)
-  const { data: allPlaylists = [], isLoading } = usePlaylists({ enabled: effectiveIsMenuOpen });
-  
-  // Filter out smart playlists - only show manual playlists
-  const playlists = allPlaylists.filter((p: Playlist) => !p.isSmart);
-
-  // Fetch which playlists this post is already in - single query instead of N queries
-  const { data: existingPlaylistIds = [], isFetching } = useQuery<number[]>({
-    queryKey: ["playlist-entries", postId, post.postId],
-    queryFn: async () => {
-      if (postId <= 0) {
-        return [];
-      }
-      return await window.api.getPlaylistsContainingPost(postId);
-    },
-    enabled: effectiveIsMenuOpen && playlists.length > 0,
-  });
-
-  // Sync selectedPlaylistIds with server data when it changes. Only sync when not fetching
-  // to avoid overwriting optimistic updates during refetch after toggle.
-  useEffect(() => {
-    if (effectiveIsMenuOpen && !isFetching) {
-      setSelectedPlaylistIds(new Set(existingPlaylistIds));
-    }
-  }, [effectiveIsMenuOpen, isFetching, existingPlaylistIds]);
-
-  const invalidatePostPlaylists = (effectivePostId: number, playlistIds: number[]) => {
-    queryClient.invalidateQueries({ queryKey: ["playlist-entries", effectivePostId] });
-    queryClient.invalidateQueries({ queryKey: ["playlist-entries", postId] });
-    queryClient.invalidateQueries({ queryKey: ["playlists"] });
-    for (const pid of playlistIds) {
-      queryClient.invalidateQueries({ queryKey: ["playlist-posts", pid] });
-    }
-  };
-
-  const handleTogglePlaylist = async (playlistId: number) => {
-    const isAdding = !selectedPlaylistIds.has(playlistId);
-    const prevSet = new Set(selectedPlaylistIds);
-
-    // Optimistic update
-    const newSet = new Set(selectedPlaylistIds);
-    if (isAdding) {
-      newSet.add(playlistId);
+  const [internalOpen, setInternalOpen] = React.useState(false);
+  const isControlled = controlledOpen !== undefined;
+  const effectiveOpen = isControlled ? controlledOpen : internalOpen;
+  const setEffectiveOpen = (next: boolean) => {
+    if (isControlled) {
+      onOpenChange(next);
     } else {
-      newSet.delete(playlistId);
-    }
-    setSelectedPlaylistIds(newSet);
-
-    try {
-      let effectivePostId = postId;
-      if (postId <= 0 && post.postId > 0) {
-        const inserted = await window.api.shadowInsertPost({
-          postId: post.postId,
-          provider: "rule34",
-        });
-        effectivePostId = inserted.id;
-      }
-      if (effectivePostId <= 0) {
-        log.error("[QuickAddToPlaylistMenu] Cannot add/remove: post has no valid DB id");
-        setSelectedPlaylistIds(prevSet);
-        return;
-      }
-
-      if (isAdding) {
-        await window.api.addPostsToPlaylist({
-          playlistIds: [playlistId],
-          postIds: [effectivePostId],
-        });
-      } else {
-        await window.api.removePostsFromPlaylist({
-          playlistId,
-          postIds: [effectivePostId],
-        });
-      }
-
-      invalidatePostPlaylists(effectivePostId, [playlistId]);
-      onSuccess?.();
-    } catch (error: unknown) {
-      log.error("[QuickAddToPlaylistMenu] Failed to toggle playlist:", error);
-      setSelectedPlaylistIds(prevSet);
-    }
-  };
-
-  const handleCreatePlaylist = async () => {
-    if (!newPlaylistName.trim()) {
-      return;
-    }
-
-    setIsCreating(true);
-    try {
-      const newPlaylist = await window.api.createPlaylist({
-        name: newPlaylistName.trim(),
-        isSmart: false, // Manual playlist
-        queryJson: "",
-        iconName: "",
-      });
-
-      // Add to selected playlists and immediately add post
-      const newSet = new Set(selectedPlaylistIds);
-      newSet.add(newPlaylist.id);
-      setSelectedPlaylistIds(newSet);
-
-      // Add post to the new playlist (shadow insert if external post)
-      let effectivePostId = postId;
-      if (postId <= 0 && post.postId > 0) {
-        const inserted = await window.api.shadowInsertPost({
-          postId: post.postId,
-          provider: "rule34",
-        });
-        effectivePostId = inserted.id;
-      }
-      if (effectivePostId > 0) {
-        await window.api.addPostsToPlaylist({
-          playlistIds: [newPlaylist.id],
-          postIds: [effectivePostId],
-        });
-      }
-
-      // Invalidate queries
-      queryClient.invalidateQueries({ queryKey: ["playlists"] });
-      queryClient.invalidateQueries({ queryKey: ["playlist-entries", postId] });
-      queryClient.invalidateQueries({ queryKey: ["playlist-posts", newPlaylist.id] });
-
-      setNewPlaylistName("");
-      setIsDialogOpen(false);
-      onSuccess?.();
-    } catch (error) {
-      log.error("[QuickAddToPlaylistMenu] Failed to create playlist:", error);
-    } finally {
-      setIsCreating(false);
+      setInternalOpen(next);
+      onOpenChange(next);
     }
   };
 
   const defaultTrigger = (
-    <Button variant="ghost" size="icon" className="h-8 w-8">
-      <List className="h-4 w-4" />
-    </Button>
+    <span role="button" className="inline-flex" tabIndex={0} aria-label="Add to playlist" />
   );
+
+  const raw = trigger ?? defaultTrigger;
+  const withOpen = isValidElement(raw)
+    ? cloneElement(raw, {
+        onClick: (e: React.MouseEvent) => {
+          (raw.props as { onClick?: (e: React.MouseEvent) => void }).onClick?.(e);
+          setEffectiveOpen(true);
+        },
+      } as { onClick: (e: React.MouseEvent) => void })
+    : raw;
 
   return (
     <>
-      {/* modal={false} allows menu to stay open when clicking outside; verify A11y with screen reader */}
-      <DropdownMenu
-        open={effectiveIsMenuOpen}
-        onOpenChange={setEffectiveIsMenuOpen}
-        modal={false}
-      >
-        <DropdownMenuTrigger asChild>
-          {trigger || defaultTrigger}
-        </DropdownMenuTrigger>
-        <DropdownMenuContent
-          align={contentAlign}
-          side={contentSide}
-          sideOffset={contentSideOffset}
-          className="w-56"
-        >
-          <DropdownMenuLabel>Add to Playlist</DropdownMenuLabel>
-          <DropdownMenuSeparator />
-          {isLoading ? (
-            <div className="flex items-center justify-center px-2 py-4">
-              <Loader2 className="h-4 w-4 animate-spin" />
-            </div>
-          ) : (
-            <>
-              {playlists.length === 0 ? (
-                <div className="px-2 py-4 text-sm text-muted-foreground text-center">
-                  No playlists yet
-                </div>
-              ) : (
-                <>
-                  {playlists.map((playlist: Playlist) => (
-                    <DropdownMenuCheckboxItem
-                      key={playlist.id}
-                      checked={selectedPlaylistIds.has(playlist.id)}
-                      onCheckedChange={() => handleTogglePlaylist(playlist.id)}
-                      onSelect={(e) => e.preventDefault()}
-                    >
-                      {playlist.name}
-                    </DropdownMenuCheckboxItem>
-                  ))}
-                  <DropdownMenuSeparator />
-                </>
-              )}
-              <DropdownMenuItem onClick={() => setIsDialogOpen(true)}>
-                <Plus className="mr-2 h-4 w-4" />
-                Create New Playlist
-              </DropdownMenuItem>
-            </>
-          )}
-        </DropdownMenuContent>
-      </DropdownMenu>
-
-      <Dialog open={isDialogOpen} onOpenChange={setIsDialogOpen}>
-        <DialogContent>
-          <DialogHeader>
-            <DialogTitle>Create New Playlist</DialogTitle>
-          </DialogHeader>
-          <div className="space-y-4">
-            <Input
-              placeholder="Playlist name"
-              value={newPlaylistName}
-              onChange={(e) => setNewPlaylistName(e.target.value)}
-              onKeyDown={(e) => {
-                if (e.key === "Enter" && !isCreating) {
-                  handleCreatePlaylist();
-                }
-              }}
-              disabled={isCreating}
-            />
-          </div>
-          <DialogFooter>
-            <Button
-              variant="outline"
-              onClick={() => setIsDialogOpen(false)}
-              disabled={isCreating}
-            >
-              Cancel
-            </Button>
-            <Button onClick={handleCreatePlaylist} disabled={isCreating || !newPlaylistName.trim()}>
-              {isCreating ? (
-                <>
-                  <Loader2 className="mr-2 h-4 w-4 animate-spin" />
-                  Creating...
-                </>
-              ) : (
-                "Create"
-              )}
-            </Button>
-          </DialogFooter>
-        </DialogContent>
-      </Dialog>
+      {withOpen}
+      <AddToPlaylistModal
+        posts={[post]}
+        open={effectiveOpen}
+        onOpenChange={setEffectiveOpen}
+        onSuccess={onSuccess}
+      />
     </>
   );
 };

--- a/src/renderer/components/ui/alert-dialog.tsx
+++ b/src/renderer/components/ui/alert-dialog.tsx
@@ -1,0 +1,127 @@
+import * as React from "react";
+import * as AlertDialogPrimitive from "@radix-ui/react-alert-dialog";
+import { cn } from "@/lib/utils";
+
+const AlertDialog = AlertDialogPrimitive.Root;
+const AlertDialogTrigger = AlertDialogPrimitive.Trigger;
+const AlertDialogPortal = AlertDialogPrimitive.Portal;
+
+const AlertDialogOverlay = React.forwardRef<
+  React.ElementRef<typeof AlertDialogPrimitive.Overlay>,
+  React.ComponentPropsWithoutRef<typeof AlertDialogPrimitive.Overlay>
+>(({ className, ...props }, ref) => (
+  <AlertDialogPrimitive.Overlay
+    ref={ref}
+    className={cn(
+      "fixed inset-0 z-50 bg-black/80 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0",
+      className
+    )}
+    {...props}
+  />
+));
+AlertDialogOverlay.displayName = AlertDialogPrimitive.Overlay.displayName;
+
+const AlertDialogContent = React.forwardRef<
+  React.ElementRef<typeof AlertDialogPrimitive.Content>,
+  React.ComponentPropsWithoutRef<typeof AlertDialogPrimitive.Content>
+>(({ className, ...props }, ref) => (
+  <AlertDialogPortal>
+    <AlertDialogOverlay />
+    <AlertDialogPrimitive.Content
+      ref={ref}
+      className={cn(
+        "fixed left-[50%] top-[50%] z-50 grid w-full max-w-lg translate-x-[-50%] translate-y-[-50%] gap-4 border bg-background p-6 shadow-lg duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[state=closed]:slide-out-to-left-1/2 data-[state=closed]:slide-out-to-top-[48%] data-[state=open]:slide-in-from-left-1/2 data-[state=open]:slide-in-from-top-[48%] sm:rounded-lg",
+        className
+      )}
+      {...props}
+    />
+  </AlertDialogPortal>
+));
+AlertDialogContent.displayName = AlertDialogPrimitive.Content.displayName;
+
+const AlertDialogHeader = ({
+  className,
+  ...props
+}: React.HTMLAttributes<HTMLDivElement>) => (
+  <div className={cn("flex flex-col space-y-2 text-center sm:text-left", className)} {...props} />
+);
+AlertDialogHeader.displayName = "AlertDialogHeader";
+
+const AlertDialogFooter = ({
+  className,
+  ...props
+}: React.HTMLAttributes<HTMLDivElement>) => (
+  <div
+    className={cn("flex flex-col-reverse sm:flex-row sm:justify-end sm:space-x-2", className)}
+    {...props}
+  />
+);
+AlertDialogFooter.displayName = "AlertDialogFooter";
+
+const AlertDialogTitle = React.forwardRef<
+  React.ElementRef<typeof AlertDialogPrimitive.Title>,
+  React.ComponentPropsWithoutRef<typeof AlertDialogPrimitive.Title>
+>(({ className, ...props }, ref) => (
+  <AlertDialogPrimitive.Title
+    ref={ref}
+    className={cn("text-lg font-semibold", className)}
+    {...props}
+  />
+));
+AlertDialogTitle.displayName = AlertDialogPrimitive.Title.displayName;
+
+const AlertDialogDescription = React.forwardRef<
+  React.ElementRef<typeof AlertDialogPrimitive.Description>,
+  React.ComponentPropsWithoutRef<typeof AlertDialogPrimitive.Description>
+>(({ className, ...props }, ref) => (
+  <AlertDialogPrimitive.Description
+    ref={ref}
+    className={cn("text-sm text-muted-foreground", className)}
+    {...props}
+  />
+));
+AlertDialogDescription.displayName = AlertDialogPrimitive.Description.displayName;
+
+const AlertDialogAction = React.forwardRef<
+  React.ElementRef<typeof AlertDialogPrimitive.Action>,
+  React.ComponentPropsWithoutRef<typeof AlertDialogPrimitive.Action>
+>(({ className, ...props }, ref) => (
+  <AlertDialogPrimitive.Action
+    ref={ref}
+    className={cn(
+      "inline-flex h-10 items-center justify-center rounded-md bg-primary px-4 py-2 text-sm font-medium text-primary-foreground ring-offset-background transition-colors hover:bg-primary/90 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50",
+      className
+    )}
+    {...props}
+  />
+));
+AlertDialogAction.displayName = AlertDialogPrimitive.Action.displayName;
+
+const AlertDialogCancel = React.forwardRef<
+  React.ElementRef<typeof AlertDialogPrimitive.Cancel>,
+  React.ComponentPropsWithoutRef<typeof AlertDialogPrimitive.Cancel>
+>(({ className, ...props }, ref) => (
+  <AlertDialogPrimitive.Cancel
+    ref={ref}
+    className={cn(
+      "mt-2 inline-flex h-10 items-center justify-center rounded-md border border-input bg-background px-4 py-2 text-sm font-medium ring-offset-background transition-colors hover:bg-accent hover:text-accent-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 sm:mt-0",
+      className
+    )}
+    {...props}
+  />
+));
+AlertDialogCancel.displayName = AlertDialogPrimitive.Cancel.displayName;
+
+export {
+  AlertDialog,
+  AlertDialogPortal,
+  AlertDialogOverlay,
+  AlertDialogTrigger,
+  AlertDialogContent,
+  AlertDialogHeader,
+  AlertDialogFooter,
+  AlertDialogTitle,
+  AlertDialogDescription,
+  AlertDialogAction,
+  AlertDialogCancel,
+};

--- a/src/renderer/features/artists/components/PostCard.tsx
+++ b/src/renderer/features/artists/components/PostCard.tsx
@@ -423,9 +423,6 @@ export const PostCard: React.FC<PostCardProps> = ({
               setContextMenuPosition(null);
             }
           }}
-          contentAlign={contextMenuPosition ? "start" : "end"}
-          contentSide={contextMenuPosition ? "bottom" : "bottom"}
-          contentSideOffset={contextMenuPosition ? 0 : 4}
           trigger={
             <span
               ref={contextMenuAnchorRef}

--- a/src/renderer/features/viewer/ViewerDialog.tsx
+++ b/src/renderer/features/viewer/ViewerDialog.tsx
@@ -2,7 +2,6 @@ import { useEffect, useCallback, useState, useMemo, useRef } from "react";
 import {
   Dialog,
   DialogContent,
-  DialogHeader,
   DialogTitle,
   DialogDescription,
 } from "../../components/ui/dialog";
@@ -39,7 +38,6 @@ import {
   ExternalLink,
   Eye,
   Loader2,
-  List,
   Plus,
   Shuffle,
 } from "lucide-react";
@@ -75,7 +73,7 @@ import { cn } from "../../lib/utils";
 import { isVideoPost } from "../../lib/filter-utils";
 import { useVideoProxyUrl } from "../../lib/hooks/useVideoProxyUrl";
 import { useViewerController } from "./hooks/useViewerController";
-import { QuickAddToPlaylistMenu } from "../../components/playlists/QuickAddToPlaylistMenu";
+import { AddToPlaylistModal } from "../../components/playlists/AddToPlaylistModal";
 
 const VIEWER_TAG_HINT_SEEN_KEY = "hasSeenTagHint";
 
@@ -1670,32 +1668,16 @@ const ViewerContent = ({
         <ChevronRight className="w-10 h-10 drop-shadow-md" />
       </Button>
 
-      <Dialog open={showPlaylistDialog} onOpenChange={setShowPlaylistDialog}>
-        <DialogContent
-          className="z-[200] sm:max-w-md gap-3"
-          onCloseAutoFocus={(e) => {
-            e.preventDefault();
-            playlistDialogTriggerRef.current?.focus();
-          }}
-        >
-          <DialogHeader>
-            <DialogTitle>Add to playlist</DialogTitle>
-            <DialogDescription>
-              Choose which playlists to add this post to.
-            </DialogDescription>
-          </DialogHeader>
-          <QuickAddToPlaylistMenu
-            post={{ id: post.id, postId: post.postId }}
-            trigger={
-              <Button variant="outline" className="w-full">
-                <List className="mr-2 h-4 w-4" />
-                Select Playlists
-              </Button>
-            }
-            onSuccess={() => setShowPlaylistDialog(false)}
-          />
-        </DialogContent>
-      </Dialog>
+      <AddToPlaylistModal
+        className="z-[200]"
+        posts={[{ id: post.id, postId: post.postId }]}
+        open={showPlaylistDialog}
+        onOpenChange={setShowPlaylistDialog}
+        onSuccess={() => setShowPlaylistDialog(false)}
+        focusReturnRef={playlistDialogTriggerRef}
+        title="Add to playlist"
+        description="Choose which playlists should include this post."
+      />
     </>
   );
 };

--- a/src/shared/schemas/playlist.ts
+++ b/src/shared/schemas/playlist.ts
@@ -117,6 +117,44 @@ export const RemovePostsFromPlaylistSchema = z.object({
 export type RemovePostsFromPlaylistRequest = z.infer<typeof RemovePostsFromPlaylistSchema>;
 
 /**
+ * Sync which manual playlists contain the given post(s) in one transaction.
+ * Adds to checked playlists, removes from all other manual playlists.
+ */
+export const SyncManualPlaylistMembershipSchema = z.object({
+  postIds: z.array(IdSchema).min(1, "At least one post required"),
+  manualPlaylistIds: z.array(IdSchema),
+});
+
+export type SyncManualPlaylistMembershipRequest = z.infer<typeof SyncManualPlaylistMembershipSchema>;
+
+/**
+ * How many of the given posts are in each manual playlist (for bulk UI pre-check / indeterminate).
+ */
+export const GetManualPlaylistMembershipForPostsSchema = z.object({
+  postIds: z.array(IdSchema).min(1, "At least one post required"),
+});
+
+export type GetManualPlaylistMembershipForPostsRequest = z.infer<
+  typeof GetManualPlaylistMembershipForPostsSchema
+>;
+
+export const ClearManualPlaylistSchema = z.object({
+  playlistId: IdSchema,
+});
+
+export type ClearManualPlaylistRequest = z.infer<typeof ClearManualPlaylistSchema>;
+
+export const MovePostsBetweenManualPlaylistsSchema = z.object({
+  fromPlaylistId: IdSchema,
+  toPlaylistId: IdSchema,
+  postIds: z.array(IdSchema).min(1, "At least one post required"),
+});
+
+export type MovePostsBetweenManualPlaylistsRequest = z.infer<
+  typeof MovePostsBetweenManualPlaylistsSchema
+>;
+
+/**
  * Get Playlist Posts Schema
  *
  * Single source of truth for GetPlaylistPosts validation and typing.


### PR DESCRIPTION
- Added new IPC methods for managing manual playlists, including `getManualPlaylistMembershipForPosts`, `syncManualPlaylistMembership`, `clearManualPlaylist`, and `movePostsBetweenManualPlaylists`.
- Implemented corresponding schemas for request validation using Zod, ensuring strict type safety and input validation.
- Updated `PlaylistController` to handle new playlist operations, improving the overall functionality and user experience.
- Enhanced `BulkActionBar` and `PlaylistsPage` components to support moving posts between manual playlists and clearing playlists, streamlining user interactions.
- Integrated `AddToPlaylistModal` for a more intuitive UI when adding posts to playlists.
- Cleaned up unused imports and ensured adherence to strict coding standards throughout the changes.