### PR TITLE
fix: frontend Virtuoso gallery audit (factories, tests, shadcn)

### DIFF
--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -165,7 +165,7 @@ Both P0 rows (#1–#2) are closed — the full v17 audit pack landed (after one 
 | Branch | Status | Notes |
 |--------|--------|-------|
 | `fix/ipc-handlers-compliance` | 🔄 PR | Legacy `ipcMain.handle` → BaseController; silent catch removed. (Branch renamed: remote `audit` ref blocks `audit/*`) |
-| `fix-frontend-virtuoso-gallery-audit` | 🔄 in progress | Decorative tests; VirtuosoGrid factory dedupe; totalCount audit; raw HTML→shadcn |
+| `fix-frontend-virtuoso-gallery-audit` | 🔄 PR | [#125](https://github.com/KazeKaze93/RuleDesk/pull/125) — decorative tests; VirtuosoGrid factory dedupe; totalCount audit (clean); raw HTML→shadcn |
 
 ### Baseline DX (earlier)
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -165,6 +165,7 @@ Both P0 rows (#1–#2) are closed — the full v17 audit pack landed (after one 
 | Branch | Status | Notes |
 |--------|--------|-------|
 | `fix/ipc-handlers-compliance` | 🔄 PR | Legacy `ipcMain.handle` → BaseController; silent catch removed. (Branch renamed: remote `audit` ref blocks `audit/*`) |
+| `fix-frontend-virtuoso-gallery-audit` | 🔄 in progress | Decorative tests; VirtuosoGrid factory dedupe; totalCount audit; raw HTML→shadcn |
 
 ### Baseline DX (earlier)
 

--- a/src/renderer/components/gallery/virtuoso-factories.tsx
+++ b/src/renderer/components/gallery/virtuoso-factories.tsx
@@ -1,0 +1,90 @@
+import React, { forwardRef } from "react";
+import { cn } from "../../lib/utils";
+
+type VirtuosoListProps = React.HTMLAttributes<HTMLDivElement> & {
+  "aria-busy"?: boolean;
+};
+
+type GridContainerProps = React.HTMLAttributes<HTMLDivElement> & {
+  viewType?: "grid" | "masonry";
+};
+
+/**
+ * Shared VirtuosoGrid List/Item factories for feed galleries that use the
+ * flex-width masonry item pattern (Browse / Favorites / Updates).
+ * Display-name prefix is the only intentional per-page difference.
+ */
+export function createVirtuosoGridFactories(displayNamePrefix: string) {
+  const GridContainer = forwardRef<HTMLDivElement, GridContainerProps>(
+    ({ className, viewType = "grid", ...props }, ref) => (
+      <div
+        ref={ref}
+        className={cn(
+          viewType === "grid"
+            ? "grid gap-4 p-4 pb-44 [grid-template-columns:repeat(var(--grid-cols,auto-fill),minmax(188px,1fr))]"
+            : "columns-2 md:columns-3 lg:columns-4 xl:columns-5 gap-4 p-4 pb-44",
+          className
+        )}
+        {...props}
+      />
+    )
+  );
+  GridContainer.displayName = "GridContainer";
+
+  const GridItemContainer = forwardRef<
+    HTMLDivElement,
+    React.HTMLAttributes<HTMLDivElement>
+  >(({ className, ...props }, ref) => (
+    <div ref={ref} className={cn("w-full aspect-[2/3]", className)} {...props} />
+  ));
+  GridItemContainer.displayName = `${displayNamePrefix}GridItemContainer`;
+
+  const MasonryItemContainer = forwardRef<
+    HTMLDivElement,
+    React.HTMLAttributes<HTMLDivElement>
+  >(({ className, ...props }, ref) => (
+    <div
+      ref={ref}
+      className={cn(
+        "flex-shrink-0 w-[calc(50%-0.5rem)] md:w-[calc(33.333%-1rem)] lg:w-[calc(25%-1rem)] xl:w-[calc(20%-1rem)]",
+        className
+      )}
+      {...props}
+    />
+  ));
+  MasonryItemContainer.displayName = `${displayNamePrefix}MasonryItemContainer`;
+
+  const GridVirtuosoList = forwardRef<HTMLDivElement, VirtuosoListProps>(
+    ({ className, "aria-busy": ariaBusy, ...props }, ref) => (
+      <GridContainer
+        {...props}
+        ref={ref}
+        className={className}
+        aria-busy={ariaBusy}
+        viewType="grid"
+      />
+    )
+  );
+  GridVirtuosoList.displayName = `${displayNamePrefix}GridVirtuosoList`;
+
+  const MasonryVirtuosoList = forwardRef<HTMLDivElement, VirtuosoListProps>(
+    ({ className, "aria-busy": ariaBusy, ...props }, ref) => (
+      <GridContainer
+        {...props}
+        ref={ref}
+        className={className}
+        aria-busy={ariaBusy}
+        viewType="masonry"
+      />
+    )
+  );
+  MasonryVirtuosoList.displayName = `${displayNamePrefix}MasonryVirtuosoList`;
+
+  return {
+    GridContainer,
+    GridItemContainer,
+    MasonryItemContainer,
+    GridVirtuosoList,
+    MasonryVirtuosoList,
+  };
+}

--- a/src/renderer/components/pages/Browse.tsx
+++ b/src/renderer/components/pages/Browse.tsx
@@ -1,4 +1,4 @@
-import React, { useMemo, forwardRef, useCallback, useEffect } from "react";
+import React, { useMemo, useCallback, useEffect } from "react";
 import {
   useQuery,
   useMutation,
@@ -8,7 +8,6 @@ import {
 import { Search, Loader2, CheckSquare } from "lucide-react";
 import { VirtuosoGrid } from "react-virtuoso";
 import log from "electron-log/renderer";
-import { cn } from "../../lib/utils";
 import { resolveErrorMessage } from "../../utils/error-message";
 import {
   assertBrowseSearchError,
@@ -44,6 +43,7 @@ import { BulkActionBar } from "../BulkActionBar/BulkActionBar";
 import { getBulkSelectId } from "../../lib/bulkSelect";
 import { useReleaseRadixModalLockOnMount } from "../../hooks/useReleaseRadixModalLockOnMount";
 import { getSearchBrowseNextPageParam, isSearchGalleryPage } from "../../utils/react-query-cache";
+import { createVirtuosoGridFactories } from "../gallery/virtuoso-factories";
 
 const POSTS_PER_PAGE = 50;
 const BROWSE_SEARCH_STALE_TIME_MS = 5 * 60 * 1000;
@@ -57,73 +57,13 @@ function isBrowseCursorPageParam(
   return typeof pageParam === "object" && "beforePostId" in pageParam;
 }
 
-// --- Компоненты для виртуализации (Grid/Masonry Layout) ---
-
-const GridContainer = forwardRef<
-  HTMLDivElement,
-  React.HTMLAttributes<HTMLDivElement> & { viewType?: "grid" | "masonry" }
->(({ className, viewType = "grid", ...props }, ref) => (
-  <div
-    ref={ref}
-    className={cn(
-      viewType === "grid"
-        ? "grid gap-4 p-4 pb-44 [grid-template-columns:repeat(var(--grid-cols,auto-fill),minmax(188px,1fr))]"
-        : "columns-2 md:columns-3 lg:columns-4 xl:columns-5 gap-4 p-4 pb-44",
-      className
-    )}
-    {...props}
-  />
-));
-GridContainer.displayName = "GridContainer";
-
-const GridItemContainer = forwardRef<HTMLDivElement, React.HTMLAttributes<HTMLDivElement>>(
-  ({ className, ...props }, ref) => (
-    <div ref={ref} className={cn("w-full aspect-[2/3]", className)} {...props} />
-  )
-);
-GridItemContainer.displayName = "BrowseGridItemContainer";
-
-const MasonryItemContainer = forwardRef<HTMLDivElement, React.HTMLAttributes<HTMLDivElement>>(
-  ({ className, ...props }, ref) => (
-    <div
-      ref={ref}
-      className={cn(
-        "flex-shrink-0 w-[calc(50%-0.5rem)] md:w-[calc(33.333%-1rem)] lg:w-[calc(25%-1rem)] xl:w-[calc(20%-1rem)]",
-        className
-      )}
-      {...props}
-    />
-  )
-);
-MasonryItemContainer.displayName = "BrowseMasonryItemContainer";
-
-const GridVirtuosoList = forwardRef<
-  HTMLDivElement,
-  React.HTMLAttributes<HTMLDivElement> & { "aria-busy"?: boolean }
->(({ className, "aria-busy": ariaBusy, ...props }, ref) => (
-  <GridContainer
-    {...props}
-    ref={ref}
-    className={className}
-    aria-busy={ariaBusy}
-    viewType="grid"
-  />
-));
-GridVirtuosoList.displayName = "BrowseGridVirtuosoList";
-
-const MasonryVirtuosoList = forwardRef<
-  HTMLDivElement,
-  React.HTMLAttributes<HTMLDivElement> & { "aria-busy"?: boolean }
->(({ className, "aria-busy": ariaBusy, ...props }, ref) => (
-  <GridContainer
-    {...props}
-    ref={ref}
-    className={className}
-    aria-busy={ariaBusy}
-    viewType="masonry"
-  />
-));
-MasonryVirtuosoList.displayName = "BrowseMasonryVirtuosoList";
+const {
+  GridContainer,
+  GridItemContainer,
+  MasonryItemContainer,
+  GridVirtuosoList,
+  MasonryVirtuosoList,
+} = createVirtuosoGridFactories("Browse");
 
 // --- Основной компонент ---
 

--- a/src/renderer/components/pages/Favorites.tsx
+++ b/src/renderer/components/pages/Favorites.tsx
@@ -1,4 +1,4 @@
-import React, { forwardRef, useCallback, useMemo, useEffect } from "react";
+import React, { useCallback, useMemo, useEffect } from "react";
 import {
   useInfiniteQuery,
   useQueryClient,
@@ -8,7 +8,6 @@ import {
 import { Heart, Loader2, CheckSquare } from "lucide-react";
 import { VirtuosoGrid } from "react-virtuoso";
 import log from "electron-log/renderer";
-import { cn } from "../../lib/utils";
 import { hasAiGeneratedTag, isVideoPost } from "../../lib/filter-utils";
 import { useViewerStore } from "../../store/viewerStore";
 import { buildBooruTagListForIpc, useSearchStore } from "../../store/searchStore";
@@ -26,6 +25,7 @@ import { useBulkSelect } from "../../hooks/useBulkSelect";
 import { BulkActionBar } from "../BulkActionBar/BulkActionBar";
 import { getBulkSelectId } from "../../lib/bulkSelect";
 import { getErrorCode } from "../../../shared/utils/type-guards";
+import { createVirtuosoGridFactories } from "../gallery/virtuoso-factories";
 
 // --- Constants ---
 // Should ideally come from a shared constant or backend config
@@ -79,73 +79,13 @@ const shouldIncludePostInFavoritesQueue = (
   return true;
 };
 
-// --- Компоненты для виртуализации (Grid/Masonry Layout) ---
-
-const GridContainer = forwardRef<
-  HTMLDivElement,
-  React.HTMLAttributes<HTMLDivElement> & { viewType?: "grid" | "masonry" }
->(({ className, viewType = "grid", ...props }, ref) => (
-  <div
-    ref={ref}
-    className={cn(
-      viewType === "grid"
-        ? "grid gap-4 p-4 pb-44 [grid-template-columns:repeat(var(--grid-cols,auto-fill),minmax(188px,1fr))]"
-        : "columns-2 md:columns-3 lg:columns-4 xl:columns-5 gap-4 p-4 pb-44",
-      className
-    )}
-    {...props}
-  />
-));
-GridContainer.displayName = "GridContainer";
-
-const GridItemContainer = forwardRef<HTMLDivElement, React.HTMLAttributes<HTMLDivElement>>(
-  ({ className, ...props }, ref) => (
-    <div ref={ref} className={cn("w-full aspect-[2/3]", className)} {...props} />
-  )
-);
-GridItemContainer.displayName = "FavoritesGridItemContainer";
-
-const MasonryItemContainer = forwardRef<HTMLDivElement, React.HTMLAttributes<HTMLDivElement>>(
-  ({ className, ...props }, ref) => (
-    <div
-      ref={ref}
-      className={cn(
-        "flex-shrink-0 w-[calc(50%-0.5rem)] md:w-[calc(33.333%-1rem)] lg:w-[calc(25%-1rem)] xl:w-[calc(20%-1rem)]",
-        className
-      )}
-      {...props}
-    />
-  )
-);
-MasonryItemContainer.displayName = "FavoritesMasonryItemContainer";
-
-const GridVirtuosoList = forwardRef<
-  HTMLDivElement,
-  React.HTMLAttributes<HTMLDivElement> & { "aria-busy"?: boolean }
->(({ className, "aria-busy": ariaBusy, ...props }, ref) => (
-  <GridContainer
-    {...props}
-    ref={ref}
-    className={className}
-    aria-busy={ariaBusy}
-    viewType="grid"
-  />
-));
-GridVirtuosoList.displayName = "FavoritesGridVirtuosoList";
-
-const MasonryVirtuosoList = forwardRef<
-  HTMLDivElement,
-  React.HTMLAttributes<HTMLDivElement> & { "aria-busy"?: boolean }
->(({ className, "aria-busy": ariaBusy, ...props }, ref) => (
-  <GridContainer
-    {...props}
-    ref={ref}
-    className={className}
-    aria-busy={ariaBusy}
-    viewType="masonry"
-  />
-));
-MasonryVirtuosoList.displayName = "FavoritesMasonryVirtuosoList";
+const {
+  GridContainer,
+  GridItemContainer,
+  MasonryItemContainer,
+  GridVirtuosoList,
+  MasonryVirtuosoList,
+} = createVirtuosoGridFactories("Favorites");
 
 // --- Основной компонент ---
 

--- a/src/renderer/components/pages/PlaylistsPage.tsx
+++ b/src/renderer/components/pages/PlaylistsPage.tsx
@@ -1295,15 +1295,18 @@ export const PlaylistsPage: React.FC<PlaylistsPageProps> = ({ onBack }) => {
                             <Minus className="w-3 h-3" />
                           )}
                           <span>{tag.tag}</span>
-                          <button
+                          <Button
+                            type="button"
+                            variant="ghost"
+                            size="icon"
                             onClick={(e) => {
                               e.stopPropagation();
                               removeTag(index);
                             }}
-                            className="ml-1 hover:bg-black/20 rounded-full p-0.5"
+                            className="ml-1 h-auto w-auto rounded-full p-0.5 hover:bg-black/20"
                           >
                             <X className="w-3 h-3" />
-                          </button>
+                          </Button>
                         </Badge>
                       ))}
                     </div>
@@ -1474,15 +1477,18 @@ export const PlaylistsPage: React.FC<PlaylistsPageProps> = ({ onBack }) => {
                           <Minus className="w-3 h-3" />
                         )}
                         <span>{tag.tag}</span>
-                        <button
+                        <Button
+                          type="button"
+                          variant="ghost"
+                          size="icon"
                           onClick={(e) => {
                             e.stopPropagation();
                             removeTag(index);
                           }}
-                          className="ml-1 hover:bg-black/20 rounded-full p-0.5"
+                          className="ml-1 h-auto w-auto rounded-full p-0.5 hover:bg-black/20"
                         >
                           <X className="w-3 h-3" />
-                        </button>
+                        </Button>
                       </Badge>
                     ))}
                   </div>

