### PR TITLE
chore: update documentation for blacklist and statistics features

### DIFF
--- a/README.md
+++ b/README.md
@@ -205,7 +205,7 @@ Settings are organized into tabs for faster scanning and lower cognitive load:
 
 ### Blacklist
 
-- **Tag blacklist** - Hide posts containing listed tags from Browse and local galleries (enforced in Main after fetch)
+- **Tag blacklist** - Hide posts containing listed tags from Browse and local galleries (enforced in Main after fetch). Maximum **100** tags (`MAX_BLACKLIST_TAGS`)
 
 ### Backup
 
@@ -219,6 +219,8 @@ Settings are organized into tabs for faster scanning and lower cognitive load:
 
 ### Account
 
+- **Provider** - `rule34` or `gelbooru`; changing provider invalidates React Query feed caches and persists the selection
+- **User ID** - Required for providers that use it (shown when applicable)
 - **API key update** - Password-style input with show/hide toggle
 - **Key status badge** - `Configured` / `Not configured` via safe `hasApiKey` contract
 
@@ -242,7 +244,7 @@ The application is stable and production-ready (see **`package.json`** → `vers
 
 ### Database & Schema
 
-- ✅ **Schema:** Core tables `artists`, `posts`, `settings`; additional `tag_metadata`, `playlists`, `playlist_entries`, and FTS5 external content for posts
+- ✅ **Schema:** Core tables `artists`, `posts`, `settings`; additional `tag_metadata`, `playlists`, `playlist_entries`, `tag_blacklist`, and FTS5 external content for posts
 - ✅ **Migrations:** Fully functional migration system using `drizzle-kit` with idempotent migration handling
 - ✅ **Media Type Support:** `media_type` column in `posts` table for efficient image/video filtering (`image`, `video`)
 - ✅ **Indexes:** Optimized indexes on `artistId`, `isViewed`, `publishedAt`, `isFavorited`, `lastChecked`, `createdAt`, `mediaType`
@@ -515,7 +517,7 @@ npm run test:verify
 
 ### Testing
 
-**Vitest** covers unit, integration, and property-based tests (**197 tests** across 28 files). **Playwright** covers E2E flows. Full suite inventory: [`tests/unit/TEST_COVERAGE.md`](tests/unit/TEST_COVERAGE.md).
+**Vitest** covers unit, integration, and property-based tests (**209 tests** across 30 files). **Playwright** covers E2E flows. Full suite inventory: [`tests/unit/TEST_COVERAGE.md`](tests/unit/TEST_COVERAGE.md).
 
 ```bash
 # Full suite: rebuild for Node → run all Vitest tests → rebuild for Electron

--- a/docs/api-guide.md
+++ b/docs/api-guide.md
@@ -245,7 +245,7 @@ interface IpcBridge {
     artistId: number;
     page?: number;
   }) => Promise<Post[]>;
-  getArtistPostsCount: (artistId?: number) => Promise<number>;
+  getArtistPostsCount: (params: GetPostsCountRequest) => Promise<number>;
   getStats: () => Promise<ExtendedStats>; // backward-compatible alias
   getExtendedStats: () => Promise<ExtendedStats>;
   markPostAsViewed: (postId: number, postData?: PostData) => Promise<boolean>;
