### PR TITLE
docs: correct Favorites as local-only in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,7 +108,7 @@ The application is organized into the following main sections accessible via the
 
 - **Updates (Subscriptions)** - View new posts from tracked artists and tag subscriptions
 - **Browse (All posts)** - Search the live booru API with chip-based tags, infinite scroll, and advanced filters; Favorites/Subscriptions modes search the local cache
-- **Favorites (Account favorites)** - Access your account favorites synced from the booru
+- **Favorites** - Local favorites only (`isFavorited` in SQLite). There is no booru account-favorites sync path
 - **Playlists (Collections)** - Create and manage curated collections of posts
 - **Statistics** - Extended local metrics and distribution charts via `getExtendedStats` (counts, pie charts, top artists/tags, provider artist split, DB size)
 - **Tracked (Artists/Tags management)** - Manage tracked artists, tags, and subscriptions
@@ -314,7 +314,7 @@ The application is stable and production-ready (see **`package.json`** → `vers
    - Confirm legal age / ToS in the mandatory Age Gate
    - Option A: enter User ID + API Key and click "Save and Login"
    - Option B: click "Skip for now" to continue in Browse-only mode
-   - Add API key later in `Settings -> Account` to unlock Updates, Favorites, Playlists, and Artists
+   - Add API key later in `Settings -> Account` to unlock Updates and Artists (Favorites and Playlists work locally without credentials)
 
 3. **Add Artists:**
 


### PR DESCRIPTION
## Summary
- README no longer claims account favorites are synced from the booru.
- Clarifies Favorites are local `isFavorited` only (no account-favorites sync path).
- Softens onboarding copy: API key unlocks Updates/Artists; Favorites and Playlists work locally.

## Test plan
- [ ] README Product Structure + Onboarding lines match local-only Favorites behavior
- [ ] No code changes
