### PR TITLE
fix(ipc): hash full args for collapse keys and delay instead of reject throttle

### DIFF
--- a/.ai/LESSONS.txt
+++ b/.ai/LESSONS.txt
@@ -23,9 +23,9 @@ Root Cause: Store contract changed but not all consumers were updated.
 Invariant Rule: Any filter contract change requires synchronized updates across store, panels, and all feed pages.
 
 3) Idempotent IPC Under Strict Mode
-Problem: Duplicate startup calls trigger throttling and unstable UX.
-Root Cause: Idempotent handlers were treated the same as mutating handlers.
-Invariant Rule: Mark truly idempotent handlers and use request collapsing for in-flight calls.
+Problem: Duplicate startup calls trigger throttling and unstable UX; partial collapse keys leak wrong results across concurrent calls.
+Root Cause: Idempotent handlers were treated like mutating ones, or collapse keys used only `id`/`type` and ignored other fields.
+Invariant Rule: Mark truly idempotent handlers; collapse in-flight calls by hashing the full canonical args; space mutating calls with delay (never reject).
 
 4) Virtualized Gallery Holes
 Problem: Large empty scroll area in filtered lists.

--- a/docs/api.md
+++ b/docs/api.md
@@ -1972,6 +1972,8 @@ All IPC operations are handled through domain-specific controllers that extend `
   - Automatic input validation using Zod schemas
   - Type-safe handler registration
   - Prevents duplicate handler registration errors
+  - Request collapsing for idempotent handlers (key = channel + hash of full stable-serialized args)
+  - Soft throttle for mutating handlers (delay spacing, never `Rate limit exceeded` reject)
 
 **Controller Setup:**
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -512,6 +512,8 @@ const posts = await db.query.posts.findMany({
    - Automatic input validation using Zod schemas
    - Type-safe handler registration
    - Prevents duplicate handler registration errors
+   - **Request collapsing** (idempotent handlers): in-flight calls with the same channel + full canonical args hash share one Promise; different payloads never share results
+   - **Call spacing** (non-idempotent handlers): rapid repeat calls on one channel are delayed (~100ms), not rejected
 
    **⚠️ CRITICAL: Always Use Limits in Database Queries**
 

--- a/src/main/core/ipc/BaseController.ts
+++ b/src/main/core/ipc/BaseController.ts
@@ -62,7 +62,7 @@ export abstract class BaseController {
 
   // Request Collapsing: For idempotent handlers, reuse in-flight Promise to prevent duplicate work
   // Map<key, { promise: Promise<unknown>, createdAt: number, timeoutId: NodeJS.Timeout }>
-  // CRITICAL: Key must include args hash, otherwise getUser(1) and getUser(2) would share Promise
+  // Key = channel + fastHash(stableStringify(args)) so different payloads never share a Promise
   // MEMORY LEAK PREVENTION: Each promise has its own setTimeout to ensure cleanup even if IPC stops
   private static readonly requestCollapseMap = new Map<
     string,
@@ -78,97 +78,87 @@ export abstract class BaseController {
   private static readonly REQUEST_COLLAPSE_TIMEOUT_MS = 30000; // 30 seconds
 
   /**
-   * Generate stable key for Request Collapsing from channel + args
-   * PERFORMANCE: Uses only critical identifiers (id, type) instead of full serialization
-   * This prevents Main Process blocking on large objects (e.g., 20k+ post arrays)
-   * 
-   * CRITICAL: Returns null if args cannot be safely collapsed (prevents data leakage)
-   * If two different calls with different complex objects get same key, they would share Promise
-   * 
-   * Strategy:
-   * - Empty args: use channel only
-   * - Single arg with id/type: use those fields
-   * - Arrays: use length + first element id (if available)
-   * - Complex objects without id/type: return null (disable collapsing)
-   * 
-   * @returns Collapse key string, or null if collapsing is unsafe
+   * Canonical JSON with sorted object keys (arrays keep order).
+   * Returns null for values that cannot be represented safely (undefined, NaN, functions, etc.).
+   */
+  private static stableStringify(value: unknown): string | null {
+    if (value === undefined) {
+      return null;
+    }
+    if (value === null) {
+      return "null";
+    }
+
+    const valueType = typeof value;
+    if (valueType === "string") {
+      return JSON.stringify(value);
+    }
+    if (valueType === "boolean") {
+      return value ? "true" : "false";
+    }
+    if (valueType === "number") {
+      if (!Number.isFinite(value)) {
+        return null;
+      }
+      return JSON.stringify(value);
+    }
+    if (
+      valueType === "bigint" ||
+      valueType === "symbol" ||
+      valueType === "function"
+    ) {
+      return null;
+    }
+
+    if (Array.isArray(value)) {
+      const parts: string[] = [];
+      for (const item of value) {
+        const itemJson = this.stableStringify(item);
+        if (itemJson === null) {
+          return null;
+        }
+        parts.push(itemJson);
+      }
+      return `[${parts.join(",")}]`;
+    }
+
+    if (valueType === "object") {
+      const proto = Object.getPrototypeOf(value);
+      if (proto !== Object.prototype && proto !== null) {
+        return null;
+      }
+
+      const keys = Object.keys(value).sort();
+      const parts: string[] = [];
+      for (const key of keys) {
+        const propJson = this.stableStringify(Reflect.get(value, key));
+        if (propJson === null) {
+          return null;
+        }
+        parts.push(`${JSON.stringify(key)}:${propJson}`);
+      }
+      return `{${parts.join(",")}}`;
+    }
+
+    return null;
+  }
+
+  /**
+   * Collapse key from channel + full canonical args hash.
+   * Returns null when args cannot be serialized (collapsing disabled, no warn).
    */
   private static getCollapseKey(channel: string, args: unknown[]): string | null {
-    // Empty args - most common case (e.g., getSettings)
-    if (args.length === 0) {
-      return channel;
+    const canonical = this.stableStringify(args);
+    if (canonical === null) {
+      return null;
     }
-
-    // Single argument - extract id or type if available
-    if (args.length === 1) {
-      const arg = args[0];
-      if (arg === null || arg === undefined) {
-        return `${channel}:null`;
-      }
-      
-      // Check for common identifier fields
-      if (typeof arg === "object" && arg !== null) {
-        const obj = arg as Record<string, unknown>;
-        if ("id" in obj && typeof obj.id === "number") {
-          return `${channel}:id=${obj.id}`;
-        }
-        if ("type" in obj && typeof obj.type === "string") {
-          return `${channel}:type=${obj.type}`;
-        }
-        // CRITICAL: Do NOT return default key for complex objects
-        // Returning ":complex" would cause data leakage - different objects would share Promise
-        // Disable collapsing for complex objects without id/type
-        log.warn(
-          `[IPC] Complex argument object for idempotent channel "${channel}" without id/type. ` +
-          `Request Collapsing disabled to prevent data leakage. Consider using non-idempotent handler or pass hash from Renderer.`
-        );
-        return null; // Disable collapsing - prevents data leakage
-      }
-      
-      // Primitive values
-      const argString = String(arg);
-      
-      // CRITICAL: Hash long arguments to prevent data leakage in static map
-      // Simple rule: hash everything longer than 16 characters
-      // No guessing about "sensitive data" - just hash long strings
-      // This prevents tokens, long tags, or other long data from being stored in memory forever
-      // PERFORMANCE: Use fast non-cryptographic hash (djb2) instead of SHA-256
-      // djb2 is O(n) but much faster and sufficient for collision-resistant key generation
-      if (argString.length > 16) {
-        const hash = this.fastHash(argString);
-        return `${channel}:hash=${hash}`;
-      }
-      
-      return `${channel}:${argString}`;
-    }
-
-    // Multiple arguments - use first arg id + count
-    const firstArg = args[0];
-    if (
-      typeof firstArg === "object" &&
-      firstArg !== null &&
-      "id" in firstArg &&
-      typeof (firstArg as Record<string, unknown>).id === "number"
-    ) {
-      return `${channel}:id=${(firstArg as Record<string, unknown>).id}:count=${args.length}`;
-    }
-
-    // CRITICAL: Do NOT return default key for multiple args without IDs
-    // Returning ":multi:count=N" would cause data leakage - different arg sets would share Promise
-    log.warn(
-      `[IPC] Multiple arguments for idempotent channel "${channel}" without id/type. ` +
-      `Request Collapsing disabled to prevent data leakage. Consider using non-idempotent handler.`
-    );
-    return null; // Disable collapsing - prevents data leakage
+    return `${channel}:${this.fastHash(canonical)}`;
   }
 
   /**
    * Fast non-cryptographic hash (djb2 algorithm)
-   * Used for hashing IPC keys to prevent data leakage without blocking Main Process
-   * 
-   * PERFORMANCE: O(n) time complexity, much faster than SHA-256
-   * Collision resistance is sufficient for IPC key generation (not security-critical)
-   * 
+   * Used for hashing IPC collapse keys without blocking Main Process
+   *
    * @param str - String to hash
    * @returns 16-character hex hash
    */
@@ -183,9 +173,8 @@ export abstract class BaseController {
     return Math.abs(hash).toString(16).substring(0, 16);
   }
 
-  // Minimum time between calls for the same channel (milliseconds)
-  // Prevents renderer from spamming IPC calls
-  private static readonly THROTTLE_MS = 100; // 100ms = max 10 calls per second per channel
+  // Minimum spacing between non-idempotent calls on the same channel (delay, never reject)
+  private static readonly THROTTLE_MS = 100;
 
   // TTL for throttle map entries (1 hour) - prevents memory leak from dynamic channel names
   private static readonly THROTTLE_TTL_MS = 60 * 60 * 1000; // 1 hour
@@ -244,10 +233,6 @@ export abstract class BaseController {
       channel,
       async (event: IpcMainInvokeEvent, ...args: unknown[]) => {
         try {
-          // Throttling: Prevent DoS attacks by limiting call frequency per channel
-          // If rate limit exceeded, throw error immediately instead of creating promise queue
-          const now = Date.now();
-
           // Cleanup old entries to prevent memory leak (TTL-based cleanup)
           // Use call counter instead of random for predictable cleanup behavior
           // Perform cleanup asynchronously to avoid blocking Main Process Event Loop
@@ -285,7 +270,7 @@ export abstract class BaseController {
               const stuckKeys: string[] = [];
               for (const [key, entry] of BaseController.requestCollapseMap.entries()) {
                 const age = now - entry.createdAt;
-                if (age > BaseController.REQUEST_COLLAPSE_TIMEOUT_MS) {
+                if (age >= BaseController.REQUEST_COLLAPSE_TIMEOUT_MS) {
                   stuckKeys.push(key);
                 }
               }
@@ -307,22 +292,16 @@ export abstract class BaseController {
 
           const isIdempotent = options?.isIdempotent === true;
 
-          // Request Collapsing: For idempotent handlers, reuse in-flight Promise
-          // This prevents duplicate work when multiple calls arrive simultaneously (e.g., React Strict Mode)
-          // CRITICAL: For idempotent handlers, Request Collapsing replaces throttling
-          // Throttling is not needed because collapsing prevents duplicate work
-          // CRITICAL: Key includes args hash to prevent data leakage (getUser(1) vs getUser(2))
+          // Request Collapsing: reuse in-flight Promise for identical (channel + args) on idempotent handlers
+          // Collapsing replaces per-call throttling for idempotent channels
           if (isIdempotent) {
-            // Generate collapse key from channel + args (prevents different args from sharing Promise)
-            // Returns null if args cannot be safely collapsed (prevents data leakage)
             const collapseKey = BaseController.getCollapseKey(channel, args);
-            
-            // If collapsing is unsafe (complex args without id/type), disable it
+
+            // Unserializable args → no collapsing; fall through to throttled execution
             if (collapseKey === null) {
               log.debug(
-                `[IPC] Request collapsing disabled for idempotent channel "${channel}" - complex args without id/type`
+                `[IPC] Request collapsing disabled for idempotent channel "${channel}" - args not serializable`
               );
-              // Fall through to normal execution (no collapsing, but still idempotent)
             } else {
               // Check for existing Promise FIRST (before creating new one)
               const existingEntry =
@@ -330,7 +309,7 @@ export abstract class BaseController {
               if (existingEntry) {
                 // MEMORY LEAK PREVENTION: Check if promise is stuck (>30s)
                 const age = Date.now() - existingEntry.createdAt;
-                if (age > BaseController.REQUEST_COLLAPSE_TIMEOUT_MS) {
+                if (age >= BaseController.REQUEST_COLLAPSE_TIMEOUT_MS) {
                   // Promise is stuck - remove it to prevent memory leak
                   log.warn(
                     `[IPC] Removing stuck promise for channel "${channel}" with key "${collapseKey}" ` +
@@ -364,7 +343,7 @@ export abstract class BaseController {
               const createdAt = Date.now();
               const timeoutId = setTimeout(() => {
                 const entry = BaseController.requestCollapseMap.get(collapseKey);
-                if (entry && Date.now() - entry.createdAt > BaseController.REQUEST_COLLAPSE_TIMEOUT_MS) {
+                if (entry && Date.now() - entry.createdAt >= BaseController.REQUEST_COLLAPSE_TIMEOUT_MS) {
                   log.warn(
                     `[IPC] Timeout cleanup: removing stuck promise for channel "${channel}" ` +
                     `with key "${collapseKey}" (age: ${Date.now() - entry.createdAt}ms)`
@@ -544,34 +523,25 @@ export abstract class BaseController {
             }
           }
 
-          // Non-idempotent handlers: execute directly with throttling
-          // Throttling: Only apply to non-idempotent requests
-          const lastCall = BaseController.throttleMap.get(channel);
-          const timeSinceLastCall =
-            lastCall !== undefined ? now - lastCall : Infinity;
-
-          if (
-            lastCall !== undefined &&
-            timeSinceLastCall < BaseController.THROTTLE_MS
-          ) {
-            const waitTime = BaseController.THROTTLE_MS - (now - lastCall);
-            log.warn(
-              `[IPC] Rate limit exceeded for channel "${channel}" - too frequent (must wait ${waitTime}ms)`
+          // Spacing for non-idempotent (and unserializable idempotent) calls: delay, never reject
+          while (true) {
+            const lastCall = BaseController.throttleMap.get(channel);
+            if (lastCall === undefined) {
+              break;
+            }
+            const elapsed = Date.now() - lastCall;
+            if (elapsed >= BaseController.THROTTLE_MS) {
+              break;
+            }
+            const waitTime = BaseController.THROTTLE_MS - elapsed;
+            log.debug(
+              `[IPC] Throttling channel "${channel}" - waiting ${waitTime}ms`
             );
-            const rateLimitError: SerializableError = {
-              message: `Rate limit exceeded. Please wait ${waitTime}ms before retrying.`,
-              stack: undefined,
-              name: "RateLimitError",
-              originalError: undefined,
-              code: ErrorCode.RATE_LIMIT, // Typed error code for reliable error handling
-            };
-            throw rateLimitError;
+            await new Promise<void>((resolve) => {
+              setTimeout(resolve, waitTime);
+            });
           }
-
-          // Update throttle timestamp only if we're actually processing the request
           BaseController.throttleMap.set(channel, Date.now());
-
-          // Continue with validation and execution (code continues below)
 
           // Security: Log only channel name and argument count, not actual arguments
           // This prevents leaking user data, file paths, or other sensitive information
@@ -745,8 +715,7 @@ export abstract class BaseController {
           log.debug(`[IPC] Request completed: ${channel}`);
           return result;
         } catch (error: unknown) {
-          // Skip error handling if it's already a serialized error (ValidationError, RateLimitError, etc.)
-          // Check for SerializableError structure: has name, message, and code properties
+          // Skip re-serialization for already-serialized IPC errors (ValidationError, etc.)
           if (
             typeof error === "object" &&
             error !== null &&
@@ -754,8 +723,6 @@ export abstract class BaseController {
             "message" in error &&
             "code" in error
           ) {
-            // Already serialized (ValidationError, RateLimitError, or other SerializableError)
-            // Just re-throw it as-is without re-serialization
             throw error;
           }
 

--- a/tests/unit/core/BaseController.collapse-throttle.test.ts
+++ b/tests/unit/core/BaseController.collapse-throttle.test.ts
@@ -1,0 +1,290 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { ipcMain, type IpcMainInvokeEvent } from "electron";
+import { z } from "zod";
+import log from "electron-log";
+import { BaseController } from "@/main/core/ipc/BaseController";
+
+vi.mock("electron", () => ({
+  ipcMain: {
+    handle: vi.fn(),
+    removeHandler: vi.fn(),
+  },
+}));
+
+vi.mock("electron-log", () => ({
+  default: {
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    debug: vi.fn(),
+  },
+}));
+
+type CollapseEntry = {
+  promise: Promise<unknown>;
+  createdAt: number;
+  timeoutId: NodeJS.Timeout;
+};
+
+type BaseControllerInternals = {
+  throttleMap: Map<string, number>;
+  requestCollapseMap: Map<string, CollapseEntry>;
+  REQUEST_COLLAPSE_TIMEOUT_MS: number;
+  THROTTLE_MS: number;
+  callCount: number;
+};
+
+function getInternals(): BaseControllerInternals {
+  return BaseController as unknown as BaseControllerInternals;
+}
+
+function clearControllerState(): void {
+  const internals = getInternals();
+  for (const entry of internals.requestCollapseMap.values()) {
+    clearTimeout(entry.timeoutId);
+  }
+  internals.requestCollapseMap.clear();
+  internals.throttleMap.clear();
+  internals.callCount = 0;
+}
+
+function getRegisteredHandler(
+  channel: string
+): (event: IpcMainInvokeEvent, ...args: unknown[]) => Promise<unknown> {
+  const registration = vi
+    .mocked(ipcMain.handle)
+    .mock.calls.find(([registeredChannel]) => registeredChannel === channel);
+
+  if (!registration) {
+    throw new Error(`Handler not registered for channel: ${channel}`);
+  }
+
+  return registration[1];
+}
+
+class TestController extends BaseController {
+  public setup(): void {
+    // no-op — tests register handlers explicitly
+  }
+
+  public registerIdempotent(
+    channel: string,
+    schema: z.ZodTypeAny,
+    handler: (
+      event: IpcMainInvokeEvent,
+      ...args: unknown[]
+    ) => Promise<unknown> | unknown
+  ): void {
+    this.handle(channel, schema, handler, { isIdempotent: true });
+  }
+
+  public registerMutating(
+    channel: string,
+    schema: z.ZodTypeAny,
+    handler: (
+      event: IpcMainInvokeEvent,
+      ...args: unknown[]
+    ) => Promise<unknown> | unknown
+  ): void {
+    this.handle(channel, schema, handler);
+  }
+}
+
+describe("BaseController request collapsing and throttle", () => {
+  let controller: TestController;
+  const mockEvent = {} as IpcMainInvokeEvent;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    clearControllerState();
+    controller = new TestController();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    clearControllerState();
+  });
+
+  it("collapses concurrent identical args into a single handler call", async () => {
+    let resolveHandler!: (value: string) => void;
+    const handlerGate = new Promise<string>((resolve) => {
+      resolveHandler = resolve;
+    });
+    const handler = vi.fn(async () => handlerGate);
+
+    controller.registerIdempotent(
+      "test:identical",
+      z.tuple([z.object({ id: z.number(), filters: z.string() })]),
+      handler
+    );
+
+    const invoke = getRegisteredHandler("test:identical");
+    const args = { id: 1, filters: "A" };
+
+    const first = invoke(mockEvent, args);
+    const second = invoke(mockEvent, args);
+
+    expect(handler).toHaveBeenCalledTimes(1);
+
+    resolveHandler("shared-result");
+    await expect(Promise.all([first, second])).resolves.toEqual([
+      "shared-result",
+      "shared-result",
+    ]);
+    expect(handler).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not mix results when id matches but other fields differ", async () => {
+    const handler = vi.fn(
+      async (
+        _event: IpcMainInvokeEvent,
+        payload: unknown
+      ): Promise<string> => {
+        if (
+          typeof payload !== "object" ||
+          payload === null ||
+          !("filters" in payload)
+        ) {
+          throw new Error("Unexpected payload");
+        }
+        const filters = Reflect.get(payload, "filters");
+        await new Promise<void>((resolve) => {
+          setTimeout(resolve, 20);
+        });
+        return `result-${String(filters)}`;
+      }
+    );
+
+    controller.registerIdempotent(
+      "test:same-id-diff-filters",
+      z.object({ id: z.number(), filters: z.string() }),
+      handler
+    );
+
+    const invoke = getRegisteredHandler("test:same-id-diff-filters");
+
+    const [resultA, resultB] = await Promise.all([
+      invoke(mockEvent, { id: 1, filters: "A" }),
+      invoke(mockEvent, { id: 1, filters: "B" }),
+    ]);
+
+    expect(handler).toHaveBeenCalledTimes(2);
+    expect(resultA).toBe("result-A");
+    expect(resultB).toBe("result-B");
+  });
+
+  it("collapses filter objects without id and does not warn about disabled collapsing", async () => {
+    const handler = vi.fn(async () => 42);
+
+    controller.registerIdempotent(
+      "db:get-posts-count-with-filters",
+      z.object({
+        artistId: z.number().optional(),
+        filters: z.object({ search: z.string() }),
+      }),
+      handler
+    );
+
+    const invoke = getRegisteredHandler("db:get-posts-count-with-filters");
+    const payload = { artistId: 7, filters: { search: "tag" } };
+
+    const [a, b] = await Promise.all([
+      invoke(mockEvent, payload),
+      invoke(mockEvent, payload),
+    ]);
+
+    expect(a).toBe(42);
+    expect(b).toBe(42);
+    expect(handler).toHaveBeenCalledTimes(1);
+    expect(log.warn).not.toHaveBeenCalledWith(
+      expect.stringContaining("Request Collapsing disabled")
+    );
+  });
+
+  it("delays rapid mutating calls instead of rejecting with Rate limit exceeded", async () => {
+    vi.useFakeTimers();
+    const handler = vi.fn(async (_event: IpcMainInvokeEvent, id: unknown) => id);
+
+    controller.registerMutating(
+      "db:mark-viewed",
+      z.tuple([z.number()]),
+      handler
+    );
+
+    const invoke = getRegisteredHandler("db:mark-viewed");
+
+    const firstPromise = invoke(mockEvent, 1);
+    await firstPromise;
+
+    const secondPromise = invoke(mockEvent, 2);
+    // Second call should be waiting on throttle spacing, not rejected
+    expect(handler).toHaveBeenCalledTimes(1);
+
+    await vi.advanceTimersByTimeAsync(getInternals().THROTTLE_MS);
+    await expect(secondPromise).resolves.toBe(2);
+    expect(handler).toHaveBeenCalledTimes(2);
+
+    const thrown = await secondPromise.then(
+      () => null,
+      (error: unknown) => error
+    );
+    expect(thrown).toBeNull();
+  });
+
+  it("removes stuck collapse promises after timeout", async () => {
+    vi.useFakeTimers();
+
+    controller.registerIdempotent(
+      "test:hang",
+      z.tuple([]),
+      () => new Promise<never>(() => undefined)
+    );
+
+    const invoke = getRegisteredHandler("test:hang");
+    void invoke(mockEvent);
+
+    expect(getInternals().requestCollapseMap.size).toBe(1);
+
+    await vi.advanceTimersByTimeAsync(
+      getInternals().REQUEST_COLLAPSE_TIMEOUT_MS
+    );
+
+    expect(getInternals().requestCollapseMap.size).toBe(0);
+    expect(log.warn).toHaveBeenCalledWith(
+      expect.stringContaining("Timeout cleanup")
+    );
+  });
+
+  it("uses the same collapse key regardless of object key insertion order", async () => {
+    let resolveHandler!: (value: string) => void;
+    const handler = vi.fn(
+      () =>
+        new Promise<string>((resolve) => {
+          resolveHandler = resolve;
+        })
+    );
+
+    controller.registerIdempotent(
+      "test:key-order",
+      z.object({ id: z.number(), filters: z.string() }),
+      handler
+    );
+
+    const invoke = getRegisteredHandler("test:key-order");
+
+    const first: Record<string, unknown> = {};
+    first.id = 1;
+    first.filters = "A";
+
+    const second: Record<string, unknown> = {};
+    second.filters = "A";
+    second.id = 1;
+
+    const p1 = invoke(mockEvent, first);
+    const p2 = invoke(mockEvent, second);
+
+    expect(handler).toHaveBeenCalledTimes(1);
+    resolveHandler("ok");
+    await expect(Promise.all([p1, p2])).resolves.toEqual(["ok", "ok"]);
+  });
+});


### PR DESCRIPTION
Id-only collapse keys mixed concurrent results; reject throttle punished legitimate rapid mutations. Collapse by stable full-args hash; space mutating calls with sleep.