### PR TITLE
chore: document timestamp units for tosAcceptedAt and lastVacuumAt

### DIFF
--- a/src/main/db/schema.ts
+++ b/src/main/db/schema.ts
@@ -150,6 +150,7 @@ export const settings = sqliteTable("settings", {
   syncIntervalMinutes: integer("sync_interval_minutes").default(0).notNull(),
   backupRetention: integer("backup_retention").default(5).notNull(),
   vacuumSchedule: text("vacuum_schedule").default("manual"),
+  // Units: milliseconds since epoch (written as Date.now()); bare integer, no Drizzle mode — do not add raw-SQL time comparisons without matching ms
   lastVacuumAt: integer("last_vacuum_at"),
   lastVacuumStatus: text("last_vacuum_status"),
   lastVacuumError: text("last_vacuum_error"),

--- a/src/main/ipc/controllers/SettingsController.ts
+++ b/src/main/ipc/controllers/SettingsController.ts
@@ -85,11 +85,10 @@ function mapSettingsToIpc(
     isSafeMode: !!dbSettings.isSafeMode, // .default(true) in schema - Drizzle ensures value exists
     isAdultConfirmed: !!dbSettings.isAdultConfirmed, // .default(false) in schema - Drizzle ensures value exists
     isAdultVerified: !!dbSettings.isAdultVerified, // .notNull() in schema - always present
-    // Convert Date to number for IPC serialization
-    // Drizzle with mode: "timestamp" returns Date | null
-    // But we need to handle edge cases where it might be a number (timestamp) or null
-    // CRITICAL: Drizzle with mode: "timestamp" stores as integer (milliseconds) in SQLite
-    // and returns Date object when reading, but we need to handle all cases
+    // Convert Date to number for IPC serialization.
+    // Drizzle mode: "timestamp" stores unix seconds in SQLite and returns Date | null on read.
+    // IPC layer converts Date → ms via getTime(). A raw integer from SQLite would be seconds —
+    // do not treat it as milliseconds (that reproduces the Stats timeline unit bug class).
     tosAcceptedAt: (() => {
       const value = dbSettings.tosAcceptedAt;
       if (value instanceof Date) {


### PR DESCRIPTION
Correct the false SettingsController claim that timestamp stores ms, and label last_vacuum_at as bare-integer ms.