@@ -277,6 +277,9 @@ interface IpcBridge {
   resolveCharacterTags: (tags: string[]) => Promise<string[]>;
   resolveCopyrightTags: (tags: string[]) => Promise<string[]>;
   resolveTagsByType: (tags: string[], type: number) => Promise<string[]>;
+  getBlacklistedTags: () => Promise<string[]>;
+  addTagToBlacklist: (tag: string) => Promise<void>;
+  removeTagFromBlacklist: (tag: string) => Promise<void>;
 
   // Sync
   syncAll: () => Promise<boolean>;
@@ -1547,20 +1550,21 @@ await window.api.logout();
 
 ---
 
-### `getArtistPostsCount(artistId?: number)`
+### `getArtistPostsCount(params: GetPostsCountRequest)`
 
-Gets the total count of posts for an artist or all posts if no artistId is provided.
+Gets the total count of posts for an artist (or all posts when `artistId` is omitted), optionally filtered.
 
 **Parameters:**
 
-- `artistId?: number` - Optional artist ID. If omitted, returns count of all posts.
+- `params.artistId?: number` - Optional artist ID. If omitted, counts across posts in scope.
+- `params.filters?: PostFilter` - Optional post filters.
 
 **Returns:** `Promise<number>`
 
 **Example:**
 
 ```typescript
-const count = await window.api.getArtistPostsCount(123);
+const count = await window.api.getArtistPostsCount({ artistId: 123 });
 console.log(`Artist has ${count} posts`);
 ```
 
@@ -2026,25 +2030,23 @@ const syncService = container.resolve(DI_TOKENS.SYNC_SERVICE);
 Controllers are registered in `setupIpc()` function:
 
 ```typescript
-export function setupIpc(): {
+export function setupIpc(
+  videoProxyServer: VideoProxyServer,
+): {
   maintenanceController: MaintenanceController;
   fileController: FileController;
+  playlistController: PlaylistController;
 } {
-  const systemController = new SystemController();
-  systemController.setup();
+  // Controllers registered here (System, Artists, Posts, Settings, Auth,
+  // Maintenance, Viewer, File, Search, Playlist, Stats, Blacklist, VideoProxy, …)
 
-  const artistsController = new ArtistsController();
-  artistsController.setup();
-
-  // ... other controllers
-
-  return { maintenanceController, fileController };
+  return { maintenanceController, fileController, playlistController };
 }
 ```
 
 **Available Controllers:**
 
-- `SystemController` - System-level operations (version, clipboard, etc.)
+- `SystemController` - System-level operations (version, clipboard, wipe-all-data, etc.)
 - `ArtistsController` - Artist management operations
 - `PostsController` - Post-related operations
 - `SettingsController` - Settings management
@@ -2052,8 +2054,11 @@ export function setupIpc(): {
 - `MaintenanceController` - Database backup/restore operations
 - `ViewerController` - Viewer-related operations
 - `FileController` - File download and management
+- `SearchController` - Booru search and tag resolution
 - `PlaylistController` - Playlist CRUD, smart resolve, reorder, import/export
 - `StatsController` - Statistics aggregates for dashboard cards/charts
+- `BlacklistController` - Tag blacklist CRUD
+- `VideoProxyController` - Local video proxy / cache control
 
 **Channel Constants:**
 
@@ -2100,7 +2105,7 @@ The application integrates with **Rule34.xxx API**. Integration is handled in th
 
 **SyncService (tracked artists):**
 
-- **Rate Limiting:** 1.5 second delay between artists, 0.5 second between pages
+- **Rate Limiting:** Shared `ProviderThrottle` (~1200ms minimum + 0–400ms jitter per request); sync retries use exponential backoff (base ~2000ms) on rate limits
 - **Pagination:** Incremental fetch by `lastPostId` (not deep offset scroll)
 - **Error Handling:** Graceful handling of API errors and network failures
 - **Authentication:** Uses User ID and API Key from settings

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -225,7 +225,7 @@ Let's trace what happens when a user clicks "Add Artist":
 
 5. **Dependency Injection** - The controller needs services (like the database). It asks the DI Container to resolve dependencies. The container provides singleton instances of services.
 
-6. **Service Layer** - The controller calls the appropriate service method (e.g., `dbService.addArtist()`). Services contain the business logic.
+6. **Service Layer** - The controller performs the business logic / Drizzle write (e.g., insert artist via `getDb()`). Dedicated services exist where needed (`SyncService`, `BackupService`, etc.).
 
 7. **Database** - The service uses Drizzle ORM to execute a type-safe query: `db.insert(artists).values(artistData)`. SQLite stores the data.
 
@@ -429,8 +429,8 @@ const posts = await db.query.posts.findMany({
 
 **Best Practices:**
 
-- **Default limit:** 50 records per page (used in `getArtistPosts`)
-- **Maximum limit:** Never exceed 1000 records in a single query
+- **Default limit:** 50 records per page (used in `getArtistPosts` / `GetPostsSchema`)
+- **Maximum limit:** `GetPostsSchema` caps `limit` at **100** (`src/shared/schemas/post.ts`)
 - **Pagination:** Use `offset` and `limit` for pagination
 - **Infinite scroll:** Use `useInfiniteQuery` with page-based pagination
 - **Count queries:** Use separate count queries (`getArtistPostsCount`) instead of `array.length`
@@ -476,8 +476,8 @@ const posts = await db.query.posts.findMany({
 
    - Drizzle ORM schema definitions for all tables
    - Type-safe table definitions with proper indexes
-   - Tables: `artists`, `posts`, `settings`
-   - Type inference: `Artist`, `Post`, `Settings`, `NewArtist`, `NewPost`
+   - Tables: `artists`, `posts`, `settings`, `tag_metadata`, `playlists`, `playlist_entries`; plus `tag_blacklist` (migration + raw SQL, not in Drizzle schema)
+   - Type inference: `Artist`, `Post`, `Settings`, `NewArtist`, `NewPost` (and playlist / tag_metadata types)
 
 3. **Sync Service** (`src/main/services/sync-service.ts`)
 
@@ -507,6 +507,9 @@ const posts = await db.query.posts.findMany({
    - `SystemController.ts` - System-level ops (version, clipboard, icon path, quit, **`wipeAllData`**)
    - `SearchController.ts` - Booru search and tag resolution (`searchBooru` with Rule34 cursor pagination, `resolveTags`, `resolveCharacterTags`, `resolveCopyrightTags`, `resolveTagsByType`, blacklist filtering)
    - `PlaylistController.ts` - Playlist CRUD, smart queries, import/export
+   - `StatsController.ts` - Extended stats for `/stats`
+   - `BlacklistController.ts` - Tag blacklist CRUD
+   - `VideoProxyController.ts` - Local video proxy URL / cache control
 
    **BaseController** (`src/main/core/ipc/BaseController.ts`):
 
@@ -557,7 +560,7 @@ const posts = await db.query.posts.findMany({
 
    **Default Limits:**
 
-   - Posts: 50 per page (max 1000 per query)
+   - Posts (`getArtistPosts` / `GetPostsSchema`): 50 per page (max **100** per query)
    - Artists: `MAX_TRACKED_ARTISTS` (5000) on `getTrackedArtists()` — logs a warning if truncated
    - Settings: Single record (no limit needed)
 
@@ -573,7 +576,7 @@ const posts = await db.query.posts.findMany({
    **Performance Guidelines:**
 
    - **Heavy queries** (full table scans, complex WHERE clauses) → Always use pagination
-   - **Indexed queries** (WHERE on indexed columns) → Can handle larger limits (up to 1000)
+   - **IPC post list queries** → Respect `GetPostsSchema` max **100**
    - **Unindexed queries** → Must use strict limits (50-100) to prevent blocking
    - **WAL mode** → Required for concurrent reads (enabled automatically)
 
@@ -683,12 +686,9 @@ const posts = await db.query.posts.findMany({
 
    - **Pages:**
 
-    - **Updates.tsx** - Subscriptions feed (implemented, with remaining roadmap parity gaps)
-    - **Browse.tsx** - Live booru search (Source: All) with infinite scroll, filters, and sorting; Favorites/Subscriptions modes query the local cache (implemented)
-    - **Favorites.tsx** - Favorites collection (implemented)
-    - **Tracked.tsx** - Artists and tags management (fully implemented)
-    - **Settings.tsx** - Application configuration shell (tabbed IA, fully implemented)
-    - **ArtistDetails.tsx** - Artist gallery view (fully implemented)
+    - **Updates.tsx** / **Browse.tsx** / **Favorites.tsx** / **PlaylistsPage.tsx** / **StatsPage.tsx** — `src/renderer/components/pages/`
+    - **Tracked.tsx** / **ArtistDetails.tsx** / **ArtistGallery.tsx** — `src/renderer/features/artists/`
+    - **Settings.tsx** — `src/renderer/features/settings/Settings.tsx` (tabbed IA)
     - **Onboarding.tsx** - API credentials input form (`src/renderer/features/onboarding/Onboarding.tsx`)
 
   - **Layout:**
@@ -1033,10 +1033,9 @@ sequenceDiagram
 
    **Path B: Validation Succeeds**
 
-   - Controller calls service: `dbService.addArtist(validatedData)`
-   - Service executes Drizzle insert:
+   - Controller inserts via Drizzle on `getDb()` (no separate `dbService` layer):
      ```typescript
-     await db
+     db
        .insert(artists)
        .values({
          name: "example_artist",
@@ -1151,8 +1150,10 @@ sequenceDiagram
    c. **Fetches posts from API** - Makes HTTP request to Rule34.xxx API:
 
    ```
-   GET https://api.rule34.xxx/index.php?page=dapi&s=post&q=index&tags=tag_name&limit=1000
+   GET https://api.rule34.xxx/index.php?page=dapi&s=post&q=index&tags=tag_name&limit=100
    ```
+
+   (`PAGE_SIZE` = 100 in `src/main/providers/types.ts`)
 
    d. **Maps API response** - Converts API JSON format to database schema format.
 
@@ -1674,12 +1675,12 @@ src/
 └── shared/                         # Shared contracts (schemas/constants/types)
     ├── schemas/
     ├── constants.ts
-    └── types.ts
+    └── types/                      # Shared TypeScript types
 
 Root:
 ├── drizzle/                        # Database migrations
 │   ├── *.sql                       # SQL migration files (tracked in git)
-│   └── meta/                       # Migration metadata (ignored by git)
+│   └── meta/                       # Migration journal + snapshots (tracked in git)
 │       ├── _journal.json           # Migration journal
 │       └── *_snapshot.json         # Schema snapshots
 ├── docs/                           # Documentation
@@ -1693,11 +1694,10 @@ Root:
 │   └── rule34-api-reference.md
 ├── scripts/                        # Build and utility scripts
 │   ├── generate-api-docs.mjs       # IPC docs generator
-│   ├── ai_reviewer.py
-│   └── system_prompt.md
+│   ├── check-img-loading-decoding.mjs
+│   └── check-release-artifacts.mjs
 ├── .github/                        # GitHub workflows
 │   └── workflows/
-│       ├── ai-review.yml
 │       └── ci.yml
 ├── electron.vite.config.ts         # Electron-Vite configuration
 ├── drizzle.config.ts               # Drizzle ORM configuration
@@ -1738,7 +1738,7 @@ Root:
 
 **Database & Schema:**
 
-- **Schema:** Core tables `artists`, `posts`, `settings`; also `tag_metadata` (`status` found|not_found + `resolved_at` TTL for misses), `playlists`, `playlist_entries`, and FTS5 for post tags
+- **Schema:** Core tables `artists`, `posts`, `settings`; also `tag_metadata` (`status` found|not_found + `resolved_at` TTL for misses), `playlists`, `playlist_entries`, `tag_blacklist`, and FTS5 for post tags
 - **Migrations:** Fully functional migration system using `drizzle-kit` 0.30+ (`drizzle.config.ts`, `npm run db:generate` / `db:migrate`)
 - **Testing & CI:** Vitest (unit, integration, property), Playwright (E2E); CI runs `validate`, `npm test`, and production `npm audit`
 - **Indexes:** Optimized indexes on `artistId`, `isViewed`, `publishedAt`, `isFavorited`, `lastChecked`, `createdAt`
@@ -1759,7 +1759,7 @@ Root:
 - **Tag Normalization:** Automatic stripping of metadata from tag names (e.g., "tag (123)" → "tag")
 - **Sync Service:** Handles `ON CONFLICT` correctly with proper upsert logic
 - **Provider Pattern:** Multi-booru support via `IBooruProvider` interface
-- **Rate Limiting:** Intelligent rate limiting with configurable delays
+- **Rate Limiting:** Shared `ProviderThrottle` (~1200ms + 0–400ms jitter per request)
 
 **UI/UX:**
 
@@ -1791,7 +1791,7 @@ Root:
 15. ✅ **Favorites System:** Mark and manage favorite posts with toggle functionality
 16. ✅ **Download Manager:** Download full-resolution files with progress tracking
 17. ✅ **Full-Screen Viewer:** Immersive viewer with keyboard shortcuts, download, favorites, and tag management
-18. ✅ **Sidebar Navigation:** Persistent sidebar with main navigation sections (Updates, Browse, Favorites, Tracked, Settings)
+18. ✅ **Sidebar Navigation:** Persistent sidebar with main navigation sections (Browse, Updates, Artists, Favorites, Playlists, Statistics, Settings)
 19. ✅ **Global Top Bar:** Search, `FiltersPanel` (AI, media, source), sort, view toggle, `SyncStatusBadge` — filters consumed by gallery/browse pipelines.
 20. ✅ **Credential Verification:** Verify API credentials before saving and during sync operations
 21. ✅ **Clipboard Integration:** Copy metadata and debug information to clipboard

--- a/docs/database.md
+++ b/docs/database.md
@@ -55,7 +55,7 @@ Stores information about tracked artists/users.
 | `name`            | TEXT (NOT NULL)                   | Artist display name                         |
 | `tag`             | TEXT (NOT NULL, UNIQUE)           | Tag or username for tracking                |
 | `provider`        | TEXT (NOT NULL, DEFAULT 'rule34') | Provider ID: "rule34" or "gelbooru"         |
-| `type`            | TEXT (NOT NULL, DEFAULT 'tag')    | Type: "tag", "uploader", or "query"         |
+| `type`            | TEXT (NOT NULL)                   | Type: "tag", "uploader", or "query"         |
 | `api_endpoint`    | TEXT (NOT NULL)                   | Base API endpoint URL                       |
 | `last_post_id`    | INTEGER (NOT NULL, DEFAULT 0)     | ID of the last seen post                    |
 | `new_posts_count` | INTEGER (NOT NULL, DEFAULT 0)     | Count of new, unviewed posts                |
@@ -136,6 +136,7 @@ Caches post metadata for filtering, statistics, and download management. Support
 
 - `postIdIdx` - Index on `post_id` for efficient lookups
 - `artistIdIdx` - Index on `artist_id` for artist-based queries
+- `posts_rating_idx` - Index on `rating` for rating filters
 - `isViewedIdx` - Index on `is_viewed` for view status filtering
 - `posts_last_viewed_at_idx` - Index on `last_viewed_at` for recently viewed sorting
 - `publishedAtIdx` - Index on `published_at` for date-based sorting
@@ -415,6 +416,22 @@ export type NewPlaylistEntry = typeof playlistEntries.$inferInsert;
 
 - Deleting a playlist automatically deletes all associated `playlist_entries` records
 - Deleting a post automatically removes it from all playlists (via cascade delete)
+
+### Table: `tag_blacklist`
+
+Local tag blocklist (Settings → Blacklist). Not modeled in Drizzle `schema.ts`; created by migration `drizzle/0025_add_tag_blacklist.sql` and accessed via raw SQL in `src/main/db/queries/blacklist.ts`.
+
+| Column       | Type                        | Description                          |
+| ------------ | --------------------------- | ------------------------------------ |
+| `id`         | INTEGER (PK, AutoIncrement) | Primary key                          |
+| `tag`        | TEXT (NOT NULL, UNIQUE)     | Normalized tag (lowercase, trimmed)  |
+| `created_at` | INTEGER (NOT NULL)          | Insert time (`unixepoch()` default)  |
+
+**Limits:** Maximum **100** tags (`MAX_BLACKLIST_TAGS` in `blacklist.ts`). Soft-deleted from feeds in Main after fetch / in local queries.
+
+**Indexes:**
+
+- `idx_blacklist_tag` — UNIQUE on `tag`
 
 All database operations are performed directly in the **Main Process** using synchronous access via `better-sqlite3`. WAL (Write-Ahead Logging) mode is enabled to allow concurrent reads while writes are in progress.
 
@@ -722,12 +739,11 @@ npm run db:migrate
 Migrations are stored in `drizzle/`:
 
 - **SQL files:** `drizzle/*.sql` - **Tracked in git** (included in repository and build)
-- **Metadata:** `drizzle/meta/` - **Ignored by git** (local development files)
+- **Metadata:** `drizzle/meta/` - **Tracked in git** (required for drizzle-kit journal / snapshots)
   - `meta/_journal.json` - Migration journal
   - `meta/*_snapshot.json` - Schema snapshots
-- **Migrations config:** `drizzle/migrations.json` - **Ignored by git** (generated file)
 
-**Note:** Only SQL migration files are tracked in version control. Meta files and migration configuration are generated locally and should not be committed.
+**Note:** Commit both SQL migrations and `drizzle/meta/` updates after `npm run db:generate`. There is no `drizzle/migrations.json` in this repo.
 
 **Example Migration:**
 
@@ -737,7 +753,7 @@ CREATE TABLE `artists` (
   `name` text NOT NULL,
   `tag` text NOT NULL UNIQUE,
   `provider` text NOT NULL DEFAULT 'rule34',
-  `type` text NOT NULL DEFAULT 'tag',
+  `type` text NOT NULL,
   `api_endpoint` text NOT NULL,
   `last_post_id` integer DEFAULT 0 NOT NULL,
   `new_posts_count` integer DEFAULT 0 NOT NULL,
@@ -847,10 +863,12 @@ Always use Drizzle's inferred types:
 
 ```typescript
 // Good
-const artist: Artist = await dbService.getTrackedArtists()[0];
+const artists = getDb().query.artists.findMany();
+const artist: Artist = artists[0];
 
 // Bad
-const artist: any = await dbService.getTrackedArtists()[0];
+const artists = getDb().query.artists.findMany();
+const artist: any = artists[0];
 ```
 
 ### 2. Error Handling
@@ -859,7 +877,7 @@ Always handle database errors:
 
 ```typescript
 try {
-  const artist = await dbService.addArtist(data);
+  getDb().insert(artists).values(data).run();
 } catch (error) {
   logger.error("Database error:", error);
   throw error;

--- a/docs/index.md
+++ b/docs/index.md
@@ -100,7 +100,7 @@ Engineering materials are intentionally grouped here to keep the top-level index
 - [Rule34 API Reference](./rule34-api-reference.md) - External API specifics
 - [README — Development Setup](../README.md#-development-setup) - Local dev, quality gates, testing, CI/CD
 - [Unit test guide](../tests/unit/README.md) - Vitest unit/property test layout
-- [Test coverage summary](../tests/unit/TEST_COVERAGE.md) - Suite inventory (**197** Vitest tests across 28 files)
+- [Test coverage summary](../tests/unit/TEST_COVERAGE.md) - Suite inventory (**209** Vitest tests across 30 files)
 - [Integration test notes](../tests/integration/README.md) - IPC + SQLite integration tests
 - [.cursorrules](../.cursorrules) - Engineering standards (includes English-only UI copy; no i18n stack)
 - [Canonical Lessons](../.ai/LESSONS.txt) - Reusable invariants (do not add root `LESSONS.md`)
@@ -111,7 +111,7 @@ Engineering materials are intentionally grouped here to keep the top-level index
 |------|---------|
 | Typecheck + lint + img policy | `npm run validate` |
 | IPC API docs freshness | `npm run docs:api` (CI: then `git diff --exit-code docs/api.md`) |
-| All Vitest suites (197 tests) | `npm test` |
+| All Vitest suites (209 tests) | `npm test` |
 | Pre-PR full gate | `npm run test:verify` |
 | Production dependency audit | `npm audit --omit=dev --audit-level=high` |
 
@@ -174,5 +174,5 @@ This documentation is maintained alongside the codebase. When making changes:
 
 ---
 
-**Last Updated:** July 2026 — Audit v17 pack complete: PRs #105–#115 (including P0 video-cache #114 and sync-cursor #115). See [roadmap — branch tracking](./roadmap.md#-technical-improvements-from-audit--dx). Vitest **197** / **28** files.
+**Last Updated:** July 2026 — Audit v17 pack complete: PRs #105–#115 (including P0 video-cache #114 and sync-cursor #115). See [roadmap — branch tracking](./roadmap.md#-technical-improvements-from-audit--dx). Vitest **209** / **30** files (`npm run test:run`).
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -116,7 +116,7 @@ The short version: the core product is shipped, now we focus on parity gaps and 
 ### M2 - UX Parity (In Progress)
 
 - ✅ Filter panel is aligned to **AI/media/source** scope.
-- ✅ Settings tabbed IA shipped (General / Sync / Appearance / Backup / Account), including Danger-zone wipe.
+- ✅ Settings tabbed IA shipped (General / Sync / Appearance / Backup / Account / Blacklist), including Danger-zone wipe.
 - Gallery/viewer: edge-case polish; core **TagsDrawer** and **PostCard** progressive loading are shipped.
 - Updates feed QoL largely shipped (Creators tab, mark all read); further polish as needed.
 
@@ -164,7 +164,7 @@ Both P0 rows (#1–#2) are closed — the full v17 audit pack landed (after one 
 
 - ✅ **Testing:** Vitest (unit, integration, property/fuzzing) + Playwright; ABI rebuild scripts for Node vs Electron.
 - ✅ **CI:** `validate` → `docs:api` freshness → `npm test` → production `npm audit --omit=dev --audit-level=high`; release tags wait for quality + e2e, then Windows zip + Linux AppImage.
-- ✅ **Post-audit regression tests:** **197** Vitest tests across **28** files (includes collapse/throttle + `SecureStorage` + video-proxy suites — see [`TEST_COVERAGE.md`](../tests/unit/TEST_COVERAGE.md)).
+- ✅ **Post-audit regression tests:** **209** Vitest tests across **30** files (includes collapse/throttle + `SecureStorage` + video-proxy suites — see [`TEST_COVERAGE.md`](../tests/unit/TEST_COVERAGE.md); inventory file may lag — trust `npm test` count).
 - ✅ **Main process HMR/watch**, shared Zod IPC helpers, provider search typed errors, video pipeline baseline (`<video>` attrs / hardware decode flags).
 
 - ⏳ **Tooling / hygiene:** keep `validate` green; remaining shared validation consolidation as needed. Dev-only audit noise (electron-builder transitive deps) is separate from production `npm audit`.

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -380,6 +380,7 @@ RuleDesk has a **sidebar** on the left side with the main sections:
 - **Browse** - Search the live booru (Source: All) or filter cached posts (Favorites / Subscriptions); infinite scroll, filters, and sorting
 - **Favorites** - Your favorited posts collection
 - **Playlists** - Manual playlists and smart collections
+- **Statistics** - Local library aggregates and charts (`/stats`)
 - **Artists** - Manage your tracked artists and tags
 - **Settings** - App configuration and preferences
 
@@ -449,6 +450,7 @@ Settings are split into tabs:
 ### Blacklist
 
 - **Tag blacklist** - Hide posts that contain specific tags from Browse and local galleries
+- Maximum **100** tags
 - Tags are stored locally; pagination still uses the raw API batch size before filtering
 
 ### Backup
@@ -462,6 +464,8 @@ Settings are split into tabs:
 
 ### Account
 
+- **Provider** - Choose `rule34` or `gelbooru` (changing provider invalidates feed query caches and saves the selection)
+- **User ID** - Shown when the selected provider needs it
 - **API key field** - Password-style input with show/hide button
 - **API key status** - `Configured` / `Not configured` badge
 - **Save API key** - Update credentials from Settings


### PR DESCRIPTION
- Added maximum limit of **100** tags for the tag blacklist in the README and user guide.
- Updated API guide to reflect changes in `getArtistPostsCount` parameters, now accepting an object with `artistId` and optional filters.
- Enhanced architecture documentation to clarify service layer responsibilities and added details about the new `BlacklistController`.
- Increased test coverage count in documentation to **209 tests** across **30 files**.

This update ensures clarity in the documentation regarding new features and limits, improving user understanding and system integrity.