### PR TITLE
refactor: enforce strict type assertion policy and update ESLint rules

### DIFF
--- a/.ai/LESSONS.txt
+++ b/.ai/LESSONS.txt
@@ -27,6 +27,11 @@ Problem: Duplicate startup calls trigger throttling and unstable UX; partial col
 Root Cause: Idempotent handlers were treated like mutating ones, or collapse keys used only `id`/`type` and ignored other fields.
 Invariant Rule: Mark truly idempotent handlers; collapse in-flight calls by hashing the full canonical args; space mutating calls with delay (never reject).
 
+3b) Type Assertion Policy
+Problem: Project rules banned all `as` casts while the codebase kept 100+ assertions — Cursor treated the rule as decorative.
+Root Cause: No enforced allowlist and no ESLint gate for narrowing assertions.
+Invariant Rule: `as` is forbidden except the closed boundary list: (1) `container.resolve` DI Map return; (2) better-sqlite3 raw `.prepare().get()`/`.all()` rows (includes drizzle instance typing); (3) Web Worker `workerData`/message payloads after Zod or trusted IPC handoff; (4) internals of `toIpcSafe` conditional return branches; (5) TanStack Query generic inference gaps (`pageParam` / default page flatten). Every allowed assertion MUST have `// boundary: <reason>` on the preceding line (and `eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion` when that rule fires). Fix types upstream or use Zod.parse — do not cast.
+
 4) Virtualized Gallery Holes
 Problem: Large empty scroll area in filtered lists.
 Root Cause: Virtualization total count used raw items while rendering filtered items.

--- a/.cursorrules
+++ b/.cursorrules
@@ -36,7 +36,8 @@ You do not tolerate sloppy code, "any" types, "as" casting, magic numbers, or pr
 4. **TypeScript & Code Quality**:
 
    - **Strict Types**: NO `any`. Use `unknown` with narrowing.
-   - **No Unsafe Casting**: NO `as` Casting. Fix the types upstream instead.
+   - **No Unsafe Casting**: `as` is forbidden except the closed **boundary** list below. Every allowed assertion MUST have `// boundary: <reason>` on the preceding line (and `eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion` when that rule fires). Fix types upstream or use Zod.parse — do not cast.
+     - **Boundary allowlist:** (1) `container.resolve` return from the DI Map; (2) better-sqlite3 raw `.prepare().get()` / `.all()` rows (includes drizzle instance typing); (3) Web Worker `workerData` / message payloads after Zod validation or trusted IPC handoff; (4) internals of `toIpcSafe` conditional return branches; (5) TanStack Query generic inference gaps (`pageParam` / default page flatten).
    - **No Magic**: NO Magic Numbers or Magic Strings. Extract constants.
    - **Definitions**: Use `type` for fixed definitions, `interface` for extendable structures.
    - **Python**: Type hinting is mandatory (TypeDict, Pydantic). No bare `try-except`.

--- a/docs/api.md
+++ b/docs/api.md
@@ -1974,6 +1974,7 @@ All IPC operations are handled through domain-specific controllers that extend `
   - Prevents duplicate handler registration errors
   - Request collapsing for idempotent handlers (key = channel + hash of full stable-serialized args)
   - Soft throttle for mutating handlers (delay spacing, never `Rate limit exceeded` reject)
+  - Type assertion policy: `as` only at documented boundaries (see `.cursorrules` / LESSONS 3b); ESLint enforces via `no-unsafe-type-assertion` on `src/**`
 
 **Controller Setup:**
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -514,6 +514,7 @@ const posts = await db.query.posts.findMany({
    - Prevents duplicate handler registration errors
    - **Request collapsing** (idempotent handlers): in-flight calls with the same channel + full canonical args hash share one Promise; different payloads never share results
    - **Call spacing** (non-idempotent handlers): rapid repeat calls on one channel are delayed (~100ms), not rejected
+   - **Type assertions:** `as` forbidden except documented boundary allowlist in `.cursorrules` / `.ai/LESSONS.txt` (enforced by `@typescript-eslint/no-unsafe-type-assertion` on `src/**`)
 
    **⚠️ CRITICAL: Always Use Limits in Database Queries**
 

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -17,7 +17,7 @@ export default tseslint.config(
     ],
   },
 
-  // 2. Базовая конфигурация
+  // 2. Базовая конфигурация (без type-aware rules — tsconfig include: src only)
   {
     extends: [js.configs.recommended, ...tseslint.configs.recommended],
     files: ["**/*.{ts,tsx}"],
@@ -38,7 +38,6 @@ export default tseslint.config(
         "warn",
         { allowConstantExport: true },
       ],
-      // Настройка строгости для TypeScript
       "@typescript-eslint/no-explicit-any": "warn",
       "@typescript-eslint/no-unused-vars": [
         "warn",
@@ -48,6 +47,36 @@ export default tseslint.config(
           caughtErrorsIgnorePattern: "^_",
         },
       ],
+      // Prefer `as` over angle-bracket assertions (object-literal ban is src-only below)
+      "@typescript-eslint/consistent-type-assertions": [
+        "error",
+        {
+          assertionStyle: "as",
+        },
+      ],
+    },
+  },
+
+  // 3. Type-aware assertion enforcement (src only — matches tsconfig include)
+  {
+    files: ["src/**/*.{ts,tsx}"],
+    ignores: ["**/*.d.ts"],
+    languageOptions: {
+      parserOptions: {
+        projectService: true,
+        tsconfigRootDir: import.meta.dirname,
+      },
+    },
+    rules: {
+      "@typescript-eslint/consistent-type-assertions": [
+        "error",
+        {
+          assertionStyle: "as",
+          objectLiteralTypeAssertions: "never",
+        },
+      ],
+      // Ban narrowing type assertions; boundary casts use // boundary: + eslint-disable-next-line
+      "@typescript-eslint/no-unsafe-type-assertion": "error",
     },
   }
 );

--- a/src/main/core/di/Container.ts
+++ b/src/main/core/di/Container.ts
@@ -151,6 +151,8 @@ export class Container {
         );
       }
 
