### PR TITLE
fix: Gelbooru HTTP 429 writes shared throttle gate

### DIFF
--- a/docs/api-guide.md
+++ b/docs/api-guide.md
@@ -1944,6 +1944,7 @@ All IPC methods can throw errors. Always wrap calls in try-catch blocks or let R
 | Layer | Responsibility |
 |-------|----------------|
 | `Rule34Provider.fetchPosts` | Throws `ProviderSearchError` with `kind` (`auth`, `rate_limit`, `network`, `parse`); XML fallback only on `parse`, never on auth/429 |
+| `GelbooruProvider.fetchPosts` | On HTTP 429 throws `ProviderSearchError("rate_limit")` after `notifyRateLimited(retryAfterMs)` (shared host gate); other failures still log + return `[]`. Non-JSON content-type on 200 remains `[]` with a warn (unchanged) |
 | `throwProviderSearchIpcError` (main) | Serializes to IPC-safe `Error` + enumerable payload fields |
 | `parseProviderSearchErrorPayload` (shared) | Normalizes Electron invoke wrapper → typed payload for UI |
 | `BrowseErrorState` (renderer) | User-facing centered error state (not a destructive banner) |

--- a/src/main/providers/gelbooru-provider.ts
+++ b/src/main/providers/gelbooru-provider.ts
@@ -31,6 +31,44 @@ function isGelbooruTagItem(item: unknown): item is GelbooruTagItem {
   return typeof v === "string" && typeof l === "string";
 }
 
