### PR TITLE
docs: track booru-favorites warmed-db audit outcome

### DIFF
--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -167,6 +167,7 @@ Both P0 rows (#1–#2) are closed — the full v17 audit pack landed (after one 
 |--------|--------|-------|
 | `fix/ipc-handlers-compliance` | ✅ merged | [#124](https://github.com/KazeKaze93/RuleDesk/pull/124) — Legacy `ipcMain.handle` → BaseController; silent catch removed. (Branch renamed: remote `audit` ref blocks `audit/*`) |
 | `fix-frontend-virtuoso-gallery-audit` | ✅ merged | [#125](https://github.com/KazeKaze93/RuleDesk/pull/125) — decorative tests; VirtuosoGrid factory dedupe; totalCount audit (clean); raw HTML→shadcn |
+| `audit-booru-favorites-warmed-db` | issued | UA/Cloudflare fingerprint hypothesis for empty `sync:booru-favorites` **refuted** (no favorites sync path; providers already send browser-style UA). README account-favorites claim corrected in [#128](https://github.com/KazeKaze93/RuleDesk/pull/128). (Remote hyphen name: flat `audit` ref blocks `audit/*`) |
 
 ### Baseline DX (earlier)
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -167,7 +167,7 @@ Both P0 rows (#1–#2) are closed — the full v17 audit pack landed (after one 
 |--------|--------|-------|
 | `fix/ipc-handlers-compliance` | ✅ merged | [#124](https://github.com/KazeKaze93/RuleDesk/pull/124) — Legacy `ipcMain.handle` → BaseController; silent catch removed. (Branch renamed: remote `audit` ref blocks `audit/*`) |
 | `fix-frontend-virtuoso-gallery-audit` | ✅ merged | [#125](https://github.com/KazeKaze93/RuleDesk/pull/125) — decorative tests; VirtuosoGrid factory dedupe; totalCount audit (clean); raw HTML→shadcn |
-| `audit-booru-favorites-warmed-db` | issued | UA/Cloudflare fingerprint hypothesis for empty `sync:booru-favorites` **refuted** (no favorites sync path; providers already send browser-style UA). README account-favorites claim corrected in [#128](https://github.com/KazeKaze93/RuleDesk/pull/128). (Remote hyphen name: flat `audit` ref blocks `audit/*`) |
+| `audit-booru-favorites-warmed-db` | ✅ merged | [#129](https://github.com/KazeKaze93/RuleDesk/pull/129) — UA/Cloudflare fingerprint hypothesis for empty `sync:booru-favorites` **refuted** (no favorites sync path; providers already send browser-style UA). README account-favorites claim corrected in [#128](https://github.com/KazeKaze93/RuleDesk/pull/128). (Remote hyphen name: flat `audit` ref blocks `audit/*`) |
 
 ### Baseline DX (earlier)
 


### PR DESCRIPTION
## Summary
- Records the `audit-booru-favorites-warmed-db` investigation in the post-v17 follow-ups table.
- Outcome: UA/Cloudflare fingerprint hypothesis for empty `sync:booru-favorites` refuted (no favorites sync path; browser-style UA already in use); README account-favorites claim already corrected in #128.

## Test plan
- [x] Diff is docs-only (`docs/roadmap.md` +1 line)
- [x] Tracking row matches existing `Audit follow-ups (post-v17)` format
