### PR TITLE
fix: prioritize user API traffic and share host 429 gate

### DIFF
--- a/.ai/LESSONS.txt
+++ b/.ai/LESSONS.txt
@@ -198,6 +198,10 @@ A report without (1)–(3) is an **incomplete task**. Do not claim a branch "lan
 **Root Cause:** A full IoC-style abstraction (cycle detection, factory theater) was introduced without automatic wiring or scopes; instance-Map `resolve` never runs user code, so circular-dependency stacks are dead.
 **Invariant Rule:** Prefer a slim typed instance registry (`Container` + `DI_TOKENS`, keyed by `token.id`). No cycle detection without lazy factories. Use a real IoC container only when automatic wiring or scope management is actually needed.
 
+### Problem: Background API consumers burned the budget for user actions, and 429 state lived in one consumer
+**Root Cause:** Shared `ProviderThrottle` had no priorities (FIFO/racing sleeps); tag-resolve kept `globalRateLimitUntilMs` locally so Sync/Browse ignored an already-known host 429.
+**Invariant Rule:** A shared API budget has exactly two priorities (`user` / `background`) and one circuit-breaker per host that every consumer writes and reads. Local copies of rate-limit state are forbidden (same split-brain class as duplicated crypto helpers).
+
 ### Problem: Re-opening the window stacks duplicate `before-quit` listeners
 **Root Cause:** `app.on("before-quit", …)` was registered inside `initializeAppAndWindow()`, which tray Show/click/`activate` can call again after the window was destroyed.
 **Invariant Rule:** Register process-lifetime Electron listeners (`before-quit`, CSP setup flags, etc.) once at module scope (or behind a one-shot guard). Window recreation may re-run IPC setup (`removeHandler` first) but must not re-bind app-level quit handlers.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -605,6 +605,8 @@ const posts = await db.query.posts.findMany({
    - Implementations: `Rule34Provider`, `GelbooruProvider`
    - Methods: `checkAuth`, `fetchPosts`, `searchTags`, `formatTag`
    - Shared request pacing via `ProviderThrottle` (~1200ms + jitter) and session UA via `pickRandomUA()`
+   - **Priorities:** `user` (Sync `fetchPosts`, Browse/search `fetchPosts`, autocomplete) drains before `background` (tag-resolve). Same min-interval; order only.
+   - **Host 429 gate:** any consumer calls `notifyRateLimited(retryAfterMs?)`; all waiters honor it (`background` fails fast, `user` waits up to `USER_GATE_WAIT_CEILING_MS` then fails with typed rate_limit)
 
 9. **Video Proxy Service** (`src/main/services/video-proxy-server.ts`)
 
@@ -1897,7 +1899,7 @@ Based on a comprehensive technical audit, here's the current implementation stat
 - **Safe Mode / NSFW Filter:** blur logic and safe mode state in gallery/viewer (`safeModeStore`, `PanicButton`, `PostCard`, `ViewerDialog`)
 - **Age Gate:** `src/renderer/components/onboarding/AgeGate.tsx` and `confirmLegal` IPC method
 - **User Data Path:** Neutral `.rdcache` via `bootstrap-user-data.ts` (not next to the executable)
-- **Anti-Bot Measures:** Shared `ProviderThrottle` (~1200ms + jitter) and session UA rotation via `pickRandomUA()` across current providers
+- **Anti-Bot Measures:** Shared `ProviderThrottle` (~1200ms + jitter) and session UA rotation via `pickRandomUA()` across current providers. One throttle instance per provider host serializes Sync/Browse/autocomplete (`user` priority) ahead of tag-resolve (`background`). A single host 429 gate (`notifyRateLimited`) is written by any consumer and checked by every `wait()` — local rate-limit copies are forbidden.
 - **DB Optimization (FTS5):** FTS5 virtual table `posts_fts` implemented with `unicode61` tokenizer for fast tag searching
 - **Composite Indexes:** Composite index on `(artist_id, rating, is_viewed)` for optimized filter queries
 - **Centralized Validation:** No single monolithic validation module by design; current direction is shared schemas + typed controller wrappers at IPC boundaries.

--- a/src/main/providers/gelbooru-provider.ts
+++ b/src/main/providers/gelbooru-provider.ts
@@ -12,7 +12,8 @@ import {
 } from "../../shared/utils/provider-tag-sanitize";
 import { MAX_RANDOM_PAGES } from "../../shared/constants";
 import { z } from "zod";
-import { ProviderThrottle, pickRandomUA } from "./provider-throttle";
+import { ProviderThrottle, pickRandomUA, ProviderRateLimitGateError } from "./provider-throttle";
+import { ProviderSearchError } from "./provider-search-errors";
 import { getProxyAgent } from "../lib/proxy";
 
 type GelbooruTagItem = {
@@ -137,7 +138,14 @@ export class GelbooruProvider implements IBooruProvider {
     isRandom: boolean,
     limit: number
   ): Promise<BooruPost[]> {
-    await this.throttle.wait();
+    try {
+      await this.throttle.wait("user");
+    } catch (error) {
+      if (error instanceof ProviderRateLimitGateError) {
+        throw new ProviderSearchError("rate_limit", undefined, error.retryAfterMs);
+      }
+      throw error;
+    }
 
     // Pseudo-random fallback: If isRandom is true, use a random page number (1-MAX_RANDOM_PAGES) for better randomization
     // NOTE: This is a fallback approach. True randomization on large datasets in Booru APIs

--- a/src/main/providers/provider-throttle.ts
+++ b/src/main/providers/provider-throttle.ts
@@ -1,6 +1,14 @@
 const DEFAULT_MIN_INTERVAL_MS = 1200;
 const DEFAULT_JITTER_MS = 400;
 
+/** Max time a user-priority waiter may block on a closed 429 gate before failing. */
+export const USER_GATE_WAIT_CEILING_MS = 30_000;
+
+/** Fallback gate duration when notifyRateLimited is called without Retry-After. */
+export const DEFAULT_RATE_LIMIT_GATE_MS = 5_000;
+
+export type ThrottlePriority = "user" | "background";
+
 const SHARED_USER_AGENTS = [
   "Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:125.0) Gecko/20100101 Firefox/125.0",
   "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/124.0.6367.119 Safari/537.36",
@@ -10,26 +18,169 @@ const SHARED_USER_AGENTS = [
   "Mozilla/5.0 (X11; Ubuntu; Linux x86_64; rv:124.0) Gecko/20100101 Firefox/124.0",
 ];
 
+export class ProviderRateLimitGateError extends Error {
+  readonly retryAfterMs: number;
+
+  constructor(retryAfterMs: number) {
+    super(
+      `Provider rate-limit gate is closed (retry after ${retryAfterMs}ms)`
+    );
+    this.name = "ProviderRateLimitGateError";
+    this.retryAfterMs = retryAfterMs;
+  }
+}
+
+type QueuedWaiter = {
+  priority: ThrottlePriority;
+  resolve: () => void;
+  reject: (error: unknown) => void;
+};
+
+type ProviderThrottleOptions = {
+  userGateWaitCeilingMs?: number;
+  defaultRateLimitGateMs?: number;
+};
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => {
+    setTimeout(resolve, ms);
+  });
+}
+
+/**
+ * Serializing request throttle with two FIFO priorities and a shared 429 gate.
+ * All consumers of one provider host must share one instance.
+ */
 export class ProviderThrottle {
   private lastRequestAt = 0;
+  private rateLimitedUntilMs = 0;
+  private pumping = false;
+  private readonly userQueue: QueuedWaiter[] = [];
+  private readonly backgroundQueue: QueuedWaiter[] = [];
   private readonly minIntervalMs: number;
   private readonly jitterMs: number;
+  private readonly userGateWaitCeilingMs: number;
+  private readonly defaultRateLimitGateMs: number;
 
   constructor(
     minIntervalMs = DEFAULT_MIN_INTERVAL_MS,
-    jitterMs = DEFAULT_JITTER_MS
+    jitterMs = DEFAULT_JITTER_MS,
+    options: ProviderThrottleOptions = {}
   ) {
     this.minIntervalMs = minIntervalMs;
     this.jitterMs = jitterMs;
+    this.userGateWaitCeilingMs =
+      options.userGateWaitCeilingMs ?? USER_GATE_WAIT_CEILING_MS;
+    this.defaultRateLimitGateMs =
+      options.defaultRateLimitGateMs ?? DEFAULT_RATE_LIMIT_GATE_MS;
   }
 
-  async wait(): Promise<void> {
+  /** Record a 429 from any consumer so every waiter sees the same host gate. */
+  notifyRateLimited(retryAfterMs?: number): void {
+    const delayMs =
+      retryAfterMs !== undefined && retryAfterMs > 0
+        ? retryAfterMs
+        : this.defaultRateLimitGateMs;
+    this.rateLimitedUntilMs = Math.max(
+      this.rateLimitedUntilMs,
+      Date.now() + delayMs
+    );
+  }
+
+  isRateLimited(): boolean {
+    return this.getRateLimitedRemainingMs() > 0;
+  }
+
+  getRateLimitedRemainingMs(): number {
+    return Math.max(0, this.rateLimitedUntilMs - Date.now());
+  }
+
+  /** Test-only: clear the shared gate without reconstructing the throttle. */
+  resetRateLimitGateForTests(): void {
+    this.rateLimitedUntilMs = 0;
+  }
+
+  /**
+   * Acquire the next request slot.
+   * `user` is drained before `background`. Priority is required (no silent default).
+   */
+  async wait(priority: ThrottlePriority): Promise<void> {
+    return new Promise<void>((resolve, reject) => {
+      const waiter: QueuedWaiter = { priority, resolve, reject };
+      if (priority === "user") {
+        this.userQueue.push(waiter);
+      } else {
+        this.backgroundQueue.push(waiter);
+      }
+      void this.pump();
+    });
+  }
+
+  private dequeue(): QueuedWaiter | undefined {
+    return this.userQueue.shift() ?? this.backgroundQueue.shift();
+  }
+
+  private dequeueMatching(priority: ThrottlePriority): QueuedWaiter | undefined {
+    if (priority === "user") {
+      return this.userQueue.shift();
+    }
+    return this.backgroundQueue.shift();
+  }
+
+  private async pump(): Promise<void> {
+    if (this.pumping) {
+      return;
+    }
+    this.pumping = true;
+    try {
+      while (this.userQueue.length > 0 || this.backgroundQueue.length > 0) {
+        // Plan gate policy from current head, but re-check queues after the wait
+        // so a user arriving during a background interval sleep still wins the slot.
+        const plannedPriority: ThrottlePriority =
+          this.userQueue.length > 0 ? "user" : "background";
+        try {
+          await this.acquireSlot(plannedPriority);
+        } catch (error) {
+          const failed = this.dequeueMatching(plannedPriority);
+          if (failed) {
+            failed.reject(error);
+          }
+          continue;
+        }
+        const waiter = this.dequeue();
+        if (!waiter) {
+          break;
+        }
+        waiter.resolve();
+      }
+    } finally {
+      this.pumping = false;
+      if (this.userQueue.length > 0 || this.backgroundQueue.length > 0) {
+        void this.pump();
+      }
+    }
+  }
+
+  private async acquireSlot(priority: ThrottlePriority): Promise<void> {
+    const remainingMs = this.getRateLimitedRemainingMs();
+    if (remainingMs > 0) {
+      if (priority === "background") {
+        throw new ProviderRateLimitGateError(remainingMs);
+      }
+      const waitMs = Math.min(remainingMs, this.userGateWaitCeilingMs);
+      await sleep(waitMs);
+      const stillLimitedMs = this.getRateLimitedRemainingMs();
+      if (stillLimitedMs > 0) {
+        throw new ProviderRateLimitGateError(stillLimitedMs);
+      }
+    }
+
     const now = Date.now();
     const elapsed = now - this.lastRequestAt;
     const jitter = Math.random() * this.jitterMs;
     const requiredWait = this.minIntervalMs + jitter - elapsed;
     if (requiredWait > 0) {
-      await new Promise((resolve) => setTimeout(resolve, requiredWait));
+      await sleep(requiredWait);
     }
     this.lastRequestAt = Date.now();
   }

--- a/src/main/providers/rule34-provider.ts
+++ b/src/main/providers/rule34-provider.ts
@@ -22,9 +22,9 @@ import {
 } from "../../shared/utils/provider-tag-sanitize";
 import { MAX_RANDOM_PAGES } from "../../shared/constants";
 import { z } from "zod";
-import { ProviderThrottle, pickRandomUA } from "./provider-throttle";
-import { getProxyAgent } from "../lib/proxy";
+import { ProviderThrottle, pickRandomUA, ProviderRateLimitGateError } from "./provider-throttle";
 import { ProviderSearchError, isProviderSearchError } from "./provider-search-errors";
+import { getProxyAgent } from "../lib/proxy";
 import {
   assertRule34NotBlockedResponse,
   isAxiosTransportFailure,
@@ -135,6 +135,23 @@ export class Rule34Provider implements IBooruProvider {
     }
   }
 
+  private async waitForUserSlot(): Promise<void> {
+    try {
+      await this.throttle.wait("user");
+    } catch (error) {
+      if (error instanceof ProviderRateLimitGateError) {
+        throw new ProviderSearchError("rate_limit", undefined, error.retryAfterMs);
+      }
+      throw error;
+    }
+  }
+
+  private notifyIfRateLimited(error: unknown): void {
+    if (isProviderSearchError(error) && error.kind === "rate_limit") {
+      this.throttle.notifyRateLimited(error.retryAfterMs);
+    }
+  }
+
   async searchTags(
     query: string,
     signal?: AbortSignal
@@ -142,7 +159,7 @@ export class Rule34Provider implements IBooruProvider {
     const safeQuery = sanitizeProviderTagQuery(query);
     if (safeQuery.length < 2) return [];
     try {
-      await this.throttle.wait();
+      await this.waitForUserSlot();
       const params = new URLSearchParams({ q: safeQuery });
       const { data } = await axios.get<R34AutocompleteItem[]>(
         `https://api.rule34.xxx/autocomplete.php?${params.toString()}`,
@@ -165,6 +182,9 @@ export class Rule34Provider implements IBooruProvider {
     } catch (error) {
       if (axios.isCancel(error)) {
         return []; // Request was cancelled, return empty array
+      }
+      if (error instanceof ProviderSearchError) {
+        throw error;
       }
       logger.error("[Rule34Provider] Autocomplete failed", error);
       return [];
@@ -258,7 +278,7 @@ export class Rule34Provider implements IBooruProvider {
     isRandom: boolean,
     limit: number
   ): Promise<BooruPost[]> {
-    await this.throttle.wait();
+    await this.waitForUserSlot();
 
     const apiPage = isRandom
       ? Math.floor(Math.random() * MAX_RANDOM_PAGES) + 1
@@ -279,6 +299,7 @@ export class Rule34Provider implements IBooruProvider {
       const posts = this.parseJsonPostSearchResponse(jsonResponse.text, tags);
       return this.maybeShufflePosts(posts, isRandom);
     } catch (error) {
+      this.notifyIfRateLimited(error);
       if (isProviderSearchError(error)) {
         if (
           error.kind === "rate_limit" ||
@@ -316,6 +337,7 @@ export class Rule34Provider implements IBooruProvider {
       );
       return this.maybeShufflePosts(posts, isRandom);
     } catch (error) {
+      this.notifyIfRateLimited(error);
       if (isProviderSearchError(error)) {
         throw error;
       }

--- a/src/main/providers/rule34-tag-metadata.ts
+++ b/src/main/providers/rule34-tag-metadata.ts
@@ -7,7 +7,10 @@ import {
   TAG_RESOLVE_REQUEST_TIMEOUT_MS,
 } from "../config/tag-resolve-constants";
 import type { ProviderSettings } from "./types";
-import type { ProviderThrottle } from "./provider-throttle";
+import {
+  ProviderRateLimitGateError,
+  type ProviderThrottle,
+} from "./provider-throttle";
 
 const R34TagResponseSchema = z
   .object({
@@ -149,7 +152,14 @@ export async function fetchRule34TagMetadata(
   throttle: ProviderThrottle,
   headers: Record<string, string>
 ): Promise<Rule34TagMetadataLookupResult> {
-  await throttle.wait();
+  try {
+    await throttle.wait("background");
+  } catch (error) {
+    if (error instanceof ProviderRateLimitGateError) {
+      throw new Rule34TagRateLimitError(error.retryAfterMs);
+    }
+    throw error;
+  }
 
   const params = new URLSearchParams({
     page: "dapi",
@@ -189,6 +199,7 @@ export async function fetchRule34TagMetadata(
     const retryAfterMs = Number.isFinite(retryAfterSeconds)
       ? retryAfterSeconds * 1000
       : undefined;
+    throttle.notifyRateLimited(retryAfterMs);
     throw new Rule34TagRateLimitError(retryAfterMs ?? 0);
   }
 

--- a/src/main/services/tag-resolve-coordinator.ts
+++ b/src/main/services/tag-resolve-coordinator.ts
@@ -34,7 +34,6 @@ type TagResolveWaveStats = {
 
 const inFlightLookups = new Map<string, Promise<TagLookupResult>>();
 const negativeCacheUntil = new Map<string, number>();
-let globalRateLimitUntilMs = 0;
 let last429BurstLogAtMs = 0;
 
 function sleep(ms: number): Promise<void> {
@@ -78,19 +77,10 @@ function resolveRetryAfterMs(retryAfterMs: number, attempt: number): number {
   return Math.min(exponentialBackoff, TAG_RESOLVE_MAX_RETRY_AFTER_MS);
 }
 
-async function waitForGlobalRateLimit(): Promise<void> {
-  const waitMs = globalRateLimitUntilMs - Date.now();
-  if (waitMs > 0) {
-    await sleep(waitMs);
-  }
-}
-
 function recordRateLimitBurst(retryAfterMs: number, attempt: number): void {
   const delayMs = resolveRetryAfterMs(retryAfterMs, attempt);
-  globalRateLimitUntilMs = Math.max(
-    globalRateLimitUntilMs,
-    Date.now() + delayMs
-  );
+  // Shared host gate — never keep a parallel local copy of rate-limit state.
+  getRule34TagProvider().getRequestThrottle().notifyRateLimited(delayMs);
 
   const now = Date.now();
   if (now - last429BurstLogAtMs >= TAG_RESOLVE_429_BURST_LOG_WINDOW_MS) {
@@ -132,7 +122,6 @@ async function lookupTagFromApi(
     attempt += 1
   ) {
     try {
-      await waitForGlobalRateLimit();
       return await fetchRule34TagMetadata(
         tagName,
         settings,
@@ -290,6 +279,10 @@ export async function resolveTagMetadataWave(
 export function resetTagResolveCoordinatorForTests(): void {
   inFlightLookups.clear();
   negativeCacheUntil.clear();
-  globalRateLimitUntilMs = 0;
   last429BurstLogAtMs = 0;
+  try {
+    getRule34TagProvider().getRequestThrottle().resetRateLimitGateForTests();
+  } catch {
+    // Provider may be mocked without a real throttle in some tests.
+  }
 }

--- a/tests/unit/TEST_COVERAGE.md
+++ b/tests/unit/TEST_COVERAGE.md
@@ -2,7 +2,7 @@
 
 ## Overview
 
-Vitest covers unit logic, integration flows (IPC + SQLite), and property-based fuzzing. The default `npm test` run executes **197 tests** across **28 files** (unit + integration + property). Helper suites under `tests/helpers/` and `tests/utils/` are separate and not counted in that total.
+Vitest covers unit logic, integration flows (IPC + SQLite), and property-based fuzzing. The default `npm test` run executes **203 tests** across **29 files** (unit + integration + property). Helper suites under `tests/helpers/` and `tests/utils/` are separate and not counted in that total.
 
 ## Test files (unit)
 
@@ -29,6 +29,7 @@ Vitest covers unit logic, integration flows (IPC + SQLite), and property-based f
 | `services/tag-resolve-coordinator.test.ts` | 3 | Tag resolve dedup / rate limit |
 | `services/secure-storage.test.ts` | 3 | `SecureStorage` encrypt/decrypt (sole crypto path) |
 | `services/video-proxy-server.test.ts` | 8 | Video proxy allowlist / cache / eviction |
+| `providers/throttle.test.ts` | 6 | Priority queue + shared 429 gate |
 
 ## Other Vitest suites
 

--- a/tests/unit/providers/throttle.test.ts
+++ b/tests/unit/providers/throttle.test.ts
@@ -1,0 +1,109 @@
+import { describe, expect, it } from "vitest";
+import {
+  ProviderRateLimitGateError,
+  ProviderThrottle,
+} from "@/main/providers/provider-throttle";
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => {
+    setTimeout(resolve, ms);
+  });
+}
+
+describe("ProviderThrottle priority and 429 gate", () => {
+  it("runs a later user waiter before an earlier background waiter", async () => {
+    const throttle = new ProviderThrottle(80, 0);
+    // Prime lastRequestAt so the next acquire must sleep (priority can cut in).
+    await throttle.wait("user");
+
+    const order: string[] = [];
+    const startedAt = Date.now();
+
+    const background = throttle.wait("background").then(() => {
+      order.push("background");
+      return Date.now() - startedAt;
+    });
+
+    // Ensure background has entered interval sleep before user joins.
+    await sleep(10);
+
+    const user = throttle.wait("user").then(() => {
+      order.push("user");
+      return Date.now() - startedAt;
+    });
+
+    const [backgroundElapsedMs, userElapsedMs] = await Promise.all([
+      background,
+      user,
+    ]);
+
+    expect(order).toEqual(["user", "background"]);
+    expect(userElapsedMs).toBeLessThan(backgroundElapsedMs);
+  });
+
+  it("rejects background waiters immediately when the shared gate is closed", async () => {
+    const throttle = new ProviderThrottle(10, 0);
+    throttle.notifyRateLimited(5_000);
+
+    const startedAt = Date.now();
+    await expect(throttle.wait("background")).rejects.toBeInstanceOf(
+      ProviderRateLimitGateError
+    );
+    expect(Date.now() - startedAt).toBeLessThan(100);
+  });
+
+  it("blocks a user waiter after tag-resolve notifies the shared gate", async () => {
+    const throttle = new ProviderThrottle(10, 0, {
+      userGateWaitCeilingMs: 80,
+      defaultRateLimitGateMs: 5_000,
+    });
+
+    // Simulate tag-resolve 429 writing the shared host gate.
+    throttle.notifyRateLimited(5_000);
+
+    const startedAt = Date.now();
+    await expect(throttle.wait("user")).rejects.toBeInstanceOf(
+      ProviderRateLimitGateError
+    );
+    const elapsedMs = Date.now() - startedAt;
+    expect(elapsedMs).toBeGreaterThanOrEqual(70);
+    expect(elapsedMs).toBeLessThan(500);
+  });
+
+  it("exposes a sync-notified gate to subsequent background waiters", async () => {
+    const throttle = new ProviderThrottle(10, 0);
+    // Simulate Sync/Browse receiving HTTP 429.
+    throttle.notifyRateLimited(3_000);
+
+    await expect(throttle.wait("background")).rejects.toMatchObject({
+      name: "ProviderRateLimitGateError",
+      retryAfterMs: expect.any(Number),
+    });
+    expect(throttle.isRateLimited()).toBe(true);
+  });
+
+  it("keeps single-caller spacing near the configured min interval", async () => {
+    const throttle = new ProviderThrottle(50, 0);
+    const startedAt = Date.now();
+    await throttle.wait("user");
+    await throttle.wait("user");
+    const elapsedMs = Date.now() - startedAt;
+    expect(elapsedMs).toBeGreaterThanOrEqual(45);
+    expect(elapsedMs).toBeLessThan(200);
+  });
+
+  it("does not consume a paced slot when background is rejected by the gate", async () => {
+    const throttle = new ProviderThrottle(80, 0);
+    await throttle.wait("user");
+    throttle.notifyRateLimited(10_000);
+
+    await expect(throttle.wait("background")).rejects.toBeInstanceOf(
+      ProviderRateLimitGateError
+    );
+
+    throttle.resetRateLimitGateForTests();
+    const startedAt = Date.now();
+    await throttle.wait("user");
+    expect(Date.now() - startedAt).toBeGreaterThanOrEqual(70);
+  });
+});

--- a/tests/unit/services/tag-resolve-coordinator.test.ts
+++ b/tests/unit/services/tag-resolve-coordinator.test.ts
@@ -34,6 +34,8 @@ vi.mock("@/main/providers", () => ({
     id: "rule34",
     getRequestThrottle: () => ({
       wait: vi.fn().mockResolvedValue(undefined),
+      notifyRateLimited: vi.fn(),
+      resetRateLimitGateForTests: vi.fn(),
     }),
     getRequestHeaders: () => ({
       "User-Agent": "test",


### PR DESCRIPTION
ProviderThrottle now drains user waiters before background and keeps one rate-limit circuit-breaker per host so Sync/Browse honor tag-resolve 429s (and the reverse) instead of racing a local coordinator copy.