### PR TITLE
chore: align as-assertion ESLint gate with boundary policy

### DIFF
--- a/.ai/LESSONS.txt
+++ b/.ai/LESSONS.txt
@@ -28,9 +28,14 @@ Root Cause: Idempotent handlers were treated like mutating ones, or collapse key
 Invariant Rule: Mark truly idempotent handlers; collapse in-flight calls by hashing the full canonical args; space mutating calls with delay (never reject).
 
 3b) Type Assertion Policy
-Problem: Project rules banned all `as` casts while the codebase kept 100+ assertions — Cursor treated the rule as decorative.
-Root Cause: No enforced allowlist and no ESLint gate for narrowing assertions.
-Invariant Rule: `as` is forbidden except the closed boundary list: (1) `container.resolve` DI Map return; (2) better-sqlite3 raw `.prepare().get()`/`.all()` rows (includes drizzle instance typing); (3) Web Worker `workerData`/message payloads after Zod or trusted IPC handoff; (4) internals of `toIpcSafe` conditional return branches; (5) TanStack Query generic inference gaps (`pageParam` / default page flatten). Every allowed assertion MUST have `// boundary: <reason>` on the preceding line (and `eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion` when that rule fires). Fix types upstream or use Zod.parse — do not cast.
+Problem: Project rules banned all `as` casts while the codebase kept assertions — Cursor treated the rule as decorative when the gate only banned narrowing (`no-unsafe-type-assertion`).
+Root Cause: Policy text required a full allowlist gate, but CI only enforced unsafe narrowing; `// boundary:` comments without `eslint-disable` were not forced.
+Invariant Rule: `as` is forbidden except `as const` and the closed boundary list: (1) `container.resolve` DI Map return; (2) better-sqlite3 raw `.prepare().get()`/`.all()` rows (includes drizzle instance typing); (3) Web Worker `workerData`/message payloads after Zod or trusted IPC handoff; (4) internals of `toIpcSafe` conditional return branches; (5) TanStack Query generic inference gaps (`pageParam` / default page flatten). Every allowed assertion MUST have `// boundary: <reason>` and `eslint-disable-next-line` for every rule that fires (`no-restricted-syntax`; also `@typescript-eslint/no-unsafe-type-assertion` when it reports). Gate: `no-restricted-syntax` on `TSAsExpression` excluding `as const`, plus `no-unsafe-type-assertion`. Fix types upstream or use Zod.parse — do not cast.
+
+3c) Syntax Policy Inventory Must Use AST
+Problem: Policy-violation counts from `grep`/`rg` for ` as ` were inflated by an order of magnitude and drove wrong “partial gate” conclusions.
+Root Cause: Regex matches `import * as X`, SQL `AS alias`, and English prose, not TypeScript `TSAsExpression` nodes.
+Invariant Rule: Inventory of syntactic constructs (type assertions, etc.) MUST use AST (ESLint selector / parser). Grep totals are not decision inputs.
 
 4) Virtualized Gallery Holes
 Problem: Large empty scroll area in filtered lists.

--- a/.cursorrules
+++ b/.cursorrules
@@ -37,7 +37,7 @@ You do not tolerate sloppy code, "any" types, "as" casting, magic numbers, or pr
 4. **TypeScript & Code Quality**:
 
    - **Strict Types**: NO `any`. Use `unknown` with narrowing.
-   - **No Unsafe Casting**: `as` is forbidden except the closed **boundary** list below. Every allowed assertion MUST have `// boundary: <reason>` on the preceding line (and `eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion` when that rule fires). Fix types upstream or use Zod.parse — do not cast.
+   - **No Unsafe Casting**: `as` is forbidden except the closed **boundary** list below (and except `as const`). Enforcement: ESLint `no-restricted-syntax` on `TSAsExpression` (excluding `as const`) plus `@typescript-eslint/no-unsafe-type-assertion` for narrowing. Every allowed assertion MUST have `// boundary: <reason>` on the preceding line and `eslint-disable-next-line` listing every rule that fires for that site (`no-restricted-syntax`, and `@typescript-eslint/no-unsafe-type-assertion` when it reports). Fix types upstream or use Zod.parse — do not cast.
      - **Boundary allowlist:** (1) `container.resolve` return from the DI Map; (2) better-sqlite3 raw `.prepare().get()` / `.all()` rows (includes drizzle instance typing); (3) Web Worker `workerData` / message payloads after Zod validation or trusted IPC handoff; (4) internals of `toIpcSafe` conditional return branches; (5) TanStack Query generic inference gaps (`pageParam` / default page flatten).
    - **No Magic**: NO Magic Numbers or Magic Strings. Extract constants.
    - **Definitions**: Use `type` for fixed definitions, `interface` for extendable structures.

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -75,8 +75,19 @@ export default tseslint.config(
           objectLiteralTypeAssertions: "never",
         },
       ],
-      // Ban narrowing type assertions; boundary casts use // boundary: + eslint-disable-next-line
+      // Narrowing-only safety net (kept); full policy gate is no-restricted-syntax below.
       "@typescript-eslint/no-unsafe-type-assertion": "error",
