### PR TITLE
feat: implement wipeAllData functionality and update documentation

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -376,11 +376,23 @@ const { data: version } = useQuery<string>({
   queryKey: ["app-version"],
   queryFn: () => window.api.getAppVersion(),
 });
-
-return <div>Version: {version}</div>;
 ```
 
-**IPC Channel:** `app:get-version`
+### `wipeAllData()`
+
+Deletes all application data under `userData` (`.rdcache`), then exits the process.
+
+**IPC Channel:** `system:wipe-all-data`  
+**Args:** none (`z.tuple([])`)  
+**Order:** `closeDatabase()` → stop video proxy → delete children of `userData` (paths validated with `isResolvedPathWithinBase`) → `app.exit(0)`.
+
+Does **not** delete the user's media download folder outside `.rdcache`. On partial delete failure, throws a user-facing error and does not exit.
+
+**Returns:** `Promise<void>` (normally does not resolve — process exits)
+
+```typescript
+await window.api.wipeAllData();
+```
 
 ---
 

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -607,6 +607,8 @@ The application redirects `userData` to a neutral `.rdcache` directory. Developm
 
 **Note:** Data is not stored next to `RuleDesk.exe`. You can move or replace the app folder freely; local database, logs, and settings stay under `.rdcache` until you delete that directory.
 
+**Delete all data (in-app):** Settings → General → **Danger zone** → **Delete all data…**. Confirm with the checkbox, then confirm. The app closes the database, stops the video proxy, deletes everything inside `.rdcache` (database + WAL/SHM, `video-cache/`, logs, `backup-settings.json`, in-app `.ruledesk-backup-*.db` files, download queue, Electron cache files), and quits. Your separate media download folder is not deleted. After restart you go through the age gate / onboarding again. Prefer this over uninstalling the `.exe` alone — uninstall does not remove `.rdcache`.
+
 **Legacy (pre-fix builds):** `%APPDATA%\RuleDesk\` may still contain old `logs/` and `backup-settings.json`. New builds copy them into `.rdcache` on first launch when targets are missing.
 
 ---

--- a/src/main/bridge.ts
+++ b/src/main/bridge.ts
@@ -80,6 +80,7 @@ export interface IpcBridge {
   getAppVersion: () => Promise<string>;
   getDatabaseLocation: () => Promise<string>;
   getIconPath: (theme?: "light" | "dark") => Promise<string>;
+  wipeAllData: () => Promise<void>;
 
   writeToClipboard: (text: string) => Promise<boolean>;
 
@@ -247,6 +248,7 @@ const ipcBridge: IpcBridge = {
   getIconPath: (theme) => {
     return ipcRenderer.invoke(IPC_CHANNELS.APP.GET_ICON_PATH, theme);
   },
+  wipeAllData: () => ipcRenderer.invoke(IPC_CHANNELS.APP.WIPE_ALL_DATA),
 
   writeToClipboard: (text) =>
     ipcRenderer.invoke(IPC_CHANNELS.APP.WRITE_CLIPBOARD, text),

--- a/src/main/ipc/channels.ts
+++ b/src/main/ipc/channels.ts
@@ -12,6 +12,7 @@ export const IPC_CHANNELS = {
     CHECK_FOR_UPDATES: "app:check-for-updates",
     START_UPDATE_DOWNLOAD: "app:start-download",
     QUIT_AND_INSTALL: "app:quit-and-install",
+    WIPE_ALL_DATA: "system:wipe-all-data",
   },
   SETTINGS: {
     GET: "app:get-settings-status",

--- a/src/main/ipc/controllers/SystemController.ts
+++ b/src/main/ipc/controllers/SystemController.ts
@@ -1,13 +1,16 @@
 import { app, clipboard, type IpcMainInvokeEvent } from "electron";
 import log from "electron-log";
 import path from "node:path";
-import { readFileSync, existsSync } from "fs";
+import { readFileSync, existsSync, promises as fs } from "fs";
 import { z } from "zod";
 import { BaseController } from "../../core/ipc/BaseController";
 import { closeDatabase } from "../../db/client";
 import { IPC_CHANNELS } from "../channels";
 import { getDatabasePaths } from "../../db/paths";
 import { getAppIconsDirectory } from "../../lib/app-resources";
+import { isResolvedPathWithinBase } from "../../utils/path-within-base";
+import type { VideoProxyServer } from "../../services/video-proxy-server";
+
 const GetIconPathArgsSchema = z.tuple([z.enum(["light", "dark"]).optional()]);
 const WriteClipboardArgsSchema = z.tuple([z.string().min(1)]);
 
@@ -16,14 +19,17 @@ const WriteClipboardArgsSchema = z.tuple([z.string().min(1)]);
  *
  * Handles system-level IPC operations:
  * - Application version info
- * - Application lifecycle (quit)
+ * - Application lifecycle (quit, wipe all local data)
  * - Clipboard operations
  */
-// Query style: Drizzle Builder API only in this controller.
 export class SystemController extends BaseController {
-  /**
-   * Setup IPC handlers for system operations
-   */
+  private readonly videoProxyServer: VideoProxyServer;
+
+  constructor(videoProxyServer: VideoProxyServer) {
+    super();
+    this.videoProxyServer = videoProxyServer;
+  }
+
   public setup(): void {
     this.handle(IPC_CHANNELS.APP.GET_VERSION, z.tuple([]), this.getAppVersion.bind(this));
     this.handle(IPC_CHANNELS.APP.GET_DB_LOCATION, z.tuple([]), this.getDatabaseLocation.bind(this));
@@ -37,6 +43,11 @@ export class SystemController extends BaseController {
     );
     this.handle(IPC_CHANNELS.APP.QUIT, z.tuple([]), this.quitApp.bind(this));
     this.handle(
+      IPC_CHANNELS.APP.WIPE_ALL_DATA,
+      z.tuple([]),
+      this.wipeAllData.bind(this)
+    );
+    this.handle(
       IPC_CHANNELS.APP.WRITE_CLIPBOARD,
       WriteClipboardArgsSchema,
       (event, ...args) => {
@@ -48,11 +59,6 @@ export class SystemController extends BaseController {
     log.info("[SystemController] All handlers registered");
   }
 
-  /**
-   * Get application version
-   *
-   * @returns Application version string from package.json
-   */
   private async getAppVersion(_event: IpcMainInvokeEvent): Promise<string> {
     const version = app.getVersion();
     log.info(`[SystemController] Version requested: ${version}`);
@@ -64,11 +70,6 @@ export class SystemController extends BaseController {
     return dbPath;
   }
 
-  /**
-   * Get application icon as base64 data URL
-   *
-   * @returns Base64 data URL of icon.png for use in img src
-   */
   private async getIconPath(
     _event: IpcMainInvokeEvent,
     theme?: "light" | "dark"
@@ -89,29 +90,30 @@ export class SystemController extends BaseController {
           .map((fileName) => path.join(iconsFolder, fileName))
           .find((candidatePath) => existsSync(candidatePath)) ??
         path.join(iconsFolder, "icon.png");
-      
+
       log.info(`[SystemController] Attempting to load icon from: ${iconPath}`);
-      
-      // Check if file exists before reading
+
       if (!existsSync(iconPath)) {
         const errorMsg = `Icon file not found at: ${iconPath}`;
         log.error(`[SystemController] ${errorMsg}`);
         throw new Error(errorMsg);
       }
-      
-      // Read file and convert to base64 data URL
+
       const iconBuffer = readFileSync(iconPath);
       const fileSizeKB = Math.round(iconBuffer.length / 1024);
-      
-      // Check file size - warn if too large (may cause performance issues)
+
       if (iconBuffer.length > 1024 * 1024) {
-        log.warn(`[SystemController] Icon file is large (${fileSizeKB}KB), may cause performance issues`);
+        log.warn(
+          `[SystemController] Icon file is large (${fileSizeKB}KB), may cause performance issues`
+        );
       }
-      
+
       const base64 = iconBuffer.toString("base64");
       const dataUrl = `data:image/png;base64,${base64}`;
-      
-      log.info(`[SystemController] Icon loaded successfully from: ${iconPath} (${fileSizeKB}KB, ${dataUrl.length} chars in data URL)`);
+
+      log.info(
+        `[SystemController] Icon loaded successfully from: ${iconPath} (${fileSizeKB}KB, ${dataUrl.length} chars in data URL)`
+      );
       return dataUrl;
     } catch (error) {
       const errorMessage = error instanceof Error ? error.message : String(error);
@@ -121,36 +123,67 @@ export class SystemController extends BaseController {
         stack: errorStack,
         error: String(error),
       });
-      // Re-throw error so BaseController can serialize it properly
       throw new Error(`Failed to load icon: ${errorMessage}`);
     }
   }
 
-  /**
-   * Quit the application
-   *
-   * ⚠️ Note: This will trigger app lifecycle events (before-quit, will-quit, quit)
-   * Make sure all cleanup handlers are properly registered before calling this.
-   * 
-   * CRITICAL: Closes database connection before quitting to prevent data corruption.
-   *
-   * @returns void (application will quit before return)
-   */
   private async quitApp(_event: IpcMainInvokeEvent): Promise<void> {
     log.info("[SystemController] Application quit requested");
-    // CRITICAL: Close database connection before quitting to prevent data corruption
-    // SQLite requires explicit close() to ensure all transactions are committed
     closeDatabase();
     app.quit();
   }
 
   /**
-   * Write text to system clipboard
-   *
-   * @param _event - IPC event (unused)
-   * @param text - Text to write to clipboard (validated: min 1 char)
-   * @returns true if operation succeeded, false otherwise
+   * Deletes all application data under userData (.rdcache), then exits.
+   * Order: close DB → stop video proxy → delete children of userData → app.exit(0).
+   * User download folders and backups outside userData are not touched.
    */
+  private async wipeAllData(_event: IpcMainInvokeEvent): Promise<void> {
+    const userDataDir = path.resolve(app.getPath("userData"));
+    log.warn(`[SystemController] Wipe all data requested for: ${userDataDir}`);
+
+    closeDatabase();
+    this.videoProxyServer.stop();
+
+    let entries: string[];
+    try {
+      entries = await fs.readdir(userDataDir);
+    } catch (error) {
+      log.error("[SystemController] Failed to list userData for wipe:", error);
+      throw new Error("Could not read application data folder.");
+    }
+
+    const failures: string[] = [];
+
+    for (const name of entries) {
+      const fullPath = path.resolve(userDataDir, name);
+      if (!isResolvedPathWithinBase(fullPath, userDataDir)) {
+        log.error(
+          `[SystemController] Refusing wipe path outside userData: ${fullPath}`
+        );
+        failures.push(name);
+        continue;
+      }
+
+      try {
+        await fs.rm(fullPath, { recursive: true, force: true });
+        log.info(`[SystemController] Wiped: ${name}`);
+      } catch (error) {
+        log.error(`[SystemController] Failed to wipe "${name}":`, error);
+        failures.push(name);
+      }
+    }
+
+    if (failures.length > 0) {
+      throw new Error(
+        `Could not delete: ${failures.join(", ")}. Close other apps using these files and try again.`
+      );
+    }
+
+    log.warn("[SystemController] Wipe complete — exiting");
+    app.exit(0);
+  }
+
   private async writeToClipboard(
     _event: IpcMainInvokeEvent,
     text: string
@@ -167,12 +200,8 @@ export class SystemController extends BaseController {
     }
   }
 
-  /**
-   * Override sanitizeArgs to prevent logging sensitive clipboard data
-   */
   protected sanitizeArgs(args: unknown[]): unknown[] {
     return args.map((arg) => {
-      // Mask clipboard content in logs
       if (typeof arg === "string" && arg.length > 0) {
         return `<string:${arg.length}chars>`;
       }

--- a/src/main/ipc/index.ts
+++ b/src/main/ipc/index.ts
@@ -44,7 +44,7 @@ export function setupIpc(
   const videoProxyController = new VideoProxyController(videoProxyServer);
   videoProxyController.setup();
 
-  const systemController = new SystemController();
+  const systemController = new SystemController(videoProxyServer);
   systemController.setup();
 
   const artistsController = new ArtistsController();

--- a/src/renderer.d.ts
+++ b/src/renderer.d.ts
@@ -67,6 +67,7 @@ export interface IpcApi extends IpcBridge {
   getAppVersion: () => Promise<string>;
   getDatabaseLocation: () => Promise<string>;
   getIconPath: (theme?: "light" | "dark") => Promise<string>;
+  wipeAllData: () => Promise<void>;
 
   // Settings
   getSettings: () => Promise<IpcSettings | undefined>;

--- a/src/renderer/features/settings/SettingsGeneralTab.tsx
+++ b/src/renderer/features/settings/SettingsGeneralTab.tsx
@@ -1,7 +1,11 @@
+import { useState } from "react";
+import { toast } from "sonner";
+import log from "electron-log/renderer";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "../../components/ui/card";
 import { Label } from "../../components/ui/label";
 import { Button } from "../../components/ui/button";
 import { Input } from "../../components/ui/input";
+import { Checkbox } from "../../components/ui/checkbox";
 import {
   Select,
   SelectContent,
@@ -11,6 +15,15 @@ import {
 } from "../../components/ui/select";
 import { Badge } from "../../components/ui/badge";
 import { Separator } from "../../components/ui/separator";
+import {
+  AlertDialog,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from "../../components/ui/alert-dialog";
 
 interface SettingsGeneralTabProps {
   downloadFolder: string | null;
@@ -45,100 +58,210 @@ export const SettingsGeneralTab = ({
   onProxyBlur,
   onSaveProxy,
 }: SettingsGeneralTabProps) => {
+  const [wipeDialogOpen, setWipeDialogOpen] = useState(false);
+  const [wipeAcknowledged, setWipeAcknowledged] = useState(false);
+  const [wipeInProgress, setWipeInProgress] = useState(false);
+
+  const handleWipeDialogOpenChange = (open: boolean) => {
+    if (wipeInProgress) {
+      return;
+    }
+    setWipeDialogOpen(open);
+    if (!open) {
+      setWipeAcknowledged(false);
+    }
+  };
+
+  const handleWipeAllData = async () => {
+    if (!wipeAcknowledged || wipeInProgress) {
+      return;
+    }
+    setWipeInProgress(true);
+    try {
+      await window.api.wipeAllData();
+      // Process exits on success; if we return, something went wrong upstream.
+    } catch (error) {
+      const message =
+        error instanceof Error ? error.message : "Failed to delete application data.";
+      log.error("[Settings] wipeAllData failed:", message);
+      toast.error(message);
+      setWipeInProgress(false);
+    }
+  };
+
   return (
-    <Card>
-      <CardHeader>
-        <CardTitle>General</CardTitle>
-        <CardDescription>Default download and connection preferences.</CardDescription>
-      </CardHeader>
-      <CardContent className="space-y-4">
-        <section className="space-y-3">
-          <Label>Default download folder</Label>
-          <p className="text-sm text-muted-foreground break-all">
-            {downloadFolder ?? "Default (Downloads/BooruClient)"}
-          </p>
-          <section className="flex flex-wrap gap-2">
-            <Button type="button" variant="outline" size="sm" onClick={onSelectDownloadFolder}>
-              Choose Folder
-            </Button>
-            {downloadFolder ? (
-              <Button type="button" variant="ghost" size="sm" onClick={onResetDownloadFolder}>
-                Reset to Default
+    <>
+      <Card>
+        <CardHeader>
+          <CardTitle>General</CardTitle>
+          <CardDescription>Default download and connection preferences.</CardDescription>
+        </CardHeader>
+        <CardContent className="space-y-4">
+          <section className="space-y-3">
+            <Label>Default download folder</Label>
+            <p className="text-sm text-muted-foreground break-all">
+              {downloadFolder ?? "Default (Downloads/BooruClient)"}
+            </p>
+            <section className="flex flex-wrap gap-2">
+              <Button type="button" variant="outline" size="sm" onClick={onSelectDownloadFolder}>
+                Choose Folder
               </Button>
-            ) : null}
-            {downloadFolderStatus === "success" ? (
-              <Badge className="border-green-600/30 bg-green-600/15 text-green-700 dark:text-green-300">
-                Updated
-              </Badge>
-            ) : null}
-            {downloadFolderStatus === "error" ? (
-              <Badge className="border-red-600/30 bg-red-600/15 text-red-700 dark:text-red-300">
-                Update failed
-              </Badge>
-            ) : null}
+              {downloadFolder ? (
+                <Button type="button" variant="ghost" size="sm" onClick={onResetDownloadFolder}>
+                  Reset to Default
+                </Button>
+              ) : null}
+              {downloadFolderStatus === "success" ? (
+                <Badge className="border-green-600/30 bg-green-600/15 text-green-700 dark:text-green-300">
+                  Updated
+                </Badge>
+              ) : null}
+              {downloadFolderStatus === "error" ? (
+                <Badge className="border-red-600/30 bg-red-600/15 text-red-700 dark:text-red-300">
+                  Update failed
+                </Badge>
+              ) : null}
+            </section>
           </section>
-        </section>
 
-        <Separator />
+          <Separator />
 
-        <section className="space-y-2">
-          <Label htmlFor="duplicate-file-behavior">When file already exists</Label>
-          <Select value={duplicateFileBehavior} onValueChange={onDuplicateFileBehaviorChange}>
-            <SelectTrigger id="duplicate-file-behavior">
-              <SelectValue />
-            </SelectTrigger>
-            <SelectContent>
-              <SelectItem value="skip">Skip (keep existing)</SelectItem>
-              <SelectItem value="overwrite">Overwrite</SelectItem>
-            </SelectContent>
-          </Select>
-        </section>
+          <section className="space-y-2">
+            <Label htmlFor="duplicate-file-behavior">When file already exists</Label>
+            <Select value={duplicateFileBehavior} onValueChange={onDuplicateFileBehaviorChange}>
+              <SelectTrigger id="duplicate-file-behavior">
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value="skip">Skip (keep existing)</SelectItem>
+                <SelectItem value="overwrite">Overwrite</SelectItem>
+              </SelectContent>
+            </Select>
+          </section>
 
-        <section className="space-y-2">
-          <Label htmlFor="download-folder-structure">Folder structure</Label>
-          <Select value={downloadFolderStructure} onValueChange={onDownloadFolderStructureChange}>
-            <SelectTrigger id="download-folder-structure">
-              <SelectValue />
-            </SelectTrigger>
-            <SelectContent>
-              <SelectItem value="flat">Flat (single folder)</SelectItem>
-              <SelectItem value="{artist_id}">By artist (subfolder)</SelectItem>
-            </SelectContent>
-          </Select>
-        </section>
+          <section className="space-y-2">
+            <Label htmlFor="download-folder-structure">Folder structure</Label>
+            <Select
+              value={downloadFolderStructure}
+              onValueChange={onDownloadFolderStructureChange}
+            >
+              <SelectTrigger id="download-folder-structure">
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value="flat">Flat (single folder)</SelectItem>
+                <SelectItem value="{artist_id}">By artist (subfolder)</SelectItem>
+              </SelectContent>
+            </Select>
+          </section>
 
-        <Separator />
+          <Separator />
 
-        <section className="space-y-2">
-          <Label htmlFor="proxy-url">Proxy URL</Label>
-          <Input
-            id="proxy-url"
-            placeholder="https://proxy.example.com:8080"
-            value={proxyUrl ?? ""}
-            onChange={(event) => onProxyUrlChange(event.target.value)}
-            onBlur={onProxyBlur}
-          />
-          <p className="text-xs text-muted-foreground">
-            Optional HTTP/HTTPS proxy for requests and downloads.
+          <section className="space-y-2">
+            <Label htmlFor="proxy-url">Proxy URL</Label>
+            <Input
+              id="proxy-url"
+              placeholder="https://proxy.example.com:8080"
+              value={proxyUrl ?? ""}
+              onChange={(event) => onProxyUrlChange(event.target.value)}
+              onBlur={onProxyBlur}
+            />
+            <p className="text-xs text-muted-foreground">
+              Optional HTTP/HTTPS proxy for requests and downloads.
+            </p>
+            {proxyError ? <p className="text-sm text-destructive">{proxyError}</p> : null}
+            <section className="flex flex-wrap items-center gap-2">
+              <Button type="button" variant="outline" size="sm" onClick={onSaveProxy}>
+                Save Proxy
+              </Button>
+              {proxyStatus === "success" ? (
+                <Badge className="border-green-600/30 bg-green-600/15 text-green-700 dark:text-green-300">
+                  Saved
+                </Badge>
+              ) : null}
+              {proxyStatus === "error" ? (
+                <Badge className="border-red-600/30 bg-red-600/15 text-red-700 dark:text-red-300">
+                  Save failed
+                </Badge>
+              ) : null}
+            </section>
+          </section>
+        </CardContent>
+      </Card>
+
+      <Card className="mt-4 border-destructive/40">
+        <CardHeader>
+          <CardTitle className="text-destructive">Danger zone</CardTitle>
+          <CardDescription>
+            Permanently delete all local RuleDesk data stored under the hidden{" "}
+            <span className="font-mono">.rdcache</span> folder, then quit the app.
+          </CardDescription>
+        </CardHeader>
+        <CardContent className="space-y-3">
+          <p className="text-sm text-muted-foreground">
+            This removes the database (<span className="font-mono">data.bin</span> and
+            WAL/SHM), video cache, logs, backup schedule, in-app DB backups, download
+            queue, and other Electron cache files inside{" "}
+            <span className="font-mono">.rdcache</span>. Your chosen media download folder
+            outside that directory is not touched. After restart you will see the age gate
+            and onboarding again.
           </p>
-          {proxyError ? <p className="text-sm text-destructive">{proxyError}</p> : null}
-          <section className="flex flex-wrap items-center gap-2">
-            <Button type="button" variant="outline" size="sm" onClick={onSaveProxy}>
-              Save Proxy
-            </Button>
-            {proxyStatus === "success" ? (
-              <Badge className="border-green-600/30 bg-green-600/15 text-green-700 dark:text-green-300">
-                Saved
-              </Badge>
-            ) : null}
-            {proxyStatus === "error" ? (
-              <Badge className="border-red-600/30 bg-red-600/15 text-red-700 dark:text-red-300">
-                Save failed
-              </Badge>
-            ) : null}
+          <Button
+            type="button"
+            variant="destructive"
+            size="sm"
+            onClick={() => {
+              setWipeAcknowledged(false);
+              setWipeDialogOpen(true);
+            }}
+          >
+            Delete all data…
+          </Button>
+        </CardContent>
+      </Card>
+
+      <AlertDialog open={wipeDialogOpen} onOpenChange={handleWipeDialogOpenChange}>
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>Delete all local data?</AlertDialogTitle>
+            <AlertDialogDescription>
+              This cannot be undone. Everything in{" "}
+              <span className="font-mono">.rdcache</span> will be erased and the app will
+              quit. Reinstalling or deleting the .exe alone does not remove this folder —
+              use this action (or delete{" "}
+              <span className="font-mono">.rdcache</span> manually) when you want a clean
+              wipe.
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <section className="flex items-start gap-3 py-2">
+            <Checkbox
+              id="wipe-acknowledge"
+              checked={wipeAcknowledged}
+              disabled={wipeInProgress}
+              onCheckedChange={(checked) => {
+                setWipeAcknowledged(checked === true);
+              }}
+            />
+            <Label htmlFor="wipe-acknowledge" className="text-sm font-normal leading-snug">
+              I understand this permanently deletes my local library, settings, and
+              credentials.
+            </Label>
           </section>
-        </section>
-      </CardContent>
-    </Card>
+          <AlertDialogFooter>
+            <AlertDialogCancel disabled={wipeInProgress}>Cancel</AlertDialogCancel>
+            <Button
+              type="button"
+              variant="destructive"
+              disabled={!wipeAcknowledged || wipeInProgress}
+              onClick={() => {
+                void handleWipeAllData();
+              }}
+            >
+              {wipeInProgress ? "Deleting…" : "Delete all data"}
+            </Button>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
+    </>
   );
 };


### PR DESCRIPTION
- Added `wipeAllData()` method to the IPC API, allowing the application to delete all data under `userData` and exit the process.
- Updated `SystemController` to handle the new IPC channel `system:wipe-all-data`, ensuring proper cleanup of application data.
- Enhanced user documentation to include instructions for deleting all data via the settings interface, detailing the process and implications.
- Introduced error handling for partial delete failures, ensuring user-facing errors are thrown without exiting the application unexpectedly.

This change aims to improve data management capabilities and provide users with a clear method for resetting application data.