--- a/src/renderer/components/pages/Updates.tsx
+++ b/src/renderer/components/pages/Updates.tsx
@@ -136,10 +136,12 @@ const CreatorsView = ({
         <div className="overflow-auto flex-1 p-4">
           <div className="space-y-3">
             {artists.map((artist) => (
-              <button
+              <Button
                 key={artist.id}
+                type="button"
+                variant="ghost"
                 onClick={() => onViewArtist(artist)}
-                className="flex items-center gap-3 p-3 w-full text-left rounded-lg border transition-colors bg-card hover:bg-accent hover:border-primary"
+                className="flex items-center gap-3 p-3 w-full h-auto text-left rounded-lg border transition-colors bg-card hover:bg-accent hover:border-primary"
                 aria-label={`View ${artist.name} gallery`}
               >
                 <div className="flex flex-shrink-0 justify-center items-center w-10 h-10 rounded-full bg-primary/10">
@@ -159,7 +161,7 @@ const CreatorsView = ({
                   </Badge>
                 )}
                 <ChevronRight className="flex-shrink-0 w-4 h-4 text-muted-foreground" />
-              </button>
+              </Button>
             ))}
           </div>
         </div>

--- a/src/renderer/components/pages/Updates.tsx
+++ b/src/renderer/components/pages/Updates.tsx
@@ -1,4 +1,4 @@
-import React, { forwardRef, useCallback, useEffect, useMemo, useState } from "react";
+import React, { useCallback, useEffect, useMemo, useState } from "react";
 import {
   useInfiniteQuery,
   useQuery,
@@ -10,7 +10,6 @@ import { RefreshCw, Loader2, CheckCheck, User, ChevronRight, CheckSquare } from 
 import { VirtuosoGrid } from "react-virtuoso";
 import { useNavigate } from "react-router-dom";
 import log from "electron-log/renderer";
-import { cn } from "../../lib/utils";
 import { hasAiGeneratedTag, isVideoPost } from "../../lib/filter-utils";
 import { useViewerStore } from "../../store/viewerStore";
 import { buildBooruTagListForIpc, useSearchStore } from "../../store/searchStore";
@@ -32,6 +31,7 @@ import { BulkActionBar } from "../BulkActionBar/BulkActionBar";
 import { getBulkSelectId } from "../../lib/bulkSelect";
 import { formatRelativeTime } from "../../lib/formatRelativeTime";
 import { useReleaseRadixModalLockOnMount } from "../../hooks/useReleaseRadixModalLockOnMount";
+import { createVirtuosoGridFactories } from "../gallery/virtuoso-factories";
 
 // --- Constants ---
 const POSTS_PER_PAGE = 50;
@@ -82,73 +82,13 @@ const updatePostInInfiniteData = (
   };
 };
 
-// --- Компоненты для виртуализации (Grid/Masonry Layout) ---
-
-const GridContainer = forwardRef<
-  HTMLDivElement,
-  React.HTMLAttributes<HTMLDivElement> & { viewType?: "grid" | "masonry" }
->(({ className, viewType = "grid", ...props }, ref) => (
-  <div
-    ref={ref}
-    className={cn(
-      viewType === "grid"
-        ? "grid gap-4 p-4 pb-44 [grid-template-columns:repeat(var(--grid-cols,auto-fill),minmax(188px,1fr))]"
-        : "columns-2 md:columns-3 lg:columns-4 xl:columns-5 gap-4 p-4 pb-44",
-      className
-    )}
-    {...props}
-  />
-));
-GridContainer.displayName = "GridContainer";
-
-const GridItemContainer = forwardRef<HTMLDivElement, React.HTMLAttributes<HTMLDivElement>>(
-  ({ className, ...props }, ref) => (
-    <div ref={ref} className={cn("w-full aspect-[2/3]", className)} {...props} />
-  )
-);
-GridItemContainer.displayName = "GridItemContainer";
-
-const MasonryItemContainer = forwardRef<HTMLDivElement, React.HTMLAttributes<HTMLDivElement>>(
-  ({ className, ...props }, ref) => (
-    <div
-      ref={ref}
-      className={cn(
-        "flex-shrink-0 w-[calc(50%-0.5rem)] md:w-[calc(33.333%-1rem)] lg:w-[calc(25%-1rem)] xl:w-[calc(20%-1rem)]",
-        className
-      )}
-      {...props}
-    />
-  )
-);
-MasonryItemContainer.displayName = "MasonryItemContainer";
-
-const GridVirtuosoList = forwardRef<
-  HTMLDivElement,
-  React.HTMLAttributes<HTMLDivElement> & { "aria-busy"?: boolean }
->(({ className, "aria-busy": ariaBusy, ...props }, ref) => (
-  <GridContainer
-    {...props}
-    ref={ref}
-    className={className}
-    aria-busy={ariaBusy}
-    viewType="grid"
-  />
-));
-GridVirtuosoList.displayName = "GridVirtuosoList";
-
-const MasonryVirtuosoList = forwardRef<
-  HTMLDivElement,
-  React.HTMLAttributes<HTMLDivElement> & { "aria-busy"?: boolean }
->(({ className, "aria-busy": ariaBusy, ...props }, ref) => (
-  <GridContainer
-    {...props}
-    ref={ref}
-    className={className}
-    aria-busy={ariaBusy}
-    viewType="masonry"
-  />
-));
-MasonryVirtuosoList.displayName = "MasonryVirtuosoList";
+const {
+  GridContainer,
+  GridItemContainer,
+  MasonryItemContainer,
+  GridVirtuosoList,
+  MasonryVirtuosoList,
+} = createVirtuosoGridFactories("Updates");
 
 // --- Основной компонент ---
 

--- a/src/renderer/features/artists/components/ArtistListRow.tsx
+++ b/src/renderer/features/artists/components/ArtistListRow.tsx
@@ -100,12 +100,13 @@ export const ArtistListRow: React.FC<ArtistListRowProps> = ({
           "transition-colors hover:bg-accent/50"
         )}
       >
-        <button
+        <Button
           type="button"
+          variant="ghost"
           onClick={() => onSelect(artist)}
           className={cn(
             "flex min-h-[52px] min-w-0 flex-1 items-center gap-2 px-3 text-left sm:gap-3",
-            "bg-transparent",
+            "h-auto rounded-none bg-transparent hover:bg-transparent",
             "focus:outline-none focus-visible:z-[1] focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-inset"
           )}
           aria-label={`Select ${artist.name}`}
@@ -134,7 +135,7 @@ export const ArtistListRow: React.FC<ArtistListRowProps> = ({
           <div className="flex min-w-0 flex-shrink-0 items-center">
             {renderStatusBadge()}
           </div>
-        </button>
+        </Button>
         <div className="flex flex-shrink-0 items-center pr-1">
           <Button
             variant="ghost"

--- a/src/renderer/features/settings/BackupControls.tsx
+++ b/src/renderer/features/settings/BackupControls.tsx
@@ -1,5 +1,6 @@
 import { useState } from "react";
 import log from "electron-log/renderer";
+import { Button } from "../../components/ui/button";
 
 export function BackupControls() {
   const [isLoading, setIsLoading] = useState(false);
@@ -61,31 +62,33 @@ export function BackupControls() {
         📦 Database Management
       </h3>
       <div className="flex gap-4">
-        <button
+        <Button
+          type="button"
           onClick={handleBackup}
           disabled={isLoading}
           aria-label="Create a full backup of the database"
-          className={`px-4 py-2 rounded text-sm font-medium transition-colors ${
+          className={
             isLoading
-              ? "cursor-not-allowed bg-muted text-muted-foreground"
-              : "text-white bg-emerald-600 hover:bg-emerald-700"
-          }`}
+              ? "cursor-not-allowed bg-muted text-muted-foreground hover:bg-muted"
+              : "bg-emerald-600 text-white hover:bg-emerald-700"
+          }
         >
           {isLoading ? "Загрузка..." : "💾 Создать бэкап"}
-        </button>
+        </Button>
 
-        <button
+        <Button
+          type="button"
           onClick={handleRestore}
           disabled={isLoading}
           aria-label="Restore database from a backup file"
-          className={`px-4 py-2 rounded text-sm font-medium transition-colors ${
+          className={
             isLoading
-              ? "cursor-not-allowed bg-muted text-muted-foreground"
-              : "text-white bg-red-600 hover:bg-red-700"
-          }`}
+              ? "cursor-not-allowed bg-muted text-muted-foreground hover:bg-muted"
+              : "bg-red-600 text-white hover:bg-red-700"
+          }
         >
           {isLoading ? "Processing..." : "♻️ Restore from File"}{" "}
-        </button>
+        </Button>
       </div>
     </div>
   );

--- a/tests/unit/components/PostCard/viewType.test.ts
+++ b/tests/unit/components/PostCard/viewType.test.ts
@@ -1,6 +1,11 @@
 import { describe, it, expect } from 'vitest';
 
 /**
+ * LOGIC-ONLY MIRROR: does not import real component, will not catch drift.
+ * @testing-library/react is not a project dependency; adding it is out of scope for this audit.
+ * Mirrored class strings below are intentionally local copies — keep in sync manually with
+ * `src/renderer/features/artists/components/PostCard.tsx` viewType styling.
+ *
  * Tests for PostCard viewType logic
  * These tests verify the conditional styling based on viewType
  */

--- a/tests/unit/components/layout/GridContainer.test.ts
+++ b/tests/unit/components/layout/GridContainer.test.ts
@@ -1,6 +1,12 @@
 import { describe, it, expect } from 'vitest';
 
 /**
+ * LOGIC-ONLY MIRROR: does not import real component, will not catch drift.
+ * @testing-library/react is not a project dependency; adding it is out of scope for this audit.
+ * Mirrored class strings below are intentionally local copies — keep in sync manually with
+ * `src/renderer/components/gallery/virtuoso-factories.tsx` (and local factories in
+ * PlaylistsPage / ArtistGallery when those differ).
+ *
  * Tests for GridContainer layout logic
  * Verifies CSS classes based on viewType
  */


### PR DESCRIPTION
## Summary
- Deduplicate identical VirtuosoGrid List/Item factories for Browse/Favorites/Updates into `createVirtuosoGridFactories` (PlaylistsPage/ArtistGallery left local — different masonry item + padding).
- Mark GridContainer/viewType unit suites as LOGIC-ONLY MIRROR (no `@testing-library/react` in deps).
- totalCount audit across 5 galleries: no bugs; no commit for that phase.
- Replace raw `<button>` with shadcn `Button` in Updates creators row, playlist tag remove controls, ArtistListRow select, BackupControls — preserve onClick/stopPropagation/aria/disabled and explicit `type=button`.

## Test plan
- [ ] Browse / Favorites / Updates: grid ↔ masonry toggle + infinite scroll after factory extract
- [ ] ArtistGallery / PlaylistsPage: unchanged factories; no layout regression
- [ ] With filters active: no empty holes (totalCount matches itemContent array)
- [ ] Playlist smart-tag Badge X still removes without toggling include/exclude
- [ ] Artist list row select + delete still keyboard/ARIA OK
- [ ] Settings backup/restore buttons still work
- [ ] `npm run typecheck` + `npm test -- tests/unit/components/layout/GridContainer.test.ts tests/unit/components/PostCard/viewType.test.ts`

Merge: squash.