+      // Policy gate: every `as` except `as const` requires // boundary: + eslint-disable-next-line
+      // (selector verified: as const uses TSTypeReference typeName.name === "const")
+      "no-restricted-syntax": [
+        "error",
+        {
+          selector:
+            'TSAsExpression:not(:has(> TSTypeReference[typeName.name="const"]))',
+          message:
+            '`as` type assertions are forbidden except the closed boundary allowlist in .cursorrules. Allowed sites need `// boundary: <reason>` and `eslint-disable-next-line` for every rule that fires (`no-restricted-syntax`; also `@typescript-eslint/no-unsafe-type-assertion` when it reports). Prefer upstream types or Zod.parse. `as const` is allowed.',
+        },
+      ],
     },
   }
 );

--- a/src/main/core/di/Container.ts
+++ b/src/main/core/di/Container.ts
@@ -68,7 +68,7 @@ export class Container {
     }
     const service = this.services.get(id);
     // boundary: DI registry erasure
-    // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion -- boundary: DI registry erasure
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion, no-restricted-syntax -- boundary: DI registry erasure
     return service as T;
   }
 

--- a/src/main/db/backfill-media-type.ts
+++ b/src/main/db/backfill-media-type.ts
@@ -36,7 +36,7 @@ export async function backfillMediaType(): Promise<void> {
   try {
     // Check how many posts need backfill
     // boundary: better-sqlite3 raw row — prepare().get() row typing
-    // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion -- boundary: better-sqlite3 raw row
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion, no-restricted-syntax -- boundary: better-sqlite3 raw row
     const countResult = sqlite
       .prepare("SELECT COUNT(*) as count FROM posts WHERE media_type IS NULL")
       .get() as { count: number } | undefined;
@@ -67,7 +67,7 @@ export async function backfillMediaType(): Promise<void> {
       // CRITICAL: This is synchronous and blocks Event Loop
       // Small BATCH_SIZE (150) minimizes blocking time
       // boundary: better-sqlite3 raw row
-      // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion -- boundary: better-sqlite3 raw row
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion, no-restricted-syntax -- boundary: better-sqlite3 raw row
       const batch = sqlite
         .prepare(
           `SELECT id, file_url FROM posts 

--- a/src/main/db/client.ts
+++ b/src/main/db/client.ts
@@ -150,6 +150,7 @@ export async function initializeDatabase(): Promise<AppDatabase> {
 
   sqliteInstance = sqlite;
   // boundary: better-sqlite3 raw row — drizzle() generic schema typing to AppDatabase
+  // eslint-disable-next-line no-restricted-syntax -- boundary: better-sqlite3 / drizzle instance typing
   dbInstance = drizzle(sqlite, { schema }) as AppDatabase;
 
   try {
@@ -160,7 +161,7 @@ export async function initializeDatabase(): Promise<AppDatabase> {
     // This can block Main Process for 30+ seconds on databases with 500k+ records
     try {
       // boundary: better-sqlite3 raw row — prepare().get() row typing
-      // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion -- boundary: better-sqlite3 raw row
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion, no-restricted-syntax -- boundary: better-sqlite3 raw row
       const postCount = sqlite
         .prepare("SELECT COUNT(*) as count FROM posts")
         .get() as { count: number } | undefined;
@@ -352,7 +353,7 @@ export async function initializeDatabase(): Promise<AppDatabase> {
                   // Initialize the single row with count from posts_fts (if table exists)
                   try {
                     // boundary: better-sqlite3 raw row — prepare().get() row typing
-                    // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion -- boundary: better-sqlite3 raw row
+                    // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion, no-restricted-syntax -- boundary: better-sqlite3 raw row
                     const countResult = sqliteInstance
                       .prepare("SELECT COUNT(*) as count FROM posts_fts")
                       .get() as { count: number } | undefined;

--- a/src/main/ipc/controllers/MaintenanceController.ts
+++ b/src/main/ipc/controllers/MaintenanceController.ts
@@ -448,7 +448,7 @@ export class MaintenanceController extends BaseController {
           // PRAGMA integrity_check returns rows: [{ integrity_check: "ok" }] when healthy
           // (better-sqlite3 pragma() with simple:false returns row objects, not string[])
           // boundary: better-sqlite3 raw row
-          // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion -- boundary: better-sqlite3 raw row
+          // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion, no-restricted-syntax -- boundary: better-sqlite3 raw row
           const integrityRows = tempDb
             .prepare("PRAGMA integrity_check")
             .all() as { integrity_check: string }[];

--- a/src/main/utils/ipc-serialization.ts
+++ b/src/main/utils/ipc-serialization.ts
@@ -70,21 +70,21 @@ export function toIpcSafe<T>(data: T): ToIpcSafeResult<T> {
   // Handle Date objects
   if (isDate(data)) {
     // boundary: toIpcSafe Date → number branch of conditional return type
-    // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion -- boundary: toIpcSafe
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion, no-restricted-syntax -- boundary: toIpcSafe
     return data.getTime() as ToIpcSafeResult<T>;
   }
 
   // Handle null/undefined (already serializable)
   if (data === null || data === undefined) {
     // boundary: toIpcSafe nullish passthrough
-    // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion -- boundary: toIpcSafe
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion, no-restricted-syntax -- boundary: toIpcSafe
     return data as ToIpcSafeResult<T>;
   }
 
   // Handle arrays
   if (Array.isArray(data)) {
     // boundary: toIpcSafe array map preserves ToIpcSafeResult element typing
-    // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion -- boundary: toIpcSafe
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion, no-restricted-syntax -- boundary: toIpcSafe
     return data.map((item) => toIpcSafe(item)) as ToIpcSafeResult<T>;
   }
 
@@ -98,14 +98,14 @@ export function toIpcSafe<T>(data: T): ToIpcSafeResult<T> {
       }
     }
     // boundary: toIpcSafe plain-object rebuild matches IpcSafe<T>
-    // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion -- boundary: toIpcSafe
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion, no-restricted-syntax -- boundary: toIpcSafe
     return result as ToIpcSafeResult<T>;
   }
 
   // Handle serializable primitives (string, number, boolean)
   if (isSerializablePrimitive(data)) {
     // boundary: toIpcSafe primitive passthrough
-    // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion -- boundary: toIpcSafe
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion, no-restricted-syntax -- boundary: toIpcSafe
     return data as ToIpcSafeResult<T>;
   }
 

--- a/src/main/workers/downloadWorker.ts
+++ b/src/main/workers/downloadWorker.ts
@@ -65,7 +65,7 @@ async function runWorker(): Promise<void> {
     downloadFolderStructure,
     queueFilePath,
   // boundary: worker message — workerData payload after trust/Zod
-  // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion -- boundary: worker message
+  // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion, no-restricted-syntax -- boundary: worker message
   } = workerData as WorkerData;
 
   let aborted = false;

--- a/src/main/workers/vacuumWorker.ts
+++ b/src/main/workers/vacuumWorker.ts
@@ -7,7 +7,7 @@ interface VacuumWorkerData {
 
 function runVacuumInWorker(): void {
   // boundary: worker message — workerData payload after trust/Zod
-  // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion -- boundary: worker message
+  // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion, no-restricted-syntax -- boundary: worker message
   const { dbPath } = workerData as VacuumWorkerData;
   let db: Database.Database | null = null;
 

--- a/src/renderer/hooks/useGalleryInfiniteScroll.ts
+++ b/src/renderer/hooks/useGalleryInfiniteScroll.ts
@@ -85,7 +85,7 @@ export function useGalleryInfiniteScroll<
     queryKey,
     queryFn: async ({ pageParam }) => {
       // boundary: TanStack Query generic inference — pageParam is unknown for unresolved TPageParam
-      // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion -- boundary: TanStack Query generic inference
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion, no-restricted-syntax -- boundary: TanStack Query generic inference
       return await fetchFn(pageParam as TPageParam);
     },
     getNextPageParam:
@@ -95,11 +95,12 @@ export function useGalleryInfiniteScroll<
           ? flattenPage(lastPage)
           : Array.isArray(lastPage)
             ? // boundary: TanStack Query generic inference — default path assumes TPage is TItem[]
+              // eslint-disable-next-line no-restricted-syntax -- boundary: TanStack Query generic inference
               (lastPage as TItem[])
             : [];
         // Default pagination uses sequential numeric page indices.
         // boundary: TanStack Query generic inference — default TPageParam is number
-        // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion -- boundary: TanStack Query generic inference
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion, no-restricted-syntax -- boundary: TanStack Query generic inference
         return (
           items.length === postsPerPage ? allPages.length + 1 : undefined
         ) as TPageParam | undefined;
@@ -168,6 +169,7 @@ export function useGalleryInfiniteScroll<
         ? flattenPage(page)
         : Array.isArray(page)
           ? // boundary: TanStack Query generic inference — default path assumes TPage is TItem[]
+            // eslint-disable-next-line no-restricted-syntax -- boundary: TanStack Query generic inference
             (page as TItem[])
           : []
     );

--- a/src/renderer/workers/data-processor.worker.ts
+++ b/src/renderer/workers/data-processor.worker.ts
@@ -204,7 +204,7 @@ self.addEventListener("message", (event: MessageEvent<WorkerRequest>) => {
     switch (action) {
       case "FILTER_AND_SORT": {
         // boundary: worker message
-        // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion -- boundary: worker message
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion, no-restricted-syntax -- boundary: worker message
         const { posts, filters } = payload as FilterAndSortPayload;
         
         // PERFORMANCE: Skip Zod validation in Worker - data comes from trusted Main process


### PR DESCRIPTION
Enforce all non-as-const TSAsExpression via no-restricted-syntax so widening casts cannot bypass CI. Keep no-unsafe-type-assertion; require boundary comments plus disables for every rule that fires. Document AST inventory over grep in LESSONS.