### PR TITLE
fix: redact credentials from axios error logs

### DIFF
--- a/src/main/lib/redact-error.ts
+++ b/src/main/lib/redact-error.ts
@@ -1,0 +1,68 @@
+import axios from "axios";
+
+const CREDENTIAL_QUERY_PARAMS = ["api_key", "user_id", "apiKey", "userId"] as const;
+const REDACTED_VALUE = "<redacted>";
+
+export type RedactedLogError = {
+  message: string;
+  name?: string;
+  code?: string;
+  status?: number;
+  url?: string;
+};
+
+/**
+ * Redacts credential query params from a URL string.
+ * Used before writing HTTP errors to disk logs (app.log).
+ */
+export function redactCredentialQueryParams(rawUrl: string): string {
+  try {
+    const url = new URL(rawUrl);
+    for (const param of CREDENTIAL_QUERY_PARAMS) {
+      if (url.searchParams.has(param)) {
+        url.searchParams.set(param, REDACTED_VALUE);
+      }
+    }
+    return url.toString();
+  } catch {
+    let result = rawUrl;
+    for (const param of CREDENTIAL_QUERY_PARAMS) {
+      result = result.replace(
+        new RegExp(`([?&]${param}=)[^&]*`, "gi"),
+        `$1${REDACTED_VALUE}`
+      );
+    }
+    return result;
+  }
+}
+
+/**
+ * Returns a log-safe summary of an unknown error.
+ * Never forwards Axios `config` / full error objects (they embed credentials in URLs).
+ */
+export function redactErrorForLog(error: unknown): RedactedLogError {
+  if (axios.isAxiosError(error)) {
+    const rawUrl = error.config?.url;
+    return {
+      message: error.message,
+      name: error.name,
+      code: error.code,
+      status: error.response?.status,
+      url:
+        typeof rawUrl === "string"
+          ? redactCredentialQueryParams(rawUrl)
+          : undefined,
+    };
+  }
+
+  if (error instanceof Error) {
+    return {
+      message: error.message,
+      name: error.name,
+    };
+  }
+
+  return {
+    message: String(error),
+  };
+}

--- a/src/main/providers/gelbooru-provider.ts
+++ b/src/main/providers/gelbooru-provider.ts
@@ -15,6 +15,7 @@ import { z } from "zod";
 import { ProviderThrottle, pickRandomUA, ProviderRateLimitGateError } from "./provider-throttle";
 import { ProviderSearchError } from "./provider-search-errors";
 import { getProxyAgent } from "../lib/proxy";
+import { redactErrorForLog } from "../lib/redact-error";
 
 type GelbooruTagItem = {
   value: string;
@@ -80,7 +81,10 @@ export class GelbooruProvider implements IBooruProvider {
       // Gelbooru sometimes returns empty array or object with post array
       return status === 200 && (Array.isArray(data) || !!data?.post);
     } catch (error) {
-      logger.error("[GelbooruProvider] Auth check failed", error);
+      logger.error(
+        "[GelbooruProvider] Auth check failed",
+        redactErrorForLog(error)
+      );
       return false;
     }
   }
@@ -250,8 +254,11 @@ export class GelbooruProvider implements IBooruProvider {
       
       return posts;
     } catch (error) {
-       logger.error(`[Gelbooru] Error fetching page ${page}`, error);
-       return [];
+      logger.error(
+        `[Gelbooru] Error fetching page ${page}`,
+        redactErrorForLog(error)
+      );
+      return [];
     }
   }
 

--- a/src/main/providers/rule34-provider.ts
+++ b/src/main/providers/rule34-provider.ts
@@ -25,6 +25,7 @@ import { z } from "zod";
 import { ProviderThrottle, pickRandomUA, ProviderRateLimitGateError } from "./provider-throttle";
 import { ProviderSearchError, isProviderSearchError } from "./provider-search-errors";
 import { getProxyAgent } from "../lib/proxy";