+/** Same contract as parseRule34RetryAfterMs: seconds → ms; invalid/negative → undefined. */
+function parseGelbooruRetryAfterMs(
+  headers: Record<string, string | string[] | undefined>
+): number | undefined {
+  const retryAfterHeader = headers["retry-after"];
+  const retryAfterRaw = Array.isArray(retryAfterHeader)
+    ? retryAfterHeader[0]
+    : retryAfterHeader;
+  if (typeof retryAfterRaw !== "string") {
+    return undefined;
+  }
+  const retryAfterSeconds = parseInt(retryAfterRaw, 10);
+  if (!Number.isFinite(retryAfterSeconds) || retryAfterSeconds < 0) {
+    return undefined;
+  }
+  return retryAfterSeconds * 1000;
+}
+
+function axiosHeadersToRetryAfterRecord(
+  headers: unknown
+): Record<string, string | string[] | undefined> {
+  if (typeof headers !== "object" || headers === null) {
+    return {};
+  }
+  const normalized: Record<string, string | string[] | undefined> = {};
+  for (const [key, value] of Object.entries(headers)) {
+    if (value === null || value === undefined) {
+      continue;
+    }
+    if (typeof value === "string" || Array.isArray(value)) {
+      normalized[key] = value;
+      continue;
+    }
+    normalized[key] = String(value);
+  }
+  return normalized;
+}
+
 export class GelbooruProvider implements IBooruProvider {
   readonly id = "gelbooru";
   readonly name = "Gelbooru";
@@ -180,9 +218,19 @@ export class GelbooruProvider implements IBooruProvider {
       const response = await axios.get(`${this.baseUrl}?${params}`, {
         timeout: REQUEST_TIMEOUT,
         headers: { "User-Agent": this.sessionUA },
-        validateStatus: (status) => status === 200,
+        validateStatus: (status) => status < 500,
         httpsAgent: getProxyAgent(),
       });
+
+      if (response.status === 429) {
+        throw new ProviderSearchError(
+          "rate_limit",
+          undefined,
+          parseGelbooruRetryAfterMs(
+            axiosHeadersToRetryAfterRecord(response.headers)
+          )
+        );
+      }
 
       // Gelbooru sometimes returns XML instead of JSON when API fails
       const rawContentType = response.headers["content-type"];
@@ -254,6 +302,13 @@ export class GelbooruProvider implements IBooruProvider {
       
       return posts;
     } catch (error) {
+      if (
+        error instanceof ProviderSearchError &&
+        error.kind === "rate_limit"
+      ) {
+        this.throttle.notifyRateLimited(error.retryAfterMs);
+        throw error;
+      }
       logger.error(
         `[Gelbooru] Error fetching page ${page}`,
         redactErrorForLog(error)

--- a/tests/unit/TEST_COVERAGE.md
+++ b/tests/unit/TEST_COVERAGE.md
@@ -26,6 +26,7 @@ Vitest covers unit logic, integration flows (IPC + SQLite), and property-based f
 | `store/searchStore.test.ts` | 3 | Search store |
 | `shared/provider-search-ipc-payload.test.ts` | 8 | Provider IPC error parsing |
 | `providers/rule34-provider-fetch-posts.test.ts` | 5 | fetchPosts error classification |
+| `providers/gelbooru-provider-fetch-posts.test.ts` | 5 | Gelbooru fetchPosts 429 → rate_limit gate |
 | `services/tag-resolve-coordinator.test.ts` | 3 | Tag resolve dedup / rate limit |
 | `services/secure-storage.test.ts` | 3 | `SecureStorage` encrypt/decrypt (sole crypto path) |
 | `services/video-proxy-server.test.ts` | 8 | Video proxy allowlist / cache / eviction |

--- a/tests/unit/providers/gelbooru-provider-fetch-posts.test.ts
+++ b/tests/unit/providers/gelbooru-provider-fetch-posts.test.ts
@@ -1,0 +1,136 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import axios, { AxiosError } from "axios";
+import { GelbooruProvider } from "@/main/providers/gelbooru-provider";
+
+vi.mock("electron-log", () => ({
+  default: {
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    debug: vi.fn(),
+  },
+}));
+
+vi.mock("@/main/lib/logger", () => ({
+  logger: {
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    debug: vi.fn(),
+  },
+}));
+
+vi.mock("@/main/lib/proxy", () => ({
+  getProxyAgent: vi.fn(() => undefined),
+}));
+
+const axiosGetMock = vi.spyOn(axios, "get");
+
+const SAMPLE_GELBOORU_POST = {
+  id: 42,
+  file_url: "https://img3.gelbooru.com/images/ab/cd/abcd1234.jpg",
+  sample_url: "https://img3.gelbooru.com/samples/ab/cd/sample_abcd1234.jpg",
+  preview_url: "https://img3.gelbooru.com/thumbnails/ab/cd/thumbnail_abcd1234.jpg",
+  tags: "solo 1girl",
+  rating: "q",
+  score: 10,
+  width: 800,
+  height: 600,
+  created_at: "Mon Jan 01 12:00:00 +0000 2024",
+};
+
+describe("GelbooruProvider.fetchPosts rate-limit classification", () => {
+  const provider = new GelbooruProvider();
+  const settings = { userId: "1", apiKey: "test-key" };
+
+  beforeEach(() => {
+    axiosGetMock.mockReset();
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("returns mapped posts for HTTP 200 with valid JSON", async () => {
+    axiosGetMock.mockResolvedValueOnce({
+      status: 200,
+      headers: { "content-type": "application/json" },
+      data: [SAMPLE_GELBOORU_POST],
+    });
+
+    const posts = await provider.fetchPosts("solo", 1, settings, false, 50);
+
+    expect(posts).toHaveLength(1);
+    expect(posts[0]?.id).toBe(42);
+    expect(posts[0]?.fileUrl).toBe(SAMPLE_GELBOORU_POST.file_url);
+    expect(axiosGetMock).toHaveBeenCalledTimes(1);
+    expect(axiosGetMock.mock.calls[0]?.[1]).toMatchObject({
+      validateStatus: expect.any(Function),
+    });
+    const validateStatus = axiosGetMock.mock.calls[0]?.[1]?.validateStatus;
+    expect(typeof validateStatus).toBe("function");
+    if (typeof validateStatus === "function") {
+      expect(validateStatus(200)).toBe(true);
+      expect(validateStatus(429)).toBe(true);
+      expect(validateStatus(500)).toBe(false);
+    }
+  });
+
+  it("throws rate_limit error on HTTP 429 and does not return []", async () => {
+    axiosGetMock.mockResolvedValueOnce({
+      status: 429,
+      headers: { "retry-after": "12", "content-type": "text/plain" },
+      data: "",
+    });
+
+    await expect(
+      provider.fetchPosts("solo", 1, settings, false, 50)
+    ).rejects.toMatchObject({
+      kind: "rate_limit",
+      retryAfterMs: 12_000,
+    });
+
+    expect(axiosGetMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("treats invalid Retry-After as undefined retryAfterMs on 429", async () => {
+    axiosGetMock.mockResolvedValueOnce({
+      status: 429,
+      headers: { "retry-after": "not-a-number" },
+      data: "",
+    });
+
+    await expect(
+      provider.fetchPosts("solo", 1, settings, false, 50)
+    ).rejects.toMatchObject({
+      kind: "rate_limit",
+      retryAfterMs: undefined,
+    });
+  });
+
+  it("returns [] for non-JSON content-type on HTTP 200 (XML fallback path)", async () => {
+    axiosGetMock.mockResolvedValueOnce({
+      status: 200,
+      headers: { "content-type": "text/xml; charset=utf-8" },
+      data: "<posts></posts>",
+    });
+
+    await expect(
+      provider.fetchPosts("solo", 1, settings, false, 50)
+    ).resolves.toEqual([]);
+
+    expect(axiosGetMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("returns [] on transport failure (unchanged non-429 catch path)", async () => {
+    const timeoutError = new AxiosError("timeout of 15000ms exceeded");
+    timeoutError.code = "ECONNABORTED";
+    axiosGetMock.mockRejectedValueOnce(timeoutError);
+
+    await expect(
+      provider.fetchPosts("solo", 1, settings, false, 50)
+    ).resolves.toEqual([]);
+
+    expect(axiosGetMock).toHaveBeenCalledTimes(1);
+  });
+});


### PR DESCRIPTION
## Summary
- Gelbooru `fetchPosts` no longer swallows HTTP 429 as empty `[]`: `validateStatus < 500`, explicit 429 → `ProviderSearchError(rate_limit)` with Retry-After (ms), then `notifyRateLimited` + rethrow.
- Mirrors Rule34 post-response pattern; existing gate wait on entry and non-JSON content-type path unchanged.
- Unit coverage for success, 429, invalid Retry-After, XML content-type, and transport failure.

## Follow-up (not in this PR)
- Add `vi.spyOn(ProviderThrottle.prototype, notifyRateLimited)` assertions in both `rule34-provider-fetch-posts.test.ts` and `gelbooru-provider-fetch-posts.test.ts` (shared coverage gap).

## Test plan
- [x] `npx vitest run tests/unit/providers/gelbooru-provider-fetch-posts.test.ts`
- [x] `npm run typecheck`
- [ ] Spot-check: Gelbooru Browse still loads posts on 200
- [ ] Spot-check: forced 429 surfaces rate_limit (not empty gallery)
