### PR TITLE
chore: update documentation for database operations and IPC structure

### DIFF
--- a/.cursorrules
+++ b/.cursorrules
@@ -18,7 +18,7 @@ You do not tolerate sloppy code, "any" types, "as" casting, magic numbers, or pr
 1. **Architecture**:
 
    - **Strict Separation**: Main Process (Backend) vs Renderer (Frontend).
-   - **Database**: Direct, synchronous access via `better-sqlite3` + Drizzle in Main Process. Use Drizzle ORM for CRUD on application tables. Raw SQL via `getSqliteInstance()` is allowed only for SQLite PRAGMAs, FTS5 virtual table/trigger management, schema introspection (`sqlite_master`, `PRAGMA table_info`), and bulk backfill/batch operations where Drizzle overhead is unacceptable. ❌ **NO Worker Threads** for DB operations.
+   - **Database**: Direct, synchronous access via `better-sqlite3` + Drizzle in Main Process. Use Drizzle ORM for CRUD on application tables. Raw SQL via `getSqliteInstance()` is allowed only for SQLite PRAGMAs, FTS5 virtual table/trigger management, schema introspection (`sqlite_master`, `PRAGMA table_info`), and bulk backfill/batch operations where Drizzle overhead is unacceptable. ❌ **NO Worker Threads** for ordinary DB CRUD. Exception: user-triggered / scheduled `VACUUM` may run in `vacuumWorker.ts` so the Main IPC loop is not blocked for the full vacuum duration.
    - **IPC**: Group handlers by domain in `src/main/ipc/handlers`. Use `ipcMain.handle` and `ipcRenderer.invoke`.
    - **Services**: Services (Sync, Updater) must call DB directly, not via IPC/RPC.
 

--- a/README.md
+++ b/README.md
@@ -87,6 +87,7 @@ This is the secure Node.js environment. It handles all I/O, persistence, and sec
 This is the sandboxed browser environment. It handles presentation.
 
 - **Frontend:** **React + TypeScript**
+- **Locale:** **English-only** — user-facing copy is inline string literals (or a local named constant when the same text is used in 3+ places). No i18n libraries.
 - **Styling:** **Tailwind CSS + shadcn/ui** (modern UI, good baseline A11y).
 - **State Management:** **Zustand** (minimalistic state layer, aligned with KISS/YAGNI).
 - **Data Fetching:** **TanStack Query (React Query)** (caching, loading states, API boundary).
@@ -111,7 +112,7 @@ The application is organized into the following main sections accessible via the
 - **Playlists (Collections)** - Create and manage curated collections of posts
 - **Statistics** - Extended local metrics and distribution charts via `getExtendedStats` (counts, pie charts, top artists/tags, provider artist split, DB size)
 - **Tracked (Artists/Tags management)** - Manage tracked artists, tags, and subscriptions
-- **Settings** - Configure downloads, sync behavior, appearance, account key, and backup/restore
+- **Settings** - Configure downloads, sync, appearance, account, backup/restore, and Danger-zone wipe
 
 ## 🎨 Core UX Principles
 
@@ -190,6 +191,7 @@ Settings are organized into tabs for faster scanning and lower cognitive load:
 - **Duplicate behavior** - `skip` or `overwrite` for existing files
 - **Folder structure** - `flat` or `{artist_id}` subfolder mode
 - **Proxy URL** - Optional HTTP/HTTPS proxy for outbound requests/downloads
+- **Danger zone — Delete all data** - Confirmed wipe of everything under `.rdcache` (database, `video-cache/`, logs, in-app backups, Electron cache), then quit. Does **not** delete the separate media download folder. Prefer this over uninstall alone (uninstall leaves `.rdcache`).
 
 ### Sync
 
@@ -230,7 +232,7 @@ The application is stable and production-ready (see **`package.json`** → `vers
 - ✅ **Build System:** electron-vite for optimal build performance
 - ✅ **Database Architecture:** Direct synchronous access via `better-sqlite3` in Main Process with WAL mode for concurrent reads
 - ✅ **User Data Path:** Neutral `.rdcache` directory for dev and packaged builds (same location on a given machine)
-- ✅ **Testing Architecture:** Vitest (unit, integration, property/fuzzing), Playwright (E2E); CI runs `validate` and `npm test` on every push/PR
+- ✅ **Testing Architecture:** Vitest (unit, integration, property/fuzzing), Playwright (E2E); CI runs `validate`, `docs:api` freshness, and `npm test` on every push/PR
 - ✅ **Dual ABI Support:** Automatic switching between Node.js and Electron ABI for `better-sqlite3` during testing
 - ✅ **HMR Status:** Renderer HMR is enabled, and Main/Preload sources are watched in development for faster backend iteration.
 
@@ -247,9 +249,10 @@ The application is stable and production-ready (see **`package.json`** → `vers
 
 ### Security & Reliability
 
-- ✅ **Secure Storage:** API credentials encrypted using Electron's `safeStorage` API (Windows Credential Manager, macOS Keychain, Linux libsecret). Credentials encrypted at rest, decryption only in Main Process
-- ✅ **Database Backup/Restore:** Manual backup and restore functionality implemented with integrity checks. Create timestamped backups and restore from files
-- ✅ **Input Validation:** Zod validation implemented per IPC handler via `BaseController`
+- ✅ **Secure Storage:** API credentials encrypted using Electron's `safeStorage` API via **`SecureStorage` only** (no parallel crypto helpers). Credentials encrypted at rest; decryption only in Main Process
+- ✅ **Database Backup/Restore:** Manual backup and restore with integrity checks; configurable retention
+- ✅ **Wipe all data:** Settings → General → Danger zone deletes `.rdcache` contents and quits
+- ✅ **Input Validation:** Zod validation per IPC handler via `BaseController` (collapse for idempotent; spacing for mutate)
 - ✅ **Context Isolation:** Enabled globally with sandbox mode for maximum security
 - ✅ **CSP (Content Security Policy):** Strict CSP in production, relaxed for development (HMR support)
 - ✅ **User Data Path:** Packaged and dev builds use `%LOCALAPPDATA%/.rdcache` on Windows (not a folder next to the executable)
@@ -263,6 +266,7 @@ The application is stable and production-ready (see **`package.json`** → `vers
 - ✅ **Provider Pattern:** Multi-booru support via `IBooruProvider` interface (Rule34, Gelbooru)
 - ✅ **Rate Limiting:** Intelligent rate limiting with 1.5s delay between artists, 0.5s between pages
 - ✅ **Anti-Bot Measures:** Shared throttling/UA strategy applied across current providers.
+- ⚠️ **Open P0:** video-cache file integrity (atomic writes) and sync `lastPostId` cursor integrity — see [Roadmap](./docs/roadmap.md#open-p0-audit--not-yet-shipped)
 
 ### UI/UX
 
@@ -490,6 +494,9 @@ Local packaging scripts: `npm run dist:win`, `npm run dist:linux` (after `npm ru
 # Typecheck + ESLint + renderer <img> loading/decoding policy
 npm run validate
 
+# Regenerate IPC channel reference (commit docs/api.md if it changes)
+npm run docs:api
+
 # Individual steps (if needed)
 npm run typecheck
 npm run lint
@@ -504,7 +511,7 @@ npm run test:verify
 
 ### Testing
 
-**Vitest** covers unit, integration, and property-based tests (**171 tests** across 25 files). **Playwright** covers E2E flows. Full suite inventory: [`tests/unit/TEST_COVERAGE.md`](tests/unit/TEST_COVERAGE.md).
+**Vitest** covers unit, integration, and property-based tests (**183 tests** across 27 files). **Playwright** covers E2E flows. Full suite inventory: [`tests/unit/TEST_COVERAGE.md`](tests/unit/TEST_COVERAGE.md).
 
 ```bash
 # Full suite: rebuild for Node → run all Vitest tests → rebuild for Electron
@@ -563,7 +570,7 @@ If integration tests fail with `NODE_MODULE_VERSION` mismatch, run `npm run db:r
 
 GitHub Actions workflow (`.github/workflows/ci.yml`):
 
-1. **Quality** — `npm run validate`, `npm test`, `npm audit --omit=dev --audit-level=high`
+1. **Quality** — `npm run validate`, `npm run docs:api` + freshness check on `docs/api.md`, `npm test`, `npm audit --omit=dev --audit-level=high`
 2. **E2E** — build app, run Playwright (needs `TEST_USER_ID` / `TEST_API_KEY` secrets for live API tests)
 3. **Release** (tags only) — Windows zip + Linux AppImage (parallel jobs), merged into one GitHub Release after quality + e2e pass
 

--- a/docs/api-guide.md
+++ b/docs/api-guide.md
@@ -400,7 +400,9 @@ await window.api.wipeAllData();
 
 ### `getVideoProxyUrl(fileUrl: string)`
 
-Returns a `http://127.0.0.1` URL served by the main-process `VideoProxyServer` that forwards Range requests to the original HTTPS CDN and caches full responses under `{userData}/video-cache/`. The renderer should use the returned value as the `<video src>` (with a temporary fallback to the direct CDN URL while this promise resolves). Input is validated with `z.string().url()`. Only the same host allowlist enforced by the proxy is permitted; other URLs are rejected with HTTP 400 if passed through the proxy.
+Returns a `http://127.0.0.1` URL served by the main-process `VideoProxyServer` that forwards Range requests to the original HTTPS CDN and writes cache files under `{userData}/video-cache/`. The renderer should use the returned value as the `<video src>` (with a temporary fallback to the direct CDN URL while this promise resolves). Input is validated with `z.string().url()`. Only the same host allowlist enforced by the proxy is permitted; other URLs are rejected with HTTP 400 if passed through the proxy.
+
+⚠️ **Known integrity gap (open P0):** cache writes are not yet atomic (tmp + rename). A client abort or mid-write failure can leave a partial/corrupt file that later `existsSync` hits treat as a valid cache. Until `fix/video-cache-integrity` lands, do not assume every file under `video-cache/` is a complete response.
 
 **Returns:** `Promise<string>`
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -504,8 +504,9 @@ const posts = await db.query.posts.findMany({
    - `MaintenanceController.ts` - Database backup/restore operations
    - `ViewerController.ts` - Viewer-related operations
    - `FileController.ts` - File download and management
-   - `SystemController.ts` - System-level operations (version, clipboard, etc.)
+   - `SystemController.ts` - System-level ops (version, clipboard, icon path, quit, **`wipeAllData`**)
    - `SearchController.ts` - Booru search and tag resolution (`searchBooru` with Rule34 cursor pagination, `resolveTags`, `resolveCharacterTags`, `resolveCopyrightTags`, `resolveTagsByType`, blacklist filtering)
+   - `PlaylistController.ts` - Playlist CRUD, smart queries, import/export
 
    **BaseController** (`src/main/core/ipc/BaseController.ts`):
 
@@ -580,18 +581,24 @@ const posts = await db.query.posts.findMany({
 
    - Slim typed instance registry (`Container` + `DI_TOKENS`) — stores instances, not factories
    - Internal `Map` keyed by **`token.id` string** (stable across hot reload; not object identity). Two `new Token('Database')` instances resolve the same service if registered once.
+   - No cycle-detection / factory theater — YAGNI for this app size
    - Singleton pattern for service management
    - Services: Database, SyncService, BackupService, SyncScheduler
    - Unit tests: `tests/unit/core/di-container.test.ts`
 
-6. **Maintenance Queue** (`src/main/db/maintenance-queue.ts`)
+6. **App lifecycle (Main)**
+
+   - Process-lifetime listeners such as `before-quit` are registered **once** at module scope (not inside window recreate paths)
+   - `closeDatabase` is idempotent; tray Show / `activate` may recreate the window and re-bind IPC (`removeHandler` first) without stacking quit handlers
+
+7. **Maintenance Queue** (`src/main/db/maintenance-queue.ts`)
 
    - Sequential execution queue for database maintenance operations
    - Prevents race conditions and "Database is closed" errors
    - Promise-based queue ensures operations complete before next starts
    - Used for backup, restore, and database close operations
 
-7. **Booru Providers** (`src/main/providers/`)
+8. **Booru Providers** (`src/main/providers/`)
 
    - Provider pattern abstraction for multi-booru support
    - `IBooruProvider` interface for standardized booru operations
@@ -599,30 +606,30 @@ const posts = await db.query.posts.findMany({
    - Methods: `checkAuth`, `fetchPosts`, `searchTags`, `formatTag`
    - Rule34 media URLs (`fileUrl`, `sampleUrl`, `previewUrl`) are rewritten by Main Process CDN selector to the currently selected Rule34 CDN host
 
-8. **CDN Selector Service** (`src/main/services/cdn-selector.ts`)
+9. **CDN Selector Service** (`src/main/services/cdn-selector.ts`)
 
    - Probes Rule34 CDN hosts (`rule34.xxx`, `us.rule34.xxx`, `wimg.rule34.xxx`, `api-cdn.rule34.xxx`) on startup using non-blocking `HEAD` checks
    - Selects the fastest reachable host and keeps `rule34.xxx` as fallback
    - Triggers re-probe on repeated request failures or slow responses
    - Rewrites only Rule34 media hosts, leaving non-Rule34 URLs unchanged
 
-9. **Updater Service** (`src/main/services/updater-service.ts`)
+10. **Updater Service** (`src/main/services/updater-service.ts`)
 
    - Manages automatic update checking via `electron-updater`
    - Handles update download and installation
    - Emits IPC events for update status and progress
    - User-controlled download (manual download trigger)
 
-10. **Secure Storage** (`src/main/services/secure-storage.ts`) and **credential helpers** (`src/main/utils/decrypted-credentials.ts`)
+11. **Secure Storage** (`src/main/services/secure-storage.ts`) and **credential helpers** (`src/main/utils/decrypted-credentials.ts`)
 
-   - `SecureStorage.encrypt()` / `decrypt()` — static wrappers around Electron `safeStorage`; `decrypt()` returns `null` on failure (never raw ciphertext)
+   - `SecureStorage.encrypt()` / `decrypt()` — static wrappers around Electron `safeStorage`; `decrypt()` returns `null` on failure (never raw ciphertext). **Sole** crypto path — do not reintroduce parallel helpers.
    - `getDecryptedCredentialsFromRecord()` — shared by IPC controllers; returns `null` if decryption fails
    - `getDecryptedCredentialsStrict()` — used by `SyncService`; throws `CredentialDecryptionError` instead of falling back to stored ciphertext
    - Decryption only occurs in Main Process when needed for API calls
    - Uses platform keychain (Windows Credential Manager, macOS Keychain, Linux libsecret)
-   - Unit tests: `tests/unit/utils/decrypted-credentials.test.ts`
+   - Unit tests: `tests/unit/utils/decrypted-credentials.test.ts`, `tests/unit/services/secure-storage.test.ts`
 
-11. **Browse** (`src/renderer/components/pages/Browse.tsx`, `SearchController.search`, `src/renderer/utils/react-query-cache.ts`)
+12. **Browse** (`src/renderer/components/pages/Browse.tsx`, `SearchController.search`, `src/renderer/utils/react-query-cache.ts`)
 
    - **Remote gallery (Source: All):** live booru search via IPC `searchBooru`, infinite scroll through `useGalleryInfiniteScroll`.
    - **Rule34 deep pagination:** offset pages 1–4 (`RULE34_MAX_OFFSET_PAGES`), then cursor via meta-tag `id:<postId>` (`beforePostId` / `nextBeforePostId`); `getSearchBrowseNextPageParam()` drives React Query `pageParam`.
@@ -636,14 +643,14 @@ const posts = await db.query.posts.findMany({
    - **Removed:** orientation filter (no UI; dead code removed from store, worker, and gallery pages).
    - Unit tests: `tests/unit/hooks/useWorkerFilteredPosts.test.ts`, `tests/unit/utils/react-query-cache.test.ts`.
 
-12. **Bridge** (`src/main/bridge.ts`, built to `out/preload/bridge.cjs`)
+13. **Bridge** (`src/main/bridge.ts`, built to `out/preload/bridge.cjs`)
 
 - Defines the IPC interface exposed as `window.api`
 - Preload forwards `ipcRenderer.invoke` / event subscriptions only — no business logic, no shared-schema imports
 - Type-safe communication contract (TypeScript types on both sides)
 - Provider-search error normalization happens in Main (`throwProviderSearchIpcError`) and Renderer (`parseProviderSearchErrorPayload`), not in preload
 
-13. **Main Entry** (`src/main/main.ts`)
+14. **Main Entry** (`src/main/main.ts`)
     - Application initialization
     - Window creation
     - Security configuration
@@ -660,6 +667,7 @@ const posts = await db.query.posts.findMany({
 - User interactions
 - State management
 - Data presentation
+- **English-only UI copy** — inline literals (or local constants at 3+ call sites); no `i18next` / locale packs under `src/renderer/`
 
 **Key Components:**
 
@@ -708,7 +716,7 @@ const posts = await db.query.posts.findMany({
   - **Settings (`src/renderer/features/settings/`):**
 
     - **Settings.tsx** - Tab container and settings orchestration
-    - **SettingsGeneralTab.tsx** - Downloads + proxy configuration
+    - **SettingsGeneralTab.tsx** - Downloads, proxy, and Danger zone (`wipeAllData`)
     - **SettingsSyncTab.tsx** - Startup/interval sync + manual sync trigger
     - **SettingsAppearanceTab.tsx** - Theme selection (`System` / `Light` / `Dark`)
     - **SettingsBackupTab.tsx** - Backup, restore, integrity check, retention, and maintenance section
@@ -724,7 +732,7 @@ const posts = await db.query.posts.findMany({
 3. **IPC Client** (`window.api`)
    - Typed interface to Main process
    - All communication goes through this bridge
-  - Methods: getSettings, saveSettings, confirmLegal, getTrackedArtists, addArtist, deleteArtist, getArtistPosts, getArtistPostsCount, syncAll, openExternal, searchArtists, searchRemoteTags, searchBooru, resolveTags, resolveCharacterTags, resolveCopyrightTags, resolveTagsByType, markPostAsViewed, togglePostViewed, togglePostFavorite, downloadFile, openFileInFolder, createBackup, restoreBackup, getVacuumStatus, runVacuum, getVacuumSchedule, setVacuumSchedule, writeToClipboard, verifyCredentials, logout, resetPostCache, repairArtist, checkForUpdates, quitAndInstall, startDownload
+   - Channel inventory is generated into [`docs/api.md`](./api.md) via `npm run docs:api` — do not maintain a hand-copied method list here. Notable domains: settings/auth, artists/posts, search/tags, playlists, backup/VACUUM, updates, `getVideoProxyUrl`, `wipeAllData` (`system:wipe-all-data`).
 
 ## Security Architecture
 
@@ -1164,6 +1172,8 @@ sequenceDiagram
 
    g. **Updates artist** - Updates artist's `lastPostId` and `newPostsCount`.
 
+   ⚠️ **Known integrity gap (open P0):** `lastPostId` may advance mid-pagination or after a partial error commit. An interrupted sync can leave a cursor ahead of fully persisted posts and skip gaps on the next run. Do not document “cursor = fully synced watermark” until the sync-cursor integrity fix lands.
+
    h. **Progress event** - Emits IPC event: `emit('sync:progress', 'Syncing artist_name...')`
 
 5. **UI updates in real-time** - React component listens to progress events:
@@ -1400,7 +1410,7 @@ The project uses **electron-vite** for building both Main and Renderer processes
 
 **CI pipeline** (`.github/workflows/ci.yml`):
 
-1. `validate` → `npm test` → `npm audit --omit=dev --audit-level=high`
+1. `validate` → `docs:api` freshness (`git diff --exit-code docs/api.md`) → `npm test` → `npm audit --omit=dev --audit-level=high`
 2. E2E on built artifact
 3. Tagged releases (parallel native runners after quality + e2e):
    - **Windows:** `RuleDesk-*-win.zip` (`windows-latest`)

--- a/docs/database.md
+++ b/docs/database.md
@@ -914,11 +914,11 @@ If the database becomes corrupted and you need to restore manually:
 
 The application also exposes VACUUM maintenance controls in Settings:
 
-1. **Manual run:** `window.api.runVacuum()` executes `VACUUM;` in a dedicated worker thread.
+1. **Manual run:** `window.api.runVacuum()` executes `VACUUM;` in a dedicated **maintenance worker** (`vacuumWorker.ts`). This is the **only** intentional DB-related worker-thread exception: interactive CRUD stays on the Main thread via synchronous `better-sqlite3` + Drizzle; VACUUM is offloaded so the UI/IPC loop is not blocked for the duration of a full vacuum.
 2. **Status:** `window.api.getVacuumStatus()` returns last run time/result/error and in-memory `isRunning`.
 3. **Schedule policy:** `window.api.getVacuumSchedule()` / `window.api.setVacuumSchedule(...)` store user policy (`manual`, `weekly`, `monthly`) in `settings`.
 
-**Important:** `VACUUM` remains blocking for SQLite itself, but is isolated from the UI/IPC loop by running in a worker thread.
+**Important:** `VACUUM` remains blocking for SQLite itself, but is isolated from the UI/IPC loop by the maintenance worker. Do not use worker threads for ordinary CRUD — that remains forbidden (see `.cursorrules`).
 
 ## Performance Considerations
 

--- a/docs/glossary.md
+++ b/docs/glossary.md
@@ -130,9 +130,33 @@ The secure Node.js environment in Electron that handles all I/O, persistence, an
 
 ### Renderer Process
 
-The sandboxed browser environment in Electron that handles UI rendering and user interactions. The Renderer Process communicates with the Main Process via IPC.
+The sandboxed browser environment in Electron that handles UI rendering and user interactions. The Renderer Process communicates with the Main Process via IPC. UI copy is **English-only** (inline literals / local constants) — there is no i18n layer under `src/renderer/`.
 
 **Related:** [Architecture - Renderer Process](./architecture.md#renderer-process-the-face)
+
+---
+
+### Wipe all data
+
+Settings → General → **Danger zone** → confirmed delete of everything under the user data directory (`.rdcache`), including the database, `video-cache/`, logs, and in-app backups, then app quit. Does not delete the separate media download folder. IPC: `system:wipe-all-data` / `wipeAllData`.
+
+**Related:** [User Guide — Settings](./user-guide.md#settings), [API Reference](./api.md)
+
+---
+
+### Video proxy / video-cache
+
+Main-process `VideoProxyServer` serves local `http://127.0.0.1` URLs for `<video>` playback and stores files under `{userData}/video-cache/`. **Integrity of cache files is an open P0** (partial files may be treated as hits until atomic write lands).
+
+**Related:** [API Guide — getVideoProxyUrl](./api-guide.md#getvideoproxyurlfileurl-string), [Roadmap — Open P0](./roadmap.md#open-p0-audit--not-yet-shipped)
+
+---
+
+### Sync cursor (`lastPostId`)
+
+Per-artist watermark used for incremental sync. **Open P0:** advancing the cursor on incomplete pagination/error paths can skip posts. Treat as “best effort” until the integrity fix ships.
+
+**Related:** [Architecture — Sync](./architecture.md), [Roadmap — Open P0](./roadmap.md#open-p0-audit--not-yet-shipped)
 
 ---
 
@@ -326,9 +350,17 @@ An error handling strategy that increases wait time between retry attempts. Rule
 
 ### validate (npm script)
 
-Local quality gate: `npm run typecheck` + `npm run lint` + `npm run check:img-attrs`. Same command runs in CI before tests.
+Local quality gate: `npm run typecheck` + `npm run lint` + `npm run check:img-attrs`. CI runs this before `docs:api` freshness and tests.
 
 **Related:** [README — Quality Checks](../README.md#quality-checks)
+
+---
+
+### docs:api (npm script)
+
+Regenerates the IPC channel reference (`docs/api.md`) from `channels.ts` and handler registrations. Hand-editing `api.md` is forbidden; CI fails if the file is stale.
+
+**Related:** [API Reference](./api.md), [API Guide](./api-guide.md), [README — Quality Checks](../README.md#quality-checks)
 
 ---
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -100,9 +100,9 @@ Engineering materials are intentionally grouped here to keep the top-level index
 - [Rule34 API Reference](./rule34-api-reference.md) - External API specifics
 - [README — Development Setup](../README.md#-development-setup) - Local dev, quality gates, testing, CI/CD
 - [Unit test guide](../tests/unit/README.md) - Vitest unit/property test layout
-- [Test coverage summary](../tests/unit/TEST_COVERAGE.md) - Suite inventory (**171** Vitest tests across 25 files)
+- [Test coverage summary](../tests/unit/TEST_COVERAGE.md) - Suite inventory (**183** Vitest tests across 27 files)
 - [Integration test notes](../tests/integration/README.md) - IPC + SQLite integration tests
-- [.cursorrules](../.cursorrules) - Engineering standards
+- [.cursorrules](../.cursorrules) - Engineering standards (includes English-only UI copy; no i18n stack)
 - [Canonical Lessons](../.ai/LESSONS.txt) - Reusable invariants (do not add root `LESSONS.md`)
 
 ### Quality gates (local & CI)
@@ -111,7 +111,7 @@ Engineering materials are intentionally grouped here to keep the top-level index
 |------|---------|
 | Typecheck + lint + img policy | `npm run validate` |
 | IPC API docs freshness | `npm run docs:api` (CI: then `git diff --exit-code docs/api.md`) |
-| All Vitest suites (171 tests) | `npm test` |
+| All Vitest suites (183 tests) | `npm test` |
 | Pre-PR full gate | `npm run test:verify` |
 | Production dependency audit | `npm audit --omit=dev --audit-level=high` |
 
@@ -169,8 +169,10 @@ This documentation is maintained alongside the codebase. When making changes:
 3. **Update glossary** - Add new terms to [Glossary](./glossary.md)
 4. **Keep lessons canonical** - Update [`.ai/LESSONS.txt`](../.ai/LESSONS.txt) for reusable engineering invariants
 5. **Check links** - Verify all internal links work correctly
+6. **IPC reference** - After channel/handler changes, run `npm run docs:api` and commit `docs/api.md` (do not hand-edit)
+7. **UI copy** - App is English-only; do not reintroduce i18n libraries or locale JSON packs
 
 ---
 
-**Last Updated:** May 2026 — v16.2.x post-audit: credentials helper, DI token.id keys, sync queue, artist cap, worker mapping, expanded Vitest coverage (see [TEST_COVERAGE.md](../tests/unit/TEST_COVERAGE.md)).
+**Last Updated:** July 2026 — Docs sync for audit series PRs #105–#112 (IPC collapse/throttle, `as` policy, SecureStorage-only crypto, slim DI, lifecycle hygiene, wipe-all-data, generated `docs/api.md`, English-only UI) + honest open P0s (video-cache integrity, sync cursor). Vitest **183** / **27** files.
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -116,7 +116,7 @@ The short version: the core product is shipped, now we focus on parity gaps and 
 ### M2 - UX Parity (In Progress)
 
 - ✅ Filter panel is aligned to **AI/media/source** scope.
-- ⏳ Settings page redesign (see [Planned product work](#planned-product-work)) remains product-driven.
+- ✅ Settings tabbed IA shipped (General / Sync / Appearance / Backup / Account), including Danger-zone wipe.
 - Gallery/viewer: edge-case polish; core **TagsDrawer** and **PostCard** progressive loading are shipped.
 - Updates feed QoL largely shipped (Creators tab, mark all read); further polish as needed.
 
@@ -128,15 +128,32 @@ The short version: the core product is shipped, now we focus on parity gaps and 
 
 ## 🔧 Technical Improvements (From Audit) & DX
 
-- ✅ **Testing:** Vitest (unit, integration, property/fuzzing) + Playwright; `test:run` / watch / coverage rebuild `better-sqlite3` for Node before running; `npm test` restores Electron ABI via `posttest`.
-- ✅ **CI:** `validate`, `npm test`, and production `npm audit --omit=dev --audit-level=high` on every push/PR; release tags wait for quality + e2e, then publish Windows zip + Linux AppImage (macOS binaries not distributed).
-- ✅ **Dependencies:** Removed unused UI packages; `repomix` in devDependencies; security bumps (Electron 39.8.x, drizzle-orm 0.45+, axios, dompurify, react-router-dom).
-- ✅ **Main process dev experience:** main sources are watched in development (`electron.vite.config.ts`), closing the previous manual-restart-only loop for routine IPC/service edits.
-- ✅ **Shared validation in Main:** IPC controller registration uses typed wrapper handlers; shared tuple parsing helpers in handler modules where appropriate.
-- ✅ **Video pipeline baseline:** hardware decode flags and `<video>` attribute tuning landed; remaining work is regression-driven per platform/device.
-- ✅ **Post-audit regression tests:** Vitest coverage for decrypt fail-safe, DI token keys, artist list cap, sync/repair serialization, worker post mapping, provider search IPC payload parsing, Rule34 fetch error classification, and tag-resolve dedup (171 tests total).
-- ✅ **Provider search errors:** Typed provider failures, IPC-safe serialization, `BrowseErrorState` UI, sync auth → `SYNC.ERROR` (no silent empty Browse on auth/429).
-- ⏳ **Tooling / hygiene:** keep `validate` green; optional stricter policy on logging and IPC surface over time. Remaining dev-only audit noise (electron-builder transitive deps) is tracked separately from production `npm audit`.
+### Shipped (Jul 2026 — PRs #105–#112)
+
+- ✅ **IPC collapse + throttle** (#105): idempotent handlers collapse by full canonical args hash; mutating handlers space calls (~100ms sleep), never reject with rate-limit errors.
+- ✅ **Type assertion policy** (#106): ESLint `no-unsafe-type-assertion` on `src/**`; closed `as` boundary allowlist in `.cursorrules` / LESSONS 3b.
+- ✅ **Crypto unify** (#107): single `SecureStorage` path; `src/main/lib/crypto.ts` removed.
+- ✅ **DI container slim** (#108): typed instance registry keyed by `token.id` (no dead cycle-detection theater).
+- ✅ **Main lifecycle + repo hygiene** (#109): one-shot `before-quit`; idempotent DB close; `coverage/` untracked.
+- ✅ **Wipe all data** (#110): `system:wipe-all-data` + Settings → General → Danger zone.
+- ✅ **Generated IPC docs** (#111): `npm run docs:api` → `docs/api.md`; CI freshness check; narrative in `docs/api-guide.md`.
+- ✅ **English-only UI** (#112): removed `i18next` / `react-i18next` / locale packs; inline literals (+ local constants at 3+ uses).
+
+### Baseline DX (earlier)
+
+- ✅ **Testing:** Vitest (unit, integration, property/fuzzing) + Playwright; ABI rebuild scripts for Node vs Electron.
+- ✅ **CI:** `validate` → `docs:api` freshness → `npm test` → production `npm audit --omit=dev --audit-level=high`; release tags wait for quality + e2e, then Windows zip + Linux AppImage.
+- ✅ **Post-audit regression tests:** **183** Vitest tests across **27** files (includes collapse/throttle + `SecureStorage` suites — see [`TEST_COVERAGE.md`](../tests/unit/TEST_COVERAGE.md)).
+- ✅ **Main process HMR/watch**, shared Zod IPC helpers, provider search typed errors, video pipeline baseline (`<video>` attrs / hardware decode flags).
+
+### Open P0 (audit — not yet shipped)
+
+| Item | Hazard | Target branch (planned) |
+|------|--------|-------------------------|
+| **Video cache integrity** | Partial/corrupt files under `video-cache/` can be served as hits | `fix/video-cache-integrity` |
+| **Sync cursor integrity** | `lastPostId` may advance on incomplete sync → skipped posts | sync-cursor integrity fix |
+
+- ⏳ **Tooling / hygiene:** keep `validate` green; remaining shared validation consolidation as needed. Dev-only audit noise (electron-builder transitive deps) is separate from production `npm audit`.
 
 ## 🏗️ Architecture Considerations
 
@@ -175,11 +192,12 @@ Items explicitly scheduled for product/engineering (beyond small bugs).
 
 | Area | What is still open |
 |------|--------------------|
+| **P0 integrity** | Video-cache atomic writes; sync `lastPostId` only after complete durable batches (see [Open P0](#open-p0-audit--not-yet-shipped)). |
 | **Filters** | Keep filter scope lean (`AI`, `Media`, `Source`) and avoid reintroducing removed panel controls without product decision (**scope is already implemented; this is a guardrail**). |
 | **Search** | Continue polish/regression coverage for chip-based syntax (`-tag`, OR groups, wildcard/fuzzy). |
 | **Navigation & layout** | **Optional** polish: tooltips, item order tuning, and small-window density improvements (see [Navigation, layout, shell](#d-navigation-layout-shell)). |
 | **Backups** | `keep last N` is implemented; optional **total-size cap** is also supported via `BACKUP_RETENTION_MAX_TOTAL_MB` env for deployments that need hard storage ceilings. UI exposure for this cap remains optional future UX work. |
-| **Engineering** | [Technical Improvements & DX](#-technical-improvements-from-audit--dx): remaining **shared** validation helper consolidation and ongoing tooling hygiene. |
+| **Engineering** | Ongoing tooling hygiene; remaining shared validation consolidation as needed. |
 | **Product** | **Smart Collections AI** (research). |
 
 **Providers:** new sites must implement **`ProviderThrottle`**-class behavior; Rule34 and Gelbooru already share `ProviderThrottle` — not a “gap” unless adding a **third** backend.

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -429,6 +429,7 @@ Settings are split into tabs:
 - **When file already exists** - Choose `Skip` or `Overwrite`
 - **Folder structure** - `Flat` or `By artist`
 - **Proxy URL** - Optional HTTP/HTTPS proxy for requests/downloads
+- **Danger zone** - **Delete all data…** (checkbox + confirm). Closes the DB, stops the video proxy, deletes the contents of `.rdcache`, and quits. Media downloads outside `.rdcache` are not removed.
 
 ### Sync
 
@@ -556,6 +557,25 @@ Open **Statistics** from the sidebar to see a quick health overview of your loca
 2. Clear restrictive filters (AI, media, rating, date) — client-side filters only apply to already loaded pages
 3. If using **Favorites** / **Subscriptions**, add at least one tag in the search bar (required by design)
 4. If Browse shows a centered error screen (not the empty “no posts” state), use **Retry** or **Open Settings** for auth failures — messages distinguish invalid API credentials, rate limits, and network errors
+
+### Video playback glitches / stuck loading
+
+**Problem:** A video fails to play, stalls, or shows a broken frame after a previous interrupt.
+
+**Solutions:**
+
+1. Retry opening the post (proxy may fall back to the direct CDN URL while resolving)
+2. If problems persist across many videos, manually delete the `video-cache` folder under `.rdcache` and restart — or use **Settings → General → Danger zone → Delete all data** as a last resort (wipes all of `.rdcache`)
+3. Known limitation: cache writes are not yet atomic — a mid-download abort can leave a bad file that looks like a cache hit (open P0 — see [roadmap](./roadmap.md#open-p0-audit--not-yet-shipped))
+
+### Artist sync seems to skip newer posts
+
+**Problem:** After an interrupted or failed sync, later syncs miss posts that should appear.
+
+**Solutions:**
+
+1. Use **Repair** on the artist (resync from the beginning)
+2. Known limitation: `lastPostId` can advance on incomplete sync batches (open P0 — see [roadmap](./roadmap.md#open-p0-audit--not-yet-shipped))
 
 ### App is slow
 

--- a/tests/unit/TEST_COVERAGE.md
+++ b/tests/unit/TEST_COVERAGE.md
@@ -2,7 +2,7 @@
 
 ## Overview
 
-Vitest covers unit logic, integration flows (IPC + SQLite), and property-based fuzzing. The default `npm test` run executes **171 tests** across **25 files** (unit + integration + property).
+Vitest covers unit logic, integration flows (IPC + SQLite), and property-based fuzzing. The default `npm test` run executes **183 tests** across **27 files** (unit + integration + property). Helper suites under `tests/helpers/` and `tests/utils/` are separate and not counted in that total.
 
 ## Test files (unit)
 
@@ -11,10 +11,11 @@ Vitest covers unit logic, integration flows (IPC + SQLite), and property-based f
 | `hooks/useGalleryInfiniteScroll.test.ts` | 7 | Infinite scroll pagination |
 | `hooks/useWorkerFilteredPosts.test.ts` | 7 | Worker post → Post field mapping |
 | `lib/filter-utils.test.ts` | 29 | AI tags, video detection |
-| `utils/decrypted-credentials.test.ts` | 7 | API key decrypt fail-safe |
+| `utils/decrypted-credentials.test.ts` | 10 | API key decrypt fail-safe |
 | `utils/parse-credentials.test.ts` | 6 | Credential paste parsing |
-| `utils/react-query-cache.test.ts` | 7 | Browse pagination / cursor helpers |
-| `core/di-container.test.ts` | 6 | DI token.id Map keys |
+| `utils/react-query-cache.test.ts` | 8 | Browse pagination / cursor helpers |
+| `core/di-container.test.ts` | 6 | Slim DI registry (`token.id` Map keys) |
+| `core/BaseController.collapse-throttle.test.ts` | 6 | Idempotent collapse (full-args hash) + mutate spacing |
 | `components/filters/SourceSwitcher.test.ts` | 8 | Source filter |
 | `components/filters/FilterToggleGroup.test.ts` | 8 | Toggle group |
 | `components/layout/GridContainer.test.ts` | 8 | Grid/masonry layout |
@@ -26,14 +27,14 @@ Vitest covers unit logic, integration flows (IPC + SQLite), and property-based f
 | `shared/provider-search-ipc-payload.test.ts` | 8 | Provider IPC error parsing |
 | `providers/rule34-provider-fetch-posts.test.ts` | 5 | fetchPosts error classification |
 | `services/tag-resolve-coordinator.test.ts` | 3 | Tag resolve dedup / rate limit |
+| `services/secure-storage.test.ts` | 3 | `SecureStorage` encrypt/decrypt (sole crypto path) |
 
 ## Other Vitest suites
 
-| Suite | Location | Tests (approx.) |
-|-------|----------|-----------------|
-| Integration | `tests/integration/` | 22 |
+| Suite | Location | Tests |
+|-------|----------|-------|
+| Integration | `tests/integration/` | 16 |
 | Property / fuzzing | `tests/property/fuzzing.test.ts` | 12 |
-| Helpers | `tests/helpers/mock-db.test.ts`, `tests/utils/db.test.ts` | — |
 
 ### Integration highlights
 
@@ -64,9 +65,11 @@ npm run test:verify                   # validate + all tests + ABI restore
 - Integration tests use in-memory SQLite (`tests/helpers/mock-db.ts`)
 - Property tests guard schema and SQL escaping invariants
 - Post-audit: pure `mapWorkerPostToPost()` in `src/renderer/lib/map-worker-post.ts` (tested without Web Worker)
+- Crypto tested via `SecureStorage` only (`src/main/lib/crypto.ts` removed)
 
 ## Future improvements
 
 1. Component rendering tests with `@testing-library/react` (optional)
 2. Broader IPC contract tests via shared Zod schemas
 3. Visual regression for masonry/grid layouts (Playwright)
+4. Coverage for video-cache atomic writes and sync-cursor integrity once those P0 fixes land


### PR DESCRIPTION
- Clarified database access rules in `.cursorrules`, specifying that user-triggered `VACUUM` may run in a dedicated maintenance worker to avoid blocking the Main IPC loop.
- Enhanced `README.md` to reflect the English-only UI copy policy and updated settings documentation to include the new Danger-zone wipe functionality.
- Updated `api-guide.md` to note the integrity gap in video-cache writes and the implications for users.
- Revised `architecture.md` to include recent changes in controller responsibilities and IPC structure.
- Adjusted `glossary.md` to define new terms related to data wiping and video proxy integrity.

These updates aim to improve clarity and maintainability of documentation, ensuring developers and users are well-informed about system operations and limitations.