+import { redactErrorForLog } from "../lib/redact-error";
 import {
   assertRule34NotBlockedResponse,
   isAxiosTransportFailure,
@@ -130,7 +131,7 @@ export class Rule34Provider implements IBooruProvider {
 
       return status === 200 && Array.isArray(data);
     } catch (error) {
-      logger.error("[Rule34Provider] Auth check failed", error);
+      logger.error("[Rule34Provider] Auth check failed", redactErrorForLog(error));
       return false;
     }
   }

--- a/src/main/services/sync-service.ts
+++ b/src/main/services/sync-service.ts
@@ -1,5 +1,6 @@
 import { BrowserWindow } from "electron";
 import { logger } from "../lib/logger";
+import { redactErrorForLog } from "../lib/redact-error";
 import { getDb, getSqliteInstance } from "../db/client";
 import { artists, settings, posts, SETTINGS_ID } from "../db/schema";
 import {
@@ -576,7 +577,10 @@ export class SyncService {
             logger.debug(`SyncService: ${artist.name} - Page ${page - 1} returned ${postsData.length} posts, continuing to page ${page}`);
           }
         } catch (e) {
-          logger.error(`Sync error for ${artist.name}`, e);
+          logger.error(
+            `Sync error for ${artist.name}`,
+            redactErrorForLog(e)
+          );
           hasMore = false;
 
           try {

--- a/tests/unit/lib/redact-error.test.ts
+++ b/tests/unit/lib/redact-error.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, it } from "vitest";
+import { AxiosError } from "axios";
+import {
+  redactCredentialQueryParams,
+  redactErrorForLog,
+} from "@/main/lib/redact-error";
+
+describe("redactCredentialQueryParams", () => {
+  it("redacts api_key and user_id from absolute URLs", () => {
+    const raw =
+      "https://api.rule34.xxx/index.php?page=dapi&api_key=secret-key-value&user_id=12345&json=1";
+    const redacted = redactCredentialQueryParams(raw);
+
+    expect(redacted).toContain("api_key=%3Credacted%3E");
+    expect(redacted).toContain("user_id=%3Credacted%3E");
+    expect(redacted).not.toContain("secret-key-value");
+    expect(redacted).not.toContain("12345");
+    expect(redacted).toContain("json=1");
+  });
+
+  it("redacts credentials from malformed relative URLs via fallback", () => {
+    const raw = "/index.php?api_key=plain-secret&user_id=99&tags=test";
+    const redacted = redactCredentialQueryParams(raw);
+
+    expect(redacted).toContain("api_key=<redacted>");
+    expect(redacted).toContain("user_id=<redacted>");
+    expect(redacted).not.toContain("plain-secret");
+    expect(redacted).toContain("tags=test");
+  });
+});
+
+describe("redactErrorForLog", () => {
+  it("returns a safe summary for AxiosError with credential URL", () => {
+    const axiosError = new AxiosError(
+      "Network Error",
+      "ERR_NETWORK",
+      {
+        url: "https://gelbooru.com/index.php?api_key=leaked-key&user_id=42",
+      },
+      undefined,
+      undefined
+    );
+
+    const safe = redactErrorForLog(axiosError);
+
+    expect(safe.message).toBe("Network Error");
+    expect(safe.code).toBe("ERR_NETWORK");
+    expect(safe.url).toContain("api_key=%3Credacted%3E");
+    expect(safe.url).toContain("user_id=%3Credacted%3E");
+    expect(JSON.stringify(safe)).not.toContain("leaked-key");
+    expect(JSON.stringify(safe)).not.toContain("user_id=42");
+  });
+
+  it("does not forward config for non-axios Errors", () => {
+    const safe = redactErrorForLog(new Error("parse failed"));
+    expect(safe).toEqual({
+      message: "parse failed",
+      name: "Error",
+    });
+  });
+
+  it("stringifies unknown non-error values", () => {
+    expect(redactErrorForLog(42)).toEqual({ message: "42" });
+  });
+});


### PR DESCRIPTION
Prevent api_key/user_id in query URLs from landing in app.log when auth/fetch fails.

Merge blocker TODO: live offline auth-check — confirm Select-String api_key/user_id= on app.log is empty after intentional network failure.