+      // boundary: container.resolve — DI Map stores as unknown, cast is the resolve contract
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion -- boundary: container.resolve
       return service as T;
     } finally {
       // Remove from stack after resolution (allows same service to be resolved again)

--- a/src/main/core/ipc/BaseController.ts
+++ b/src/main/core/ipc/BaseController.ts
@@ -379,8 +379,7 @@ export abstract class BaseController {
 
                 // Strict validation: Check argument count BEFORE parsing
                 if (isTuple) {
-                  const tupleSchema = schema as z.AnyZodTuple;
-                  const expectedCount = tupleSchema.items.length;
+                  const expectedCount = schema.items.length;
                   if (args.length !== expectedCount) {
                     const errorMessage = `Argument count mismatch: expected ${expectedCount}, got ${args.length}`;
                     log.error(
@@ -415,7 +414,7 @@ export abstract class BaseController {
                 // Normalize schema and validate
                 const normalizedSchema = isTuple
                   ? schema
-                  : z.tuple([schema as z.ZodTypeAny]);
+                  : z.tuple([schema]);
                 
                 // Use z.infer to extract types from schema for proper type safety
                 // This eliminates the need for 'as unknown[]' type assertion
@@ -425,7 +424,7 @@ export abstract class BaseController {
                 try {
                   validatedArgs = normalizedSchema.parse(args, {
                     errorMap: sanitizedErrorMap,
-                  }) as ValidatedArgs;
+                  });
                 } catch (validationError) {
                   if (validationError instanceof z.ZodError) {
                     // Build detailed error message with path information
@@ -558,10 +557,7 @@ export abstract class BaseController {
           // Strict validation: Check argument count BEFORE parsing
           // This prevents silent failures when Renderer sends wrong number of arguments
           if (isTuple) {
-            // Use proper Zod type checking: ZodTuple has items property
-            // Cast to z.AnyZodTuple for type-safe access to items.length
-            const tupleSchema = schema as z.AnyZodTuple;
-            const expectedCount = tupleSchema.items.length;
+            const expectedCount = schema.items.length;
             if (args.length !== expectedCount) {
               const errorMessage = `Argument count mismatch: expected ${expectedCount}, got ${args.length}`;
               // Security: Log only error details, not sanitized args (may still leak info)
@@ -621,7 +617,7 @@ export abstract class BaseController {
           // Normalize schema: if single ZodType (not tuple), wrap in tuple for validation
           const normalizedSchema = isTuple
             ? schema
-            : z.tuple([schema as z.ZodTypeAny]);
+            : z.tuple([schema]);
 
           // Use z.infer to extract types from schema instead of as unknown[]
           // This provides proper type safety without type assertions
@@ -631,7 +627,7 @@ export abstract class BaseController {
           try {
             validatedArgs = normalizedSchema.parse(args, {
               errorMap: sanitizedErrorMap,
-            }) as ValidatedArgs;
+            });
           } catch (validationError) {
             if (validationError instanceof z.ZodError) {
               // Build detailed error message with path information

--- a/src/main/db/backfill-media-type.ts
+++ b/src/main/db/backfill-media-type.ts
@@ -35,6 +35,8 @@ export async function backfillMediaType(): Promise<void> {
 
   try {
     // Check how many posts need backfill
+    // boundary: better-sqlite3 raw row — prepare().get() row typing
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion -- boundary: better-sqlite3 raw row
     const countResult = sqlite
       .prepare("SELECT COUNT(*) as count FROM posts WHERE media_type IS NULL")
       .get() as { count: number } | undefined;
@@ -64,6 +66,8 @@ export async function backfillMediaType(): Promise<void> {
       // Get batch of posts with NULL media_type
       // CRITICAL: This is synchronous and blocks Event Loop
       // Small BATCH_SIZE (150) minimizes blocking time
+      // boundary: better-sqlite3 raw row
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion -- boundary: better-sqlite3 raw row
       const batch = sqlite
         .prepare(
           `SELECT id, file_url FROM posts 

--- a/src/main/db/client.ts
+++ b/src/main/db/client.ts
@@ -9,6 +9,7 @@ import * as schema from "./schema";
 import { logger } from "../lib/logger";
 import { getDatabasePaths, getLegacyDatabasePaths } from "./paths";
 import { SQLITE_BUSY_TIMEOUT_MS } from "../config/constants";
+import { getErrorCode } from "../../shared/utils/type-guards";
 
 type AppDatabase = BetterSQLite3Database<typeof schema>;
 
@@ -148,6 +149,7 @@ export async function initializeDatabase(): Promise<AppDatabase> {
   }
 
   sqliteInstance = sqlite;
+  // boundary: better-sqlite3 raw row — drizzle() generic schema typing to AppDatabase
   dbInstance = drizzle(sqlite, { schema }) as AppDatabase;
 
   try {
@@ -157,6 +159,8 @@ export async function initializeDatabase(): Promise<AppDatabase> {
     // Migration 0006_add_fts5_search.sql performs INSERT INTO posts_fts SELECT ...
     // This can block Main Process for 30+ seconds on databases with 500k+ records
     try {
+      // boundary: better-sqlite3 raw row — prepare().get() row typing
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion -- boundary: better-sqlite3 raw row
       const postCount = sqlite
         .prepare("SELECT COUNT(*) as count FROM posts")
         .get() as { count: number } | undefined;
@@ -347,6 +351,8 @@ export async function initializeDatabase(): Promise<AppDatabase> {
                   
                   // Initialize the single row with count from posts_fts (if table exists)
                   try {
+                    // boundary: better-sqlite3 raw row — prepare().get() row typing
+                    // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion -- boundary: better-sqlite3 raw row
                     const countResult = sqliteInstance
                       .prepare("SELECT COUNT(*) as count FROM posts_fts")
                       .get() as { count: number } | undefined;
@@ -417,9 +423,8 @@ export async function initializeDatabase(): Promise<AppDatabase> {
                   .run(entry.tag, Date.now());
               }
             } catch (migrationError: unknown) {
-              const error = migrationError as Error & { code?: string; message?: string };
-              const errorMessage = error.message || String(error);
-              const errorCode = error.code || "";
+              const errorMessage = migrationError instanceof Error ? migrationError.message : String(migrationError);
+              const errorCode = getErrorCode(migrationError) ?? "";
               
               // If it's a duplicate column/table/index error, log and mark as executed
               // (DB was created without migrations or from different schema)

--- a/src/main/db/maintenance-queue.ts
+++ b/src/main/db/maintenance-queue.ts
@@ -23,7 +23,7 @@ class MaintenanceQueue {
     const previousOperation = this.queue;
     
     // Create new promise that waits for previous operation and then executes current one
-    const currentOperation = previousOperation
+    const currentOperation: Promise<T> = previousOperation
       .then(async () => {
         this.isLocked = true;
         log.debug("[MaintenanceQueue] Operation started");
@@ -35,7 +35,7 @@ class MaintenanceQueue {
           log.debug("[MaintenanceQueue] Operation completed");
         }
       })
-      .catch((error) => {
+      .catch((error: unknown) => {
         this.isLocked = false;
         log.error("[MaintenanceQueue] Operation failed:", error);
         throw error;
@@ -44,7 +44,7 @@ class MaintenanceQueue {
     // Update queue to include current operation
     this.queue = currentOperation;
 
-    return currentOperation as Promise<T>;
+    return currentOperation;
   }
 
   /**

--- a/src/main/ipc/controllers/ArtistsController.ts
+++ b/src/main/ipc/controllers/ArtistsController.ts
@@ -141,7 +141,7 @@ export class ArtistsController extends BaseController {
       // Convert Date objects to numbers for Electron 39+ IPC serialization
       // Uses universal toIpcSafe utility to avoid code duplication
       // Note: postsCount is already a number, so it will pass through toIpcSafe unchanged
-      return toIpcSafe(result) as IpcArtist[];
+      return toIpcSafe(result);
     } catch (error) {
       log.error("[ArtistsController] Failed to get artists:", error);
       throw new Error("Failed to fetch artists");
@@ -201,7 +201,7 @@ export class ArtistsController extends BaseController {
       log.info(`[ArtistsController] Artist added/updated: ${inserted.name}`);
 
       // Convert Date objects to numbers for Electron 39+ IPC serialization
-      return toIpcSafe(inserted) as IpcArtist;
+      return toIpcSafe(inserted);
     } catch (error) {
       const msg = error instanceof Error ? error.message : String(error);
       log.error("[ArtistsController] Failed to add artist:", error);
@@ -276,7 +276,7 @@ export class ArtistsController extends BaseController {
       );
 
       // Convert Date objects to numbers for Electron 39+ IPC serialization
-      return toIpcSafe(result) as IpcArtist[];
+      return toIpcSafe(result);
     } catch (error) {
       log.error("[ArtistsController] Search failed:", error);
       return [];

--- a/src/main/ipc/controllers/FileController.ts
+++ b/src/main/ipc/controllers/FileController.ts
@@ -15,6 +15,7 @@ import { settings, SETTINGS_ID } from "../../db/schema";
 import { getProxyAgent } from "../../lib/proxy";
 import { IPC_CHANNELS } from "../channels";
 import { isResolvedPathWithinBase } from "../../utils/path-within-base";
+import { isErrnoException } from "../../../shared/utils/type-guards";
 
 const DEFAULT_DOWNLOAD_ROOT = path.join(app.getPath("downloads"), "BooruClient");
 const DOWNLOAD_QUEUE_FILE = "download-queue.json";
@@ -164,7 +165,7 @@ export class FileController extends BaseController {
       await unlink(p);
       this.notifyPendingDownloadStateChanged();
     } catch (e) {
-      if ((e as NodeJS.ErrnoException).code !== "ENOENT") {
+      if (isErrnoException(e) && e.code !== "ENOENT") {
         log.warn("[FileController] Failed to delete queue file:", e);
       }
     }
@@ -235,9 +236,9 @@ export class FileController extends BaseController {
         .get();
       return {
         duplicateFileBehavior:
-          (row?.duplicateFileBehavior as "skip" | "overwrite") || "skip",
+          z.enum(["skip", "overwrite"]).safeParse(row?.duplicateFileBehavior).data ?? "skip",
         downloadFolderStructure:
-          (row?.downloadFolderStructure as "flat" | "{artist_id}") || "flat",
+          z.enum(["flat", "{artist_id}"]).safeParse(row?.downloadFolderStructure).data ?? "flat",
       };
     } catch (e) {
       log.warn("[FileController] Failed to get download settings:", e);
@@ -656,7 +657,7 @@ export class FileController extends BaseController {
             await access(filePath);
             await unlink(filePath);
           } catch (unlinkError) {
-            if ((unlinkError as NodeJS.ErrnoException).code !== "ENOENT") {
+            if (isErrnoException(unlinkError) && unlinkError.code !== "ENOENT") {
               log.warn("[FileController] Failed to clean up partial file:", unlinkError);
             }
           }

--- a/src/main/ipc/controllers/MaintenanceController.ts
+++ b/src/main/ipc/controllers/MaintenanceController.ts
@@ -18,6 +18,7 @@ import {
 import { maintenanceQueue } from "../../db/maintenance-queue";
 import { settings, SETTINGS_ID } from "../../db/schema";
 import type { SyncService } from "../../services/sync-service";
+import { isErrnoException } from "../../../shared/utils/type-guards";
 import type { BackupService, AutoBackupInterval } from "../../services/backup-service";
 import { BACKUP_FILE_PREFIX, getDatabasePaths } from "../../db/paths";
 import {
@@ -422,7 +423,7 @@ export class MaintenanceController extends BaseController {
           await fs.promises.access(source);
           await fs.promises.rename(source, target);
         } catch (error) {
-          if ((error as NodeJS.ErrnoException).code !== "ENOENT") {
+          if (!isErrnoException(error) || error.code !== "ENOENT") {
             throw error;
           }
         }
@@ -446,6 +447,8 @@ export class MaintenanceController extends BaseController {
 
           // PRAGMA integrity_check returns rows: [{ integrity_check: "ok" }] when healthy
           // (better-sqlite3 pragma() with simple:false returns row objects, not string[])
+          // boundary: better-sqlite3 raw row
+          // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion -- boundary: better-sqlite3 raw row
           const integrityRows = tempDb
             .prepare("PRAGMA integrity_check")
             .all() as { integrity_check: string }[];
@@ -477,7 +480,7 @@ export class MaintenanceController extends BaseController {
             await fs.promises.access(bakPath);
             await fs.promises.rm(bakPath, { force: true });
           } catch (error) {
-            if ((error as NodeJS.ErrnoException).code !== "ENOENT") {
+            if (isErrnoException(error) && error.code !== "ENOENT") {
               log.warn(`[MaintenanceController] Failed to delete backup file ${bakPath}:`, error);
             }
           }

--- a/src/main/ipc/controllers/PlaylistController.ts
+++ b/src/main/ipc/controllers/PlaylistController.ts
@@ -875,7 +875,7 @@ export class PlaylistController extends BaseController {
         }
       }
 
-      return toIpcSafe(playlist) as IpcPlaylist;
+      return toIpcSafe(playlist);
     } catch (error) {
       log.error("[PlaylistController] Failed to create playlist:", error);
       throw error;
@@ -913,17 +913,18 @@ export class PlaylistController extends BaseController {
         const allConditions: SQL[] = [];
 
         if (includeConditions.length > 0) {
-          allConditions.push(
-            includeConditions.length === 1
-              ? includeConditions[0]
-              : (and(...includeConditions) as SQL)
-          );
+          if (includeConditions.length === 1) {
+            allConditions.push(includeConditions[0]);
+          } else {
+            const combined = and(...includeConditions);
+            if (combined) allConditions.push(combined);
+          }
         }
 
         if (excludeConditions.length > 0) {
           const excludeOr = or(...excludeConditions);
           if (excludeOr) {
-            allConditions.push(not(excludeOr) as SQL);
+            allConditions.push(not(excludeOr));
           }
         }
 
@@ -934,12 +935,11 @@ export class PlaylistController extends BaseController {
               SELECT 1
               FROM tag_blacklist bl
               WHERE instr(' ' || lower(${posts.tags}) || ' ', ' ' || lower(bl.tag) || ' ') > 0
-            )` as SQL
+            )`
           );
         }
 
-        const whereClause =
-          allConditions.length > 0 ? (and(...allConditions) as SQL) : undefined;
+        const whereClause = allConditions.length > 0 ? and(...allConditions) : undefined;
         const postCount = getSmartPlaylistPostCount(db, whereClause);
 
         return {
@@ -954,7 +954,7 @@ export class PlaylistController extends BaseController {
 
       log.info(`[PlaylistController] Retrieved ${result.length} playlists with stats`);
 
-      return toIpcSafe(result) as IpcPlaylistWithStats[];
+      return toIpcSafe(result);
     } catch (error) {
       log.error("[PlaylistController] Failed to get playlists:", error);
       throw error;
@@ -986,7 +986,7 @@ export class PlaylistController extends BaseController {
         return null;
       }
 
-      return toIpcSafe(result) as IpcPlaylist;
+      return toIpcSafe(result);
     } catch (error) {
       log.error(`[PlaylistController] Failed to get playlist ${playlistId}:`, error);
       throw error;
@@ -1044,7 +1044,7 @@ export class PlaylistController extends BaseController {
 
       log.info(`[PlaylistController] Updated playlist: ${playlistId}`);
 
-      return toIpcSafe(result[0]) as IpcPlaylist;
+      return toIpcSafe(result[0]);
     } catch (error) {
       log.error(`[PlaylistController] Failed to update playlist ${playlistId}:`, error);
       throw error;
@@ -1429,12 +1429,8 @@ export class PlaylistController extends BaseController {
         conditions.push(eq(posts.mediaType, "video"));
       } else if (filters?.mediaType === "images") {
         // Images OR NULL (NULL treated as image during backfill)
-        conditions.push(
-          or(
-            eq(posts.mediaType, "image"),
-            sql`${posts.mediaType} IS NULL`
-          ) as SQL
-        );
+        const imageOrNull = or(eq(posts.mediaType, "image"), sql`${posts.mediaType} IS NULL`);
+        if (imageOrNull) conditions.push(imageOrNull);
       }
 
       const blacklistedTags = getAllBlacklistedTags();
@@ -1444,7 +1440,7 @@ export class PlaylistController extends BaseController {
             SELECT 1
             FROM tag_blacklist bl
             WHERE instr(' ' || lower(${posts.tags}) || ' ', ' ' || lower(bl.tag) || ' ') > 0
-          )` as SQL
+          )`
         );
       }
 
@@ -1467,6 +1463,8 @@ export class PlaylistController extends BaseController {
           createdAt: posts.createdAt,
           isViewed: posts.isViewed,
           isFavorited: posts.isFavorited,
+          lastViewedAt: posts.lastViewedAt,
+          viewCount: posts.viewCount,
         })
         .from(playlistEntries)
         .innerJoin(posts, eq(playlistEntries.postId, posts.id))
@@ -1490,7 +1488,7 @@ export class PlaylistController extends BaseController {
         `[PlaylistController] Retrieved ${result.length} posts from playlist ${playlistId} (page ${page})`
       );
 
-      return toIpcSafe(result) as IpcPost[];
+      return toIpcSafe(result);
     } catch (error) {
       log.error(`[PlaylistController] Failed to get playlist posts for ${playlistId}:`, error);
       throw error;
@@ -1798,12 +1796,8 @@ export class PlaylistController extends BaseController {
       if (filters?.mediaType === "videos") {
         globalConditions.push(eq(posts.mediaType, "video"));
       } else if (filters?.mediaType === "images") {
-        globalConditions.push(
-          or(
-            eq(posts.mediaType, "image"),
-            sql`${posts.mediaType} IS NULL`
-          ) as SQL
-        );
+        const imageOrNull = or(eq(posts.mediaType, "image"), sql`${posts.mediaType} IS NULL`);
+        if (imageOrNull) globalConditions.push(imageOrNull);
       }
 
       const blacklistedTags = getAllBlacklistedTags();
@@ -1813,7 +1807,7 @@ export class PlaylistController extends BaseController {
             SELECT 1
             FROM tag_blacklist bl
             WHERE instr(' ' || lower(${posts.tags}) || ' ', ' ' || lower(bl.tag) || ' ') > 0
-          )` as SQL
+          )`
         );
       }
 
@@ -1842,6 +1836,8 @@ export class PlaylistController extends BaseController {
             createdAt: posts.createdAt,
             isViewed: posts.isViewed,
             isFavorited: posts.isFavorited,
+            lastViewedAt: posts.lastViewedAt,
+            viewCount: posts.viewCount,
           })
           .from(playlistEntries)
           .innerJoin(posts, eq(playlistEntries.postId, posts.id))
@@ -1865,7 +1861,7 @@ export class PlaylistController extends BaseController {
           `[PlaylistController] Resolved ${result.length} posts from static playlist ${playlistId} (page ${page})`
         );
 
-        return toIpcSafe(result) as IpcPost[];
+        return toIpcSafe(result);
       }
 
       // Smart playlist: parse query_json and build dynamic query
@@ -1926,17 +1922,18 @@ export class PlaylistController extends BaseController {
         if (includeConditions.length === 1) {
           allConditions.push(includeConditions[0]);
         } else {
-          allConditions.push(and(...includeConditions) as SQL);
+          const combined = and(...includeConditions);
+          if (combined) allConditions.push(combined);
         }
       }
 
       if (excludeConditions.length > 0) {
         if (excludeConditions.length === 1) {
-          allConditions.push(not(excludeConditions[0]) as SQL);
+          allConditions.push(not(excludeConditions[0]));
         } else {
           const orCondition = or(...excludeConditions);
           if (orCondition) {
-            allConditions.push(not(orCondition) as SQL);
+            allConditions.push(not(orCondition));
           }
         }
       }
@@ -1969,6 +1966,8 @@ export class PlaylistController extends BaseController {
                 createdAt: posts.createdAt,
                 isViewed: posts.isViewed,
                 isFavorited: posts.isFavorited,
+                lastViewedAt: posts.lastViewedAt,
+                viewCount: posts.viewCount,
               })
               .from(posts)
               .where(whereClause);
@@ -1985,7 +1984,7 @@ export class PlaylistController extends BaseController {
             log.info(
               `[PlaylistController] Local DB query returned ${result.length} posts for smart playlist ${playlistId}`
             );
-            return toIpcSafe(result) as IpcPost[];
+            return toIpcSafe(result);
           } catch (error) {
             log.error(`[PlaylistController] Local DB query failed for smart playlist ${playlistId}:`, error);
             return []; // Return empty array on error, continue with remote results
@@ -2155,7 +2154,7 @@ export class PlaylistController extends BaseController {
           
           return true;
         })
-        .map((post) => {
+        .map((post): IpcPost => {
           const isVideo = isVideoUrl(post.fileUrl);
           return {
             id: 0, // Remote posts don't have local DB ID
@@ -2172,7 +2171,9 @@ export class PlaylistController extends BaseController {
             createdAt: post.createdAt.getTime(),
             isViewed: false, // Remote posts are never viewed locally
             isFavorited: false, // Remote posts are never favorited locally
-          } as IpcPost;
+            lastViewedAt: null,
+            viewCount: 0,
+          };
         });
 
       // Sort or shuffle posts based on isRandom flag

--- a/src/main/ipc/controllers/PostsController.ts
+++ b/src/main/ipc/controllers/PostsController.ts
@@ -384,7 +384,7 @@ export class PostsController extends BaseController {
       const tokenCondition =
         termConditions.length === 1
           ? termConditions[0]
-          : (or(...termConditions) as SQL);
+          : (or(...termConditions) ?? termConditions[0]);
 
       tokenConditions.push(token.exclude ? not(tokenCondition) : tokenCondition);
     }
@@ -393,9 +393,10 @@ export class PostsController extends BaseController {
       return sql`1 = 1`;
     }
 
-    return tokenConditions.length === 1
-      ? tokenConditions[0]
-      : (and(...tokenConditions) as SQL);
+    if (tokenConditions.length === 1) {
+      return tokenConditions[0];
+    }
+    return and(...tokenConditions) ?? tokenConditions[0];
   }
 
   private createSearchTermCondition(term: ParsedSearchTerm): SQL | null {
@@ -505,7 +506,7 @@ export class PostsController extends BaseController {
                   WHERE posts_fts.rowid = ${posts.id} 
                     AND posts_fts MATCH ${ftsQuery}
                 )`
-              ) as SQL
+              )
             );
           } else {
             // Only AI posts: FTS5 match
@@ -514,7 +515,7 @@ export class PostsController extends BaseController {
                 SELECT 1 FROM posts_fts 
                 WHERE posts_fts.rowid = ${posts.id} 
                   AND posts_fts MATCH ${ftsQuery}
-              )` as SQL
+              )`
             );
           }
         }
@@ -534,11 +535,13 @@ export class PostsController extends BaseController {
           (pattern) => sql`${posts.tags} LIKE ${pattern} ESCAPE '\\'`
         );
         if (aiConditions.length > 0) {
-          const aiOrCondition = or(...aiConditions) as SQL;
-          if (filters.aiFilter === "hide") {
-            conditions.push(not(aiOrCondition));
-          } else {
-            conditions.push(aiOrCondition);
+          const aiOrCondition = or(...aiConditions);
+          if (aiOrCondition) {
+            if (filters.aiFilter === "hide") {
+              conditions.push(not(aiOrCondition));
+            } else {
+              conditions.push(aiOrCondition);
+            }
           }
         }
       }
@@ -553,12 +556,8 @@ export class PostsController extends BaseController {
       conditions.push(eq(posts.mediaType, "video"));
     } else if (filters?.mediaType === "images") {
       // Images OR NULL (NULL treated as image during backfill)
-      conditions.push(
-        or(
-          eq(posts.mediaType, "image"),
-          sql`${posts.mediaType} IS NULL`
-        ) as SQL
-      );
+      const imageOrNull = or(eq(posts.mediaType, "image"), sql`${posts.mediaType} IS NULL`);
+      if (imageOrNull) conditions.push(imageOrNull);
     }
 
     const blacklistedTags = getAllBlacklistedTags();
@@ -568,7 +567,7 @@ export class PostsController extends BaseController {
           SELECT 1
           FROM tag_blacklist bl
           WHERE instr(' ' || lower(${posts.tags}) || ' ', ' ' || lower(bl.tag) || ' ') > 0
-        )` as SQL
+        )`
       );
     }
 
@@ -666,10 +665,13 @@ export class PostsController extends BaseController {
             title: posts.title,
             rating: posts.rating,
             tags: posts.tags,
+            mediaType: posts.mediaType,
             publishedAt: posts.publishedAt,
             createdAt: posts.createdAt,
             isViewed: posts.isViewed,
             isFavorited: posts.isFavorited,
+            lastViewedAt: posts.lastViewedAt,
+            viewCount: posts.viewCount,
           })
           .from(posts)
           .innerJoin(artists, joinConditions)
@@ -692,7 +694,7 @@ export class PostsController extends BaseController {
         );
 
         // Convert Date objects to numbers for Electron 39+ IPC serialization
-        return toIpcSafe(result) as IpcPost[];
+        return toIpcSafe(result);
       }
 
       // Standard query path (no sinceTracking filter)
@@ -716,10 +718,13 @@ export class PostsController extends BaseController {
           title: posts.title,
           rating: posts.rating,
           tags: posts.tags,
+          mediaType: posts.mediaType,
           publishedAt: posts.publishedAt,
           createdAt: posts.createdAt,
           isViewed: posts.isViewed,
           isFavorited: posts.isFavorited,
+          lastViewedAt: posts.lastViewedAt,
+          viewCount: posts.viewCount,
         })
         .from(posts)
         .where(whereClause);
@@ -742,7 +747,7 @@ export class PostsController extends BaseController {
 
       // Convert Date objects to numbers for Electron 39+ IPC serialization
       // Uses universal toIpcSafe utility to avoid code duplication
-      return toIpcSafe(result) as IpcPost[];
+      return toIpcSafe(result);
     } catch (error) {
       log.error("[PostsController] Failed to get posts:", error);
       // Re-throw original error to preserve stack trace and context
@@ -1134,9 +1139,8 @@ export class PostsController extends BaseController {
             newPostPostId: number;
             newFavoriteState: boolean;
           };
-      let result: ToggleFavoriteResult | null = null;
 
-      db.transaction((tx) => {
+      const result = db.transaction((tx): ToggleFavoriteResult => {
         // Use shared helper method to find post
         const existingPost = this.findPostInTransaction(tx, postId, postData);
 
@@ -1155,132 +1159,115 @@ export class PostsController extends BaseController {
             `[PostsController] Post ${existingPost.id} (postId: ${existingPost.postId}) favorite toggled in transaction`
           );
 
-          result = {
+          return {
             existingPostId: existingPost.id,
             existingPostPostId: existingPost.postId,
             newFavoriteState: newState,
           };
-        } else {
-          // Post doesn't exist - can only add to favorites (not remove)
-          // For toggle operation, if post doesn't exist, we're adding it to favorites (isFavorite = true)
-          // Validate that postData is provided for network posts (Browse tab)
-          if (!postData) {
-            throw new Error(
-              `Post with id ${postId} not found. For external posts from Browse, postData must be provided when adding to favorites.`
-            );
-          }
+        }
 
-          // Validate required fields for NOT NULL constraints
-          // Schema requires: fileUrl (NOT NULL), previewUrl (NOT NULL), tags (NOT NULL)
-          if (!postData.fileUrl || postData.fileUrl.trim() === "") {
-            throw new Error(
-              `Post data validation failed: fileUrl is required and cannot be empty (NOT NULL constraint)`
-            );
-          }
-          if (!postData.previewUrl || postData.previewUrl.trim() === "") {
-            throw new Error(
-              `Post data validation failed: previewUrl is required and cannot be empty (NOT NULL constraint)`
-            );
-          }
+        // Post doesn't exist - can only add to favorites (not remove)
+        // Validate that postData is provided for network posts (Browse tab)
+        if (!postData) {
+          throw new Error(
+            `Post with id ${postId} not found. For external posts from Browse, postData must be provided when adding to favorites.`
+          );
+        }
 
-          // CRITICAL: Check if artist exists before inserting post (FOREIGN KEY constraint)
-          // SECURITY: For external posts from Browse, always use EXTERNAL_ARTIST_ID
-          // Never trust artistId from Renderer - it could be hijacked to target existing artists
-          const targetArtistId = EXTERNAL_ARTIST_ID;
+        // Validate required fields for NOT NULL constraints
+        // Schema requires: fileUrl (NOT NULL), previewUrl (NOT NULL), tags (NOT NULL)
+        if (!postData.fileUrl || postData.fileUrl.trim() === "") {
+          throw new Error(
+            `Post data validation failed: fileUrl is required and cannot be empty (NOT NULL constraint)`
+          );
+        }
+        if (!postData.previewUrl || postData.previewUrl.trim() === "") {
+          throw new Error(
+            `Post data validation failed: previewUrl is required and cannot be empty (NOT NULL constraint)`
+          );
+        }
 
-          // Use synchronous select query inside transaction
-          // Drizzle with better-sqlite3 executes queries synchronously inside transactions
-          const existingArtist = tx
-            .select()
-            .from(artists)
-            .where(eq(artists.id, targetArtistId))
-            .limit(1)
-            .get();
+        // CRITICAL: Check if artist exists before inserting post (FOREIGN KEY constraint)
+        // SECURITY: For external posts from Browse, always use EXTERNAL_ARTIST_ID
+        // Never trust artistId from Renderer - it could be hijacked to target existing artists
+        const targetArtistId = EXTERNAL_ARTIST_ID;
 
-          if (!existingArtist) {
-            // Artist doesn't exist - create placeholder artist to satisfy FOREIGN KEY constraint
-            // Use explicit id (SQLite allows this even with autoIncrement by using INSERT with explicit id)
-            const now = new Date();
-            tx.insert(artists)
-              .values({
-                id: targetArtistId, // Explicit ID for placeholder artist
-                name: `Artist ${targetArtistId}`,
-                tag: `${EXTERNAL_ARTIST_TAG_PREFIX}${targetArtistId}`, // Unique tag for placeholder
-                provider: "rule34", // Default provider
-                type: "tag", // Default type
-                apiEndpoint: "", // Safe default (required field)
-                lastPostId: 0,
-                newPostsCount: 0,
-                createdAt: now,
-              })
-              .run();
+        // Use synchronous select query inside transaction
+        // Drizzle with better-sqlite3 executes queries synchronously inside transactions
+        const existingArtist = tx
+          .select()
+          .from(artists)
+          .where(eq(artists.id, targetArtistId))
+          .limit(1)
+          .get();
 
-            log.debug(
-              `[PostsController] Created placeholder artist ${targetArtistId} for external post in transaction`
-            );
-          }
-
-          // Create post with isFavorited = true (since we're adding to favorites via toggle)
+        if (!existingArtist) {
+          // Artist doesn't exist - create placeholder artist to satisfy FOREIGN KEY constraint
           const now = new Date();
-          const publishedAt = postData.publishedAt
-            ? new Date(postData.publishedAt)
-            : now;
-
-          tx.insert(posts)
+          tx.insert(artists)
             .values({
-              postId: postData.postId,
-              artistId: EXTERNAL_ARTIST_ID, // SECURITY: Always use EXTERNAL_ARTIST_ID for external posts
-              fileUrl: postData.fileUrl,
-              previewUrl: postData.previewUrl,
-              sampleUrl: postData.sampleUrl ?? "",
-              title: "",
-              rating: postData.rating ?? "",
-              tags: postData.tags ?? "", // NOT NULL constraint - empty string is valid
-              mediaType: isVideoUrl(postData.fileUrl) ? "video" : "image",
-              publishedAt: publishedAt,
+              id: targetArtistId, // Explicit ID for placeholder artist
+              name: `Artist ${targetArtistId}`,
+              tag: `${EXTERNAL_ARTIST_TAG_PREFIX}${targetArtistId}`, // Unique tag for placeholder
+              provider: "rule34", // Default provider
+              type: "tag", // Default type
+              apiEndpoint: "", // Safe default (required field)
+              lastPostId: 0,
+              newPostsCount: 0,
               createdAt: now,
-              isViewed: false,
-              isFavorited: true, // Set to true since we're adding to favorites
             })
             .run();
 
           log.debug(
-            `[PostsController] Created new post (postId: ${postData.postId}) and set as favorited in transaction`
+            `[PostsController] Created placeholder artist ${targetArtistId} for external post in transaction`
           );
-
-          result = {
-            newPostPostId: postData.postId,
-            newFavoriteState: true, // New posts are always favorited when created via toggle
-          };
         }
+
+        // Create post with isFavorited = true (since we're adding to favorites via toggle)
+        const now = new Date();
+        const publishedAt = postData.publishedAt
+          ? new Date(postData.publishedAt)
+          : now;
+
+        tx.insert(posts)
+          .values({
+            postId: postData.postId,
+            artistId: EXTERNAL_ARTIST_ID, // SECURITY: Always use EXTERNAL_ARTIST_ID for external posts
+            fileUrl: postData.fileUrl,
+            previewUrl: postData.previewUrl,
+            sampleUrl: postData.sampleUrl ?? "",
+            title: "",
+            rating: postData.rating ?? "",
+            tags: postData.tags ?? "", // NOT NULL constraint - empty string is valid
+            mediaType: isVideoUrl(postData.fileUrl) ? "video" : "image",
+            publishedAt: publishedAt,
+            createdAt: now,
+            isViewed: false,
+            isFavorited: true, // Set to true since we're adding to favorites
+          })
+          .run();
+
+        log.debug(
+          `[PostsController] Created new post (postId: ${postData.postId}) and set as favorited in transaction`
+        );
+
+        return {
+          newPostPostId: postData.postId,
+          newFavoriteState: true, // New posts are always favorited when created via toggle
+        };
       });
 
-      if (!result) {
-        throw new Error(
-          `Post with id ${postId} not found or not updated. For external posts from Browse, postData must be provided.`
+      if ("existingPostId" in result) {
+        log.info(
+          `[PostsController] Post ${result.existingPostId} (postId: ${result.existingPostPostId}) favorite toggled to ${result.newFavoriteState}`
         );
+        return result.newFavoriteState;
       }
 
-      if ("existingPostId" in result) {
-        const r = result as {
-          existingPostId: number;
-          existingPostPostId: number;
-          newFavoriteState: boolean;
-        };
-        log.info(
-          `[PostsController] Post ${r.existingPostId} (postId: ${r.existingPostPostId}) favorite toggled to ${r.newFavoriteState}`
-        );
-        return r.newFavoriteState;
-      } else {
-        const r = result as {
-          newPostPostId: number;
-          newFavoriteState: boolean;
-        };
-        log.info(
-          `[PostsController] Post new (postId: ${r.newPostPostId}) favorite toggled to ${r.newFavoriteState}`
-        );
-        return r.newFavoriteState;
-      }
+      log.info(
+        `[PostsController] Post new (postId: ${result.newPostPostId}) favorite toggled to ${result.newFavoriteState}`
+      );
+      return result.newFavoriteState;
     } catch (error) {
       log.error("[PostsController] Failed to toggle favorite:", error);
       // Re-throw original error to preserve stack trace and context
@@ -1440,7 +1427,7 @@ export class PostsController extends BaseController {
 
       if (existingPost) {
         log.debug(`[PostsController] Shadow insert: Post already exists (id: ${existingPost.id}, postId: ${request.postId})`);
-        return toIpcSafe(existingPost) as IpcPost;
+        return toIpcSafe(existingPost);
       }
 
       // Step 2: Fetch post data from API (Main process controls data source)
@@ -1576,7 +1563,7 @@ export class PostsController extends BaseController {
       }
 
       // Step 6: Return IPC-safe Post object
-      return toIpcSafe(insertedPost) as IpcPost;
+      return toIpcSafe(insertedPost);
     } catch (error) {
       const errorMessage = error instanceof Error ? error.message : String(error);
       log.error(`[PostsController] Failed to shadow insert post (postId: ${request.postId}):`, {

--- a/src/main/ipc/controllers/SearchController.ts
+++ b/src/main/ipc/controllers/SearchController.ts
@@ -44,8 +44,7 @@ const ResolveTagsArgsSchema = z.tuple([z.array(z.string().min(1)).max(100)]);
 const ResolveTagsByTypeArgsSchema = z.tuple([
   z.array(z.string().min(1)).max(100),
   z.number().int().refine((n): n is TagType => {
-    const allowed = Object.values(TAG_TYPES) as number[];
-    return allowed.includes(n);
+    return Object.values(TAG_TYPES).some((v) => v === n);
   }, "Invalid tag type"),
 ]);
 

--- a/src/main/ipc/controllers/SettingsController.ts
+++ b/src/main/ipc/controllers/SettingsController.ts
@@ -20,7 +20,7 @@ import {
 import type { BetterSQLite3Database } from "drizzle-orm/better-sqlite3";
 import type * as schema from "../../db/schema";
 import { z } from "zod";
-import { PROVIDER_IDS, type ProviderId } from "../../../shared/constants";
+import { PROVIDER_IDS } from "../../../shared/constants";
 import { normalizeCredentialsInput } from "../../../shared/utils/parse-credentials";
 import { getDecryptedCredentialsFromRecord, hasConfiguredApiKey } from "../../utils/decrypted-credentials";
 
@@ -71,7 +71,7 @@ function mapSettingsToIpc(
   return {
     hasSettingsRecord,
     userId: dbSettings.userId ?? "",
-    provider: (dbSettings.provider as ProviderId) ?? "rule34",
+    provider: z.enum(PROVIDER_IDS).safeParse(dbSettings.provider).data ?? "rule34",
     // True when a key is stored; decrypt must succeed for API calls, not for gate dismissal.
     hasApiKey: hasConfiguredApiKey({
       encryptedApiKey: dbSettings.encryptedApiKey,
@@ -102,10 +102,10 @@ function mapSettingsToIpc(
     })(),
     downloadFolder: dbSettings.downloadFolder ?? null,
     duplicateFileBehavior:
-      (dbSettings.duplicateFileBehavior as "skip" | "overwrite") || "skip",
+      z.enum(["skip", "overwrite"]).safeParse(dbSettings.duplicateFileBehavior).data ?? "skip",
     downloadFolderStructure:
-      (dbSettings.downloadFolderStructure as "flat" | "{artist_id}") || "flat",
-    theme: (dbSettings.theme as ThemePreference) || "system",
+      z.enum(["flat", "{artist_id}"]).safeParse(dbSettings.downloadFolderStructure).data ?? "flat",
+    theme: ThemePreferenceSchema.safeParse(dbSettings.theme).data ?? "system",
     autoSyncOnStartup: !!dbSettings.autoSyncOnStartup,
     syncIntervalMinutes: dbSettings.syncIntervalMinutes ?? 0,
     backupRetention: dbSettings.backupRetention ?? 5,
@@ -318,7 +318,7 @@ export class SettingsController extends BaseController {
           const finalProvider =
             provider !== undefined && PROVIDER_IDS.includes(provider)
               ? provider
-              : ((existing.provider as ProviderId | undefined) ?? "rule34");
+              : (z.enum(PROVIDER_IDS).safeParse(existing.provider).data ?? "rule34");
           // CRITICAL: Use existing.id instead of SETTINGS_ID to ensure we update the correct record
           const targetId = existing.id;
 

--- a/src/main/ipc/handlers/updates.ts
+++ b/src/main/ipc/handlers/updates.ts
@@ -34,7 +34,8 @@ const buildUpdatesUnreadConditions = (filters: z.infer<typeof PostFilterSchema> 
   if (filters?.mediaType === "videos") {
     conditions.push(eq(posts.mediaType, "video"));
   } else if (filters?.mediaType === "images") {
-    conditions.push(or(eq(posts.mediaType, "image"), sql`${posts.mediaType} IS NULL`) as SQL);
+    const imageOrNull = or(eq(posts.mediaType, "image"), sql`${posts.mediaType} IS NULL`);
+    if (imageOrNull) conditions.push(imageOrNull);
   }
 
   if (filters?.tags && filters.tags.trim().length > 0) {

--- a/src/main/lib/backup-sidecar.ts
+++ b/src/main/lib/backup-sidecar.ts
@@ -2,10 +2,12 @@ import fs from "node:fs";
 import path from "node:path";
 import { app } from "electron";
 import log from "electron-log";
+import { z } from "zod";
 import { eq } from "drizzle-orm";
 import type { AutoBackupInterval } from "../services/backup-service";
 import { settings, SETTINGS_ID } from "../db/schema";
 import { getDb } from "../db/client";
+import { isErrnoException } from "../../shared/utils/type-guards";
 
 export const BACKUP_SIDECAR_SUFFIX = ".settings.json";
 
@@ -28,21 +30,24 @@ function readBackupScheduleFromDisk(): BackupSidecarV1["backupSchedule"] {
     lastAutoBackupAt: null,
   };
 
+  const BackupScheduleSchema = z.object({
+    autoBackupInterval: z.enum(["never", "daily", "weekly"]).optional(),
+    lastAutoBackupAt: z.number().nullable().optional(),
+  });
+
   const configPath = getElectronStoreConfigPath("backup-settings");
   try {
     const raw = fs.readFileSync(configPath, "utf-8");
-    const parsed = JSON.parse(raw) as Partial<{
-      autoBackupInterval?: AutoBackupInterval;
-      lastAutoBackupAt?: number | null;
-    }>;
+    const parsed = BackupScheduleSchema.safeParse(JSON.parse(raw));
+    const data = parsed.success ? parsed.data : {};
 
     return {
-      autoBackupInterval: parsed.autoBackupInterval ?? defaults.autoBackupInterval,
+      autoBackupInterval: data.autoBackupInterval ?? defaults.autoBackupInterval,
       lastAutoBackupAt:
-        typeof parsed.lastAutoBackupAt === "number" ? parsed.lastAutoBackupAt : null,
+        typeof data.lastAutoBackupAt === "number" ? data.lastAutoBackupAt : null,
     };
   } catch (error) {
-    if ((error as NodeJS.ErrnoException).code !== "ENOENT") {
+    if (isErrnoException(error) && error.code !== "ENOENT") {
       log.warn("[BackupSidecar] Failed to read backup schedule file:", error);
     }
     return defaults;
@@ -71,13 +76,23 @@ export function restoreBackupSidecar(backupDbPath: string): boolean {
     return false;
   }
 
+  const BackupSidecarSchema = z.object({
+    version: z.literal(1),
+    exportedAt: z.string(),
+    backupSchedule: z.object({
+      autoBackupInterval: z.enum(["never", "daily", "weekly"]),
+      lastAutoBackupAt: z.number().nullable(),
+    }),
+  });
+
   try {
     const raw = fs.readFileSync(sidecarPath, "utf-8");
-    const parsed = JSON.parse(raw) as BackupSidecarV1;
-    if (parsed.version !== 1 || !parsed.backupSchedule) {
+    const parseResult = BackupSidecarSchema.safeParse(JSON.parse(raw));
+    if (!parseResult.success) {
       log.warn("[BackupSidecar] Unsupported sidecar version, skipping restore");
       return false;
     }
+    const parsed = parseResult.data;
 
     const configPath = getElectronStoreConfigPath("backup-settings");
     fs.mkdirSync(path.dirname(configPath), { recursive: true });

--- a/src/main/providers/gelbooru-provider.ts
+++ b/src/main/providers/gelbooru-provider.ts
@@ -15,6 +15,20 @@ import { z } from "zod";
 import { ProviderThrottle, pickRandomUA } from "./provider-throttle";
 import { getProxyAgent } from "../lib/proxy";
 
+type GelbooruTagItem = {
+  value: string;
+  label: string;
+  category?: unknown;
+  type?: unknown;
+};
+
+function isGelbooruTagItem(item: unknown): item is GelbooruTagItem {
+  if (typeof item !== "object" || item === null) return false;
+  const v = Reflect.get(item, "value");
+  const l = Reflect.get(item, "label");
+  return typeof v === "string" && typeof l === "string";
+}
+
 export class GelbooruProvider implements IBooruProvider {
   readonly id = "gelbooru";
   readonly name = "Gelbooru";
@@ -93,25 +107,14 @@ export class GelbooruProvider implements IBooruProvider {
         // Gelbooru format: [{"value":"tag_name","label":"tag_name (123)","type":"0"}]
         const results: SearchResults[] = [];
         for (const item of data) {
-          if (
-            typeof item === "object" &&
-            item !== null &&
-            "value" in item &&
-            "label" in item &&
-            typeof (item as { value: unknown }).value === "string" &&
-            typeof (item as { label: unknown }).label === "string"
-          ) {
-            const typed = item as {
-              value: string;
-              label: string;
-              category?: string;
-              type?: string;
-            };
+          if (isGelbooruTagItem(item)) {
             results.push({
-              id: typed.value,
-              label: typed.label,
-              value: typed.value,
-              type: typed.category || typed.type,
+              id: item.value,
+              label: item.label,
+              value: item.value,
+              type: typeof item.category === "string" ? item.category
+                  : typeof item.type === "string" ? item.type
+                  : undefined,
             });
           }
         }
@@ -189,9 +192,7 @@ export class GelbooruProvider implements IBooruProvider {
       if (Array.isArray(data)) {
         rawPosts = data;
       } else if (data && typeof data === "object" && data !== null && "post" in data) {
-        // Type guard: check if data has 'post' property
-        const dataWithPost = data as { post: unknown };
-        const postData = dataWithPost.post;
+        const postData: unknown = data.post;
         if (Array.isArray(postData)) {
           rawPosts = postData;
         } else if (postData && typeof postData === "object") {

--- a/src/main/providers/rule34-provider.ts
+++ b/src/main/providers/rule34-provider.ts
@@ -2,6 +2,7 @@ import axios from "axios";
 import { XMLParser } from "fast-xml-parser";
 import { logger } from "../lib/logger";
 import { selectBestPreview } from "../lib/media-utils";
+import { isRecord } from "../../shared/utils/type-guards";
 import {
   REQUEST_TIMEOUT,
   AUTOCOMPLETE_TIMEOUT,
@@ -446,7 +447,7 @@ export class Rule34Provider implements IBooruProvider {
       // Map each raw post to BooruPost format
       const mappedPosts = postsRaw
         .map((raw: unknown) => this.mapPostFromXml(raw))
-        .filter((p: BooruPost | null) => p !== null) as BooruPost[];
+        .filter((p: BooruPost | null): p is BooruPost => p !== null);
 
       return mappedPosts;
     } catch (error) {
@@ -463,10 +464,8 @@ export class Rule34Provider implements IBooruProvider {
    * @returns BooruPost object or null if invalid
    */
   private mapPostFromXml(raw: unknown): BooruPost | null {
-    if (!raw || typeof raw !== "object") return null;
-
-    // Type guard: ensure raw is a record with string keys
-    const post = raw as Record<string, unknown>;
+    if (!isRecord(raw)) return null;
+    const post = raw;
 
     // With attributeNamePrefix: "", attributes are accessible directly
     // No need for "@_" prefix - access post.id, post.file_url, etc.

--- a/src/main/services/backup-service.ts
+++ b/src/main/services/backup-service.ts
@@ -34,16 +34,23 @@ type BackupStoreConstructor = new (options: {
   defaults: BackupStoreSchema;
 }) => BackupStoreContract;
 
+function isBackupStoreConstructor(v: unknown): v is BackupStoreConstructor {
+  return typeof v === "function";
+}
+
 const require = createRequire(import.meta.url);
-const storeModule = require("electron-store");
-const storeModuleDefault =
+const storeModule: unknown = require("electron-store");
+const storeModuleDefault: unknown =
   typeof storeModule === "object" && storeModule !== null && "default" in storeModule
     ? storeModule.default
     : null;
-const StoreConstructor: BackupStoreConstructor =
-  typeof storeModule === "function"
-    ? (storeModule as BackupStoreConstructor)
-    : (storeModuleDefault as BackupStoreConstructor);
+const resolvedConstructor = isBackupStoreConstructor(storeModule)
+  ? storeModule
+  : storeModuleDefault;
+if (!isBackupStoreConstructor(resolvedConstructor)) {
+  throw new Error("[backup-service] electron-store module did not export a constructor");
+}
+const StoreConstructor: BackupStoreConstructor = resolvedConstructor;
 
 let store: BackupStoreContract | null = null;
 

--- a/src/main/utils/ipc-serialization.ts
+++ b/src/main/utils/ipc-serialization.ts
@@ -1,16 +1,18 @@
 /**
  * IPC Serialization Utilities
- * 
+ *
  * Converts database objects to IPC-safe format by recursively transforming Date objects to numbers.
  * Required for Electron 39+ IPC serialization compatibility (V8 Structured Clone Algorithm).
- * 
+ *
  * Performance: This function is synchronous and performs recursive object traversal.
  * For large datasets (1000+ records), consider batching or using Worker threads.
  * However, for typical IPC responses (50-100 records per request), this is acceptable.
- * 
+ *
  * Security: Uses proper type guards and runtime checks instead of `as any` to prevent
  * unexpected data types from being serialized through IPC.
  */
+
+import type { IpcSafe } from "../../shared/types/ipc";
 
 /**
  * Type guard to check if value is a Date object.
@@ -48,56 +50,42 @@ function isSerializablePrimitive(
   );
 }
 
+type ToIpcSafeResult<T> = T extends Date
+  ? number
+  : T extends (infer U)[]
+    ? ToIpcSafeResult<U>[]
+    : T extends object
+      ? IpcSafe<T>
+      : T;
+
 /**
  * Recursively converts Date objects to numbers (timestamps in milliseconds) for IPC serialization.
  * Handles objects, arrays, and nested structures with proper type guards and runtime checks.
- * 
- * Type-safe: Uses TypeScript's type system with proper type guards instead of `as any`.
- * Runtime-safe: Validates data types at runtime to prevent unexpected values from being serialized.
- * 
+ *
  * @param data - Data to convert (object, array, or primitive)
  * @returns IPC-safe data with Date objects converted to numbers
  * @throws {TypeError} If data contains non-serializable types (functions, symbols, etc.)
- * 
- * @example
- * ```typescript
- * const dbPost = { id: 1, publishedAt: new Date(), createdAt: new Date() };
- * const ipcPost = toIpcSafe(dbPost); // { id: 1, publishedAt: 1234567890, createdAt: 1234567890 }
- * 
- * const dbArtists = [{ id: 1, createdAt: new Date() }, { id: 2, createdAt: new Date() }];
- * const ipcArtists = toIpcSafe(dbArtists); // Array with Date converted to numbers
- * ```
  */
-export function toIpcSafe<T>(data: T): T extends Date
-  ? number
-  : T extends (infer U)[]
-  ? U extends Date
-    ? number[]
-    : ReturnType<typeof toIpcSafe<U>>[]
-  : T extends object
-  ? {
-      [K in keyof T]: T[K] extends Date
-        ? number
-        : T[K] extends Date | null
-        ? number | null
-        : ReturnType<typeof toIpcSafe<T[K]>>
-    }
-  : T {
+export function toIpcSafe<T>(data: T): ToIpcSafeResult<T> {
   // Handle Date objects
   if (isDate(data)) {
-    return data.getTime() as ReturnType<typeof toIpcSafe<T>>;
+    // boundary: toIpcSafe Date → number branch of conditional return type
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion -- boundary: toIpcSafe
+    return data.getTime() as ToIpcSafeResult<T>;
   }
 
   // Handle null/undefined (already serializable)
   if (data === null || data === undefined) {
-    return data as ReturnType<typeof toIpcSafe<T>>;
+    // boundary: toIpcSafe nullish passthrough
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion -- boundary: toIpcSafe
+    return data as ToIpcSafeResult<T>;
   }
 
   // Handle arrays
   if (Array.isArray(data)) {
-    return data.map((item) => toIpcSafe(item)) as ReturnType<
-      typeof toIpcSafe<T>
-    >;
+    // boundary: toIpcSafe array map preserves ToIpcSafeResult element typing
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion -- boundary: toIpcSafe
+    return data.map((item) => toIpcSafe(item)) as ToIpcSafeResult<T>;
   }
 
   // Handle plain objects
@@ -106,26 +94,24 @@ export function toIpcSafe<T>(data: T): T extends Date
     for (const key in data) {
       if (Object.prototype.hasOwnProperty.call(data, key)) {
         const value = data[key];
-        // Convert Date to number, or recursively process nested structures
         result[key] = isDate(value) ? value.getTime() : toIpcSafe(value);
       }
     }
-    return result as ReturnType<typeof toIpcSafe<T>>;
+    // boundary: toIpcSafe plain-object rebuild matches IpcSafe<T>
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion -- boundary: toIpcSafe
+    return result as ToIpcSafeResult<T>;
   }
 
   // Handle serializable primitives (string, number, boolean)
   if (isSerializablePrimitive(data)) {
-    return data as ReturnType<typeof toIpcSafe<T>>;
+    // boundary: toIpcSafe primitive passthrough
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion -- boundary: toIpcSafe
+    return data as ToIpcSafeResult<T>;
   }
 
   // Reject non-serializable types (functions, symbols, BigInt, etc.)
-  // This prevents unexpected data from being sent through IPC
   throw new TypeError(
     `Cannot serialize non-serializable type: ${typeof data}. ` +
       `IPC can only serialize: string, number, boolean, null, undefined, Date, arrays, and plain objects.`
   );
 }
-
-
-
-

--- a/src/main/utils/security.ts
+++ b/src/main/utils/security.ts
@@ -80,9 +80,7 @@ export function sanitizeFileName(fileName: string): string {
   // Note: For NSFW Booru client, we only allow media files for security.
   // Non-media extensions are replaced with .bin to prevent execution of malicious files.
   // If you need to support other file types (e.g., .txt, .json), add them to ALLOWED_EXTENSIONS.
-  const safeExt = ALLOWED_EXTENSIONS.includes(
-    ext as (typeof ALLOWED_EXTENSIONS)[number]
-  )
+  const safeExt = ALLOWED_EXTENSIONS.some((v) => v === ext)
     ? ext
     : ".bin"; // Replace unsafe extensions with .bin (prevents execution)
 

--- a/src/main/workers/downloadWorker.ts
+++ b/src/main/workers/downloadWorker.ts
@@ -64,6 +64,8 @@ async function runWorker(): Promise<void> {
     duplicateFileBehavior,
     downloadFolderStructure,
     queueFilePath,
+  // boundary: worker message — workerData payload after trust/Zod
+  // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion -- boundary: worker message
   } = workerData as WorkerData;
 
   let aborted = false;

--- a/src/main/workers/vacuumWorker.ts
+++ b/src/main/workers/vacuumWorker.ts
@@ -6,6 +6,8 @@ interface VacuumWorkerData {
 }
 
 function runVacuumInWorker(): void {
+  // boundary: worker message — workerData payload after trust/Zod
+  // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion -- boundary: worker message
   const { dbPath } = workerData as VacuumWorkerData;
   let db: Database.Database | null = null;
 

--- a/src/renderer/components/dialogs/UpdateNotification.tsx
+++ b/src/renderer/components/dialogs/UpdateNotification.tsx
@@ -1,17 +1,12 @@
 import React, { useEffect, useState } from "react";
 import { useTranslation } from "react-i18next";
+import { z } from "zod";
 import { Download, RefreshCw, X, CheckCircle, AlertCircle } from "lucide-react";
 import { cn } from "../../lib/utils";
 import { Button } from "../ui/button";
 
-type UpdateStatus =
-  | "idle"
-  | "checking"
-  | "available"
-  | "not-available"
-  | "downloading"
-  | "downloaded"
-  | "error";
+const UpdateStatusSchema = z.enum(["idle", "checking", "available", "not-available", "downloading", "downloaded", "error"]);
+type UpdateStatus = z.infer<typeof UpdateStatusSchema>;
 
 export const UpdateNotification: React.FC = () => {
   const { t } = useTranslation();
@@ -27,7 +22,9 @@ export const UpdateNotification: React.FC = () => {
         return;
       }
 
-      setStatus(data.status as UpdateStatus);
+      const parsed = UpdateStatusSchema.safeParse(data.status);
+      if (!parsed.success) return;
+      setStatus(parsed.data);
       if (data.version) setVersion(data.version);
 
       setVisible(true);

--- a/src/renderer/components/inputs/AsyncAutocomplete.tsx
+++ b/src/renderer/components/inputs/AsyncAutocomplete.tsx
@@ -89,10 +89,10 @@ export function AsyncAutocomplete({
   const handleBlurInternal = (e: React.FocusEvent<HTMLInputElement>) => {
     // Check if focus is moving to an element within the container
     // relatedTarget is the element receiving focus (if any)
-    const relatedTarget = e.relatedTarget as Node | null;
+    const relatedTarget = e.relatedTarget;
     
     // If focus is moving to an element inside the container, don't close dropdown
-    if (relatedTarget && containerRef.current?.contains(relatedTarget)) {
+    if (relatedTarget instanceof Node && containerRef.current?.contains(relatedTarget)) {
       return;
     }
     
@@ -160,7 +160,8 @@ export function AsyncAutocomplete({
     const handleClickOutside = (event: MouseEvent) => {
       if (
         containerRef.current &&
-        !containerRef.current.contains(event.target as Node)
+        event.target instanceof Node &&
+        !containerRef.current.contains(event.target)
       ) {
         setIsOpen(false);
         setSelectedIndex(-1);

--- a/src/renderer/components/inputs/TagAutocomplete.tsx
+++ b/src/renderer/components/inputs/TagAutocomplete.tsx
@@ -267,10 +267,10 @@ export function TagAutocomplete({
 
   useEffect(() => {
     const onDoc = (ev: MouseEvent) => {
-      if (!containerRef.current || !ev.target) {
+      if (!containerRef.current || !(ev.target instanceof Node)) {
         return;
       }
-      if (!containerRef.current.contains(ev.target as globalThis.Node)) {
+      if (!containerRef.current.contains(ev.target)) {
         setListOpen(false);
         setSelectedIndex(-1);
       }

--- a/src/renderer/components/layout/filters/SourceSwitcher.tsx
+++ b/src/renderer/components/layout/filters/SourceSwitcher.tsx
@@ -3,9 +3,15 @@ import { ToggleGroup, ToggleGroupItem } from "../../ui/toggle-group";
 import { Users, Heart, Grid3x3 } from "lucide-react";
 import { cn } from "../../../lib/utils";
 
+type SourceValue = "all" | "favorites" | "subscriptions";
+
+function isSourceValue(v: string): v is SourceValue {
+  return v === "all" || v === "favorites" || v === "subscriptions";
+}
+
 interface SourceSwitcherProps {
-  value: "all" | "favorites" | "subscriptions";
-  onValueChange: (value: "all" | "favorites" | "subscriptions") => void;
+  value: SourceValue;
+  onValueChange: (value: SourceValue) => void;
   hasActiveSearch: boolean;
 }
 
@@ -20,7 +26,7 @@ export const SourceSwitcher: React.FC<SourceSwitcherProps> = ({
       value={value}
       onValueChange={(val) => {
         const stringVal = typeof val === "string" ? val : val[0] || "";
-        if (stringVal) onValueChange(stringVal as "all" | "favorites" | "subscriptions");
+        if (stringVal && isSourceValue(stringVal)) onValueChange(stringVal);
       }}
       size="sm"
       variant="outline"

--- a/src/renderer/components/pages/Browse.tsx
+++ b/src/renderer/components/pages/Browse.tsx
@@ -37,6 +37,7 @@ import type { WorkerFilterConfig } from "../../hooks/useWorkerProcessor";
 import type { Post } from "../../../main/db/schema";
 import { normalizePostToPostData } from "../../../shared/utils/post-normalization";
 import { EXTERNAL_ARTIST_ID } from "../../../shared/constants";
+import { getErrorCode } from "../../../shared/utils/type-guards";
 import type { SearchBooruPageResult, BrowseSearchPageParam } from "../../../shared/schemas/search";
 import { useBulkSelect } from "../../hooks/useBulkSelect";
 import { BulkActionBar } from "../BulkActionBar/BulkActionBar";
@@ -203,6 +204,7 @@ export const Browse = () => {
     BrowseSearchPageParam
   >({
     queryKey: ["search", tags, source],
+    initialPageParam: 1,
     flattenPage: (page) => page.posts,
     fetchFn: async (pageParam) => {
       if (source === "favorites") {
@@ -436,7 +438,7 @@ export const Browse = () => {
       );
     },
     onError: (err) => {
-      const errorCode = (err as { code?: string })?.code;
+      const errorCode = getErrorCode(err);
       if (errorCode === "RATE_LIMIT") {
         return;
       }

--- a/src/renderer/components/pages/Favorites.tsx
+++ b/src/renderer/components/pages/Favorites.tsx
@@ -25,6 +25,7 @@ import {
 import { useBulkSelect } from "../../hooks/useBulkSelect";
 import { BulkActionBar } from "../BulkActionBar/BulkActionBar";
 import { getBulkSelectId } from "../../lib/bulkSelect";
+import { getErrorCode } from "../../../shared/utils/type-guards";
 
 // --- Constants ---
 // Should ideally come from a shared constant or backend config
@@ -287,7 +288,7 @@ export const Favorites = () => {
     },
     onError: (err) => {
       // Ignore rate limit errors - use typed errorCode, NOT string parsing
-      const errorCode = (err as { code?: string })?.code;
+      const errorCode = getErrorCode(err);
       if (errorCode === "RATE_LIMIT") {
         return; // Silently ignore rate limit errors
       }

--- a/src/renderer/components/pages/PlaylistsPage.tsx
+++ b/src/renderer/components/pages/PlaylistsPage.tsx
@@ -2,6 +2,8 @@ import React, { forwardRef, useCallback, useEffect, useMemo, useState } from "re
 import {
   useQueryClient,
   useInfiniteQuery,
+  type InfiniteData,
+  type QueryKey,
 } from "@tanstack/react-query";
 import { ArrowLeft, Loader2, List, Sparkles, Plus, Trash2, X, Check, Minus, Pencil, Download, Upload, CheckSquare, Eraser } from "lucide-react";
 import { VirtuosoGrid } from "react-virtuoso";
@@ -266,7 +268,7 @@ const PlaylistGallery: React.FC<PlaylistGalleryProps> = ({ playlist, onBack }) =
     hasNextPage,
     isFetchingNextPage,
     isLoading,
-  } = useInfiniteQuery<Post[]>({
+  } = useInfiniteQuery<Post[], Error, InfiniteData<Post[]>, QueryKey, number>({
     queryKey: [
       "playlist-posts",
       playlist.id,
@@ -275,10 +277,11 @@ const PlaylistGallery: React.FC<PlaylistGalleryProps> = ({ playlist, onBack }) =
       filters.aiFilter,
       sortOrder,
     ],
-    queryFn: async ({ pageParam = 1 }) => {
+    initialPageParam: 1,
+    queryFn: async ({ pageParam }) => {
       return await window.api.resolvePlaylistPosts({
         playlistId: playlist.id,
-        page: pageParam as number,
+        page: pageParam,
         limit: 50,
         filters: Object.keys(apiFilters).length > 0 ? apiFilters : undefined,
         sortOrder,
@@ -289,7 +292,6 @@ const PlaylistGallery: React.FC<PlaylistGalleryProps> = ({ playlist, onBack }) =
       if (lastPage.length < 50) return undefined;
       return allPages.length + 1;
     },
-    initialPageParam: 1,
   });
 
   const allPosts = useMemo(() => {
@@ -730,10 +732,9 @@ export const PlaylistsPage: React.FC<PlaylistsPageProps> = ({ onBack }) => {
           }))
         : [];
       
+      const queryObj: SmartPlaylistQuery = { tags: normalizedTags, provider: "rule34" };
       const queryJson = playlistType === "smart" 
-        ? JSON.stringify({ 
-            tags: normalizedTags,
-          } as SmartPlaylistQuery)
+        ? JSON.stringify(queryObj)
         : "";
       
       await window.api.createPlaylist({
@@ -807,10 +808,9 @@ export const PlaylistsPage: React.FC<PlaylistsPageProps> = ({ onBack }) => {
           }))
         : [];
       
+      const queryObj: SmartPlaylistQuery = { tags: normalizedTags, provider: "rule34" };
       const queryJson = playlistType === "smart" 
-        ? JSON.stringify({ 
-            tags: normalizedTags,
-          } as SmartPlaylistQuery)
+        ? JSON.stringify(queryObj)
         : "";
       
       await window.api.updatePlaylist(playlistToEdit.id, {

--- a/src/renderer/components/playlists/AddToPlaylistModal.tsx
+++ b/src/renderer/components/playlists/AddToPlaylistModal.tsx
@@ -154,9 +154,9 @@ export const AddToPlaylistModal: React.FC<AddToPlaylistModalProps> = ({
 
   const { data: singleContaining = [], isFetching: isFetchingSingle } = useQuery({
     queryKey: ["manual-plist-single", sortedKey] as const,
-    queryFn: async () => {
+    queryFn: async (): Promise<number[]> => {
       if (isBulk || n !== 1) {
-        return [] as number[];
+        return [];
       }
       const only = resolvedPostIds[0];
       if (only == null) {
@@ -169,9 +169,9 @@ export const AddToPlaylistModal: React.FC<AddToPlaylistModalProps> = ({
 
   const { data: bulkRows = [], isFetching: isFetchingBulk } = useQuery({
     queryKey: ["manual-plist-bulk", sortedKey] as const,
-    queryFn: async () => {
+    queryFn: async (): Promise<{ playlistId: number; matchCount: number }[]> => {
       if (!isBulk || n < 1) {
-        return [] as { playlistId: number; matchCount: number }[];
+        return [];
       }
       return await window.api.getManualPlaylistMembershipForPosts({
         postIds: resolvedPostIds,

--- a/src/renderer/components/playlists/QuickAddToPlaylistMenu.tsx
+++ b/src/renderer/components/playlists/QuickAddToPlaylistMenu.tsx
@@ -39,12 +39,19 @@ export const QuickAddToPlaylistMenu: React.FC<QuickAddToPlaylistMenuProps> = ({
 
   const raw = trigger ?? defaultTrigger;
   const withOpen = isValidElement(raw)
-    ? cloneElement(raw, {
-        onClick: (e: React.MouseEvent) => {
-          (raw.props as { onClick?: (e: React.MouseEvent) => void }).onClick?.(e);
-          setEffectiveOpen(true);
-        },
-      } as { onClick: (e: React.MouseEvent) => void })
+    ? cloneElement(raw, (() => {
+        const existingOnClick: unknown =
+          typeof raw.props === "object" && raw.props !== null
+            ? Reflect.get(raw.props, "onClick")
+            : undefined;
+        const extraProps: { onClick: (e: React.MouseEvent) => void } = {
+          onClick: (e: React.MouseEvent) => {
+            if (typeof existingOnClick === "function") existingOnClick(e);
+            setEffectiveOpen(true);
+          },
+        };
+        return extraProps;
+      })())
     : raw;
 
   return (

--- a/src/renderer/features/artists/ArtistGallery.tsx
+++ b/src/renderer/features/artists/ArtistGallery.tsx
@@ -20,6 +20,7 @@ import { getPostCardKey } from "../../lib/postCardKey";
 import { useGalleryInfiniteScroll } from "../../hooks/useGalleryInfiniteScroll";
 import { useDownloadAllFromBackend } from "../../hooks/useDownloadAll";
 import { DownloadAllButton } from "../../components/downloads/DownloadAllButton";
+import { getErrorCode } from "../../../shared/utils/type-guards";
 
 interface ArtistGalleryProps {
   artist: Artist;
@@ -153,6 +154,7 @@ export const ArtistGallery: React.FC<ArtistGalleryProps> = ({
     handleEndReached,
   } = useGalleryInfiniteScroll({
     queryKey: ["posts", artist.id, aiFilter, rating, mediaType, source, sortOrder],
+    initialPageParam: 1,
     fetchFn: async (pageParam) => {
       return await window.api.getArtistPosts({
         artistId: artist.id,
@@ -215,7 +217,7 @@ export const ArtistGallery: React.FC<ArtistGalleryProps> = ({
     },
     onError: (err) => {
       // Ignore rate limit errors - use typed errorCode, NOT string parsing
-      const errorCode = (err as { code?: string })?.code;
+      const errorCode = getErrorCode(err);
       if (errorCode === "RATE_LIMIT") {
         return; // Silently ignore rate limit errors
       }

--- a/src/renderer/features/viewer/hooks/useViewerController.ts
+++ b/src/renderer/features/viewer/hooks/useViewerController.ts
@@ -5,6 +5,7 @@ import type { Post } from "../../../../main/db/schema";
 import type { ViewerOrigin } from "../../../store/viewerStore";
 import { normalizePostToPostData } from "../../../../shared/utils/post-normalization";
 import { EXTERNAL_ARTIST_ID } from "../../../../shared/constants";
+import { getErrorCode } from "../../../../shared/utils/type-guards";
 import { updatePostInCache, updatePostInSearchCache } from "../../../utils/react-query-cache";
 import type { SearchBooruPageResult } from "../../../../shared/schemas/search";
 
@@ -80,7 +81,7 @@ export function useViewerController({
       // Fire and forget: suppress rate limit errors, they are expected during fast scrolling
       window.api.markPostAsViewed(post.id, postData).catch((err) => {
         // Ignore rate limit errors - use typed errorCode, NOT string parsing
-        const errorCode = (err as { code?: string })?.code;
+        const errorCode = getErrorCode(err);
         if (errorCode === "RATE_LIMIT") {
           return; // Silently ignore rate limit errors
         }

--- a/src/renderer/hooks/useDownloadAll.ts
+++ b/src/renderer/hooks/useDownloadAll.ts
@@ -3,6 +3,7 @@ import log from "electron-log/renderer";
 import type { Post } from "../../main/db/schema";
 import type { GetPostsRequest } from "../../main/types/ipc";
 import { useDownloadStore } from "../store/downloadStore";
+import { getErrorCode } from "../../shared/utils/type-guards";
 
 function postToDownloadItem(p: Post): { url: string; filename: string } | null {
   if (!p.fileUrl?.trim()) return null;
@@ -93,7 +94,7 @@ export function useDownloadAllWithFilters(
       .getPostsCountWithFilters(fetchParams)
       .then(setTotalCount)
       .catch((e) => {
-        if ((e as { code?: string })?.code !== "RATE_LIMIT") {
+        if (getErrorCode(e) !== "RATE_LIMIT") {
           setTotalCount(0);
         }
       });

--- a/src/renderer/hooks/useGalleryInfiniteScroll.ts
+++ b/src/renderer/hooks/useGalleryInfiniteScroll.ts
@@ -43,7 +43,7 @@ export function useGalleryInfiniteScroll<
   debounceDelay = DEBOUNCE_DELAY,
   getNextPageParam,
   flattenPage,
-  initialPageParam = 1 as TPageParam,
+  initialPageParam,
   staleTime,
   gcTime,
   refetchOnMount,
@@ -62,7 +62,7 @@ export function useGalleryInfiniteScroll<
     allPages: TPage[]
   ) => TPageParam | undefined;
   flattenPage?: (page: TPage) => TItem[];
-  initialPageParam?: TPageParam;
+  initialPageParam: TPageParam;
 } & GalleryInfiniteScrollQueryOptions) {
   const endReachedTimeoutRef = useRef<NodeJS.Timeout | null>(null);
   const hasNextPageRef = useRef(false);
@@ -83,7 +83,9 @@ export function useGalleryInfiniteScroll<
     refetch,
   } = useInfiniteQuery({
     queryKey,
-    queryFn: async ({ pageParam = initialPageParam }) => {
+    queryFn: async ({ pageParam }) => {
+      // boundary: TanStack Query generic inference — pageParam is unknown for unresolved TPageParam
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion -- boundary: TanStack Query generic inference
       return await fetchFn(pageParam as TPageParam);
     },
     getNextPageParam:
@@ -91,9 +93,15 @@ export function useGalleryInfiniteScroll<
       ((lastPage, allPages) => {
         const items = flattenPage
           ? flattenPage(lastPage)
-          : (lastPage as unknown as TItem[]);
+          : Array.isArray(lastPage)
+            ? // boundary: TanStack Query generic inference — default path assumes TPage is TItem[]
+              (lastPage as TItem[])
+            : [];
+        // Default pagination uses sequential numeric page indices.
+        // boundary: TanStack Query generic inference — default TPageParam is number
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion -- boundary: TanStack Query generic inference
         return (
-          items.length === postsPerPage ? (allPages.length + 1) : undefined
+          items.length === postsPerPage ? allPages.length + 1 : undefined
         ) as TPageParam | undefined;
       }),
     initialPageParam,
@@ -157,8 +165,11 @@ export function useGalleryInfiniteScroll<
     }
     return data.pages.flatMap((page) =>
       flattenPage
-        ? flattenPage(page as TPage)
-        : (page as unknown as TItem[])
+        ? flattenPage(page)
+        : Array.isArray(page)
+          ? // boundary: TanStack Query generic inference — default path assumes TPage is TItem[]
+            (page as TItem[])
+          : []
     );
   }, [data, flattenPage]);
 

--- a/src/renderer/utils/react-query-cache.ts
+++ b/src/renderer/utils/react-query-cache.ts
@@ -21,7 +21,7 @@ export function isSearchGalleryPage(page: unknown): page is SearchGalleryPage {
     typeof page === "object" &&
     page !== null &&
     "posts" in page &&
-    Array.isArray((page as SearchGalleryPage).posts)
+    Array.isArray(page.posts)
   );
 }
 

--- a/src/renderer/workers/data-processor.worker.ts
+++ b/src/renderer/workers/data-processor.worker.ts
@@ -203,15 +203,15 @@ self.addEventListener("message", (event: MessageEvent<WorkerRequest>) => {
   try {
     switch (action) {
       case "FILTER_AND_SORT": {
+        // boundary: worker message
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion -- boundary: worker message
         const { posts, filters } = payload as FilterAndSortPayload;
         
         // PERFORMANCE: Skip Zod validation in Worker - data comes from trusted Main process
         // Zod.parse() on 20k+ posts wastes 80% of Worker time on redundant validation
         // Main process already validates data before sending to Renderer
         // Trust your own IPC layer - don't validate twice
-        const validatedPosts = posts as WorkerPost[];
-        
-        const result = filterAndSortPosts(validatedPosts, filters);
+        const result = filterAndSortPosts(posts, filters);
         
         const response: WorkerResponse<WorkerPost[]> = {
           id,

--- a/src/shared/utils/provider-search-ipc.ts
+++ b/src/shared/utils/provider-search-ipc.ts
@@ -7,6 +7,7 @@ import {
   type ProviderErrorKind,
   type ProviderSearchErrorPayload,
 } from "../schemas/provider-errors";
+import { isRecord } from "./type-guards";
 
 const IPC_INVOKE_PREFIX = /^Error invoking remote method '[^']+':\s*/;
 
@@ -30,12 +31,10 @@ function stripIpcMessagePrefix(message: string): string {
 }
 
 function inferKindFromUserMessage(message: string): ProviderErrorKind | null {
-  const entries = Object.entries(PROVIDER_SEARCH_USER_MESSAGES) as Array<
-    [ProviderErrorKind, string]
-  >;
-  for (const [kind, text] of entries) {
-    if (message === text) {
-      return kind;
+  for (const key of Object.keys(PROVIDER_SEARCH_USER_MESSAGES)) {
+    const kind = ProviderErrorKindSchema.safeParse(key);
+    if (kind.success && PROVIDER_SEARCH_USER_MESSAGES[kind.data] === message) {
+      return kind.data;
     }
   }
   return null;
@@ -74,8 +73,8 @@ function tryParseJsonProviderPayload(
   }
   try {
     const parsed: unknown = JSON.parse(trimmed);
-    if (typeof parsed === "object" && parsed !== null) {
-      return parsed as Record<string, unknown>;
+    if (isRecord(parsed)) {
+      return parsed;
     }
   } catch {
     return null;

--- a/src/shared/utils/type-guards.ts
+++ b/src/shared/utils/type-guards.ts
@@ -1,0 +1,25 @@
+/**
+ * Shared type guards for narrowing unknown values without type assertions.
+ */
+
+export function isErrnoException(error: unknown): error is NodeJS.ErrnoException {
+  return (
+    typeof error === "object" &&
+    error !== null &&
+    "code" in error &&
+    (typeof Reflect.get(error, "code") === "string" ||
+      typeof Reflect.get(error, "code") === "undefined")
+  );
+}
+
+export function getErrorCode(error: unknown): string | undefined {
+  if (typeof error !== "object" || error === null || !("code" in error)) {
+    return undefined;
+  }
+  const code = Reflect.get(error, "code");
+  return typeof code === "string" ? code : undefined;
+}
+
+export function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null;
+}


### PR DESCRIPTION
- Updated `.cursorrules` to specify that `as` casting is forbidden except for a defined boundary list, ensuring stricter type safety.
- Enhanced ESLint configuration to enforce consistent type assertions and prevent unsafe type assertions across the codebase.
- Documented the type assertion policy in `.ai/LESSONS.txt` and relevant documentation files to maintain clarity and consistency.
- Refactored various files to comply with the new type assertion rules, removing unnecessary casts and ensuring proper type handling.

This change aims to improve code quality and maintainability by adhering to strict type safety standards.