### PR TITLE
fix: correct backup size-cap retention and auto prune resilience

### DIFF
--- a/README.md
+++ b/README.md
@@ -214,7 +214,7 @@ Settings are organized into tabs for faster scanning and lower cognitive load:
 - **Integrity check** - Run `PRAGMA integrity_check`
 - **Auto-backup schedule** - `Never` / `Daily` / `Weekly` (evaluated on app startup)
 - **Automatic backup rotation** - Keep the last `N` backups (`backupRetention`, configurable in UI, range `1..20`)
-- **Optional storage cap (env)** - `BACKUP_RETENTION_MAX_TOTAL_MB` can enforce a total size ceiling for backup files in addition to `keep last N`
+- **Optional storage cap (env)** - `BACKUP_RETENTION_MAX_TOTAL_MB` can enforce a total size ceiling for backup files in addition to `keep last N` (newest is always kept even if a single file exceeds the cap)
 - **Database maintenance (VACUUM)** - Last run timestamp/status/error, manual run button, and schedule (`manual` / `weekly` / `monthly`)
 
 ### Account

--- a/docs/database.md
+++ b/docs/database.md
@@ -927,7 +927,7 @@ The application provides built-in backup functionality:
    - Auto-backup pattern: `data.backup.YYYY-MM-DD.bin`
 3. **Backup Format:** Full SQLite database copy (via `VACUUM INTO`)
 4. **Rotation:** After a successful backup, older files matching the backup name prefix are deleted so only the most recent `backupRetention` copies remain. `backupRetention` is stored in `settings` and clamped to `1..20` by Main Process validation.
-5. **Optional total-size cap (env):** If `BACKUP_RETENTION_MAX_TOTAL_MB` is set to a positive number, backup cleanup additionally prunes oldest files until total backup size is under the configured threshold.
+5. **Optional total-size cap (env):** If `BACKUP_RETENTION_MAX_TOTAL_MB` is set to a positive number, backup cleanup additionally prunes oldest files until total backup size is under the configured threshold. `runningTotal` only counts retained files. If the newest backup alone exceeds the cap, it is still kept so at least one backup always survives.
 
 **Example:**
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -218,7 +218,7 @@ Items explicitly scheduled for product/engineering (beyond small bugs).
 | **Filters** | Keep filter scope lean (`AI`, `Media`, `Source`) and avoid reintroducing removed panel controls without product decision (**scope is already implemented; this is a guardrail**). |
 | **Search** | Continue polish/regression coverage for chip-based syntax (`-tag`, OR groups, wildcard/fuzzy). |
 | **Navigation & layout** | **Optional** polish: tooltips, item order tuning, and small-window density improvements (see [Navigation, layout, shell](#d-navigation-layout-shell)). |
-| **Backups** | `keep last N` is implemented; optional **total-size cap** is also supported via `BACKUP_RETENTION_MAX_TOTAL_MB` env for deployments that need hard storage ceilings. UI exposure for this cap remains optional future UX work. |
+| **Backups** | `keep last N` is implemented; optional **total-size cap** is also supported via `BACKUP_RETENTION_MAX_TOTAL_MB` env for deployments that need hard storage ceilings (retained-only size accounting; newest backup always kept even if alone over cap). UI exposure for this cap remains optional future UX work. |
 | **Engineering** | Ongoing tooling hygiene; remaining shared validation consolidation as needed. |
 | **Testing** | Assert host-gate feedback: `vi.spyOn(ProviderThrottle.prototype, "notifyRateLimited")` in both `rule34-provider-fetch-posts.test.ts` and `gelbooru-provider-fetch-posts.test.ts` on HTTP 429 (coverage gap noted after [#126](https://github.com/KazeKaze93/RuleDesk/pull/126); reject `kind` alone is insufficient). |
 | **Media filters (P3)** | Browse worker video regex (`mp4\|webm\|mov` in `data-processor.worker.ts`) is narrower than canonical `VIDEO_EXTENSIONS` in `src/shared/utils/media.ts` — align when touching the worker. |

--- a/src/main/ipc/controllers/MaintenanceController.ts
+++ b/src/main/ipc/controllers/MaintenanceController.ts
@@ -28,6 +28,7 @@ import {
   restoreBackupSidecar,
   writeBackupSidecar,
 } from "../../lib/backup-sidecar";
+import { markBackupsExceedingSizeCap } from "../../lib/backup-retention-size-cap";
 import { IdSchema } from "../../../shared/schemas/ipc";
 import {
   SetVacuumScheduleArgsSchema,
@@ -387,16 +388,11 @@ export class MaintenanceController extends BaseController {
         const newestFirst = [...existingFiles].sort((a, b) =>
           b.name.localeCompare(a.name)
         );
-        let runningTotal = 0;
-        for (const file of newestFirst) {
-          if (toDelete.has(file.fullPath)) {
-            continue;
-          }
-          runningTotal += file.size;
-          if (runningTotal > MAX_TOTAL_BACKUP_BYTES) {
-            toDelete.add(file.fullPath);
-          }
-        }
+        markBackupsExceedingSizeCap(
+          newestFirst,
+          MAX_TOTAL_BACKUP_BYTES,
+          toDelete
+        );
       }
 
       for (const file of backupFiles) {

--- a/src/main/lib/backup-retention-size-cap.ts
+++ b/src/main/lib/backup-retention-size-cap.ts
@@ -1,0 +1,48 @@
+export type BackupFileWithSize = {
+  fullPath: string;
+  name: string;
+  size: number;
+};
+
+/**
+ * Marks additional backup paths for deletion so retained files stay within
+ * `maxTotalBytes`. Prefer newest files. `runningTotal` only accumulates sizes of
+ * files that remain retained (not marked for deletion).
+ *
+ * The newest eligible file (not already in `toDelete`) is always kept — even when
+ * it alone exceeds the cap — so size-cap never prefers older smaller backups over
+ * the newest, and never wipes the last backup.
+ *
+ * Mutates `toDelete` in place (includes prior count-based marks).
+ */
+export function markBackupsExceedingSizeCap(
+  filesNewestFirst: readonly BackupFileWithSize[],
+  maxTotalBytes: number,
+  toDelete: Set<string>
+): void {
+  if (maxTotalBytes <= 0 || filesNewestFirst.length === 0) {
+    return;
+  }
+
+  let runningTotal = 0;
+  let retainedNewestEligible = false;
+
+  for (const file of filesNewestFirst) {
+    if (toDelete.has(file.fullPath)) {
+      continue;
+    }
+
+    // Always keep the newest eligible backup, even when it alone exceeds the cap.
+    if (!retainedNewestEligible) {
+      runningTotal += file.size;
+      retainedNewestEligible = true;
+      continue;
+    }
+
+    if (runningTotal + file.size > maxTotalBytes) {
+      toDelete.add(file.fullPath);
+    } else {
+      runningTotal += file.size;
+    }
+  }
+}

--- a/src/main/services/backup-service.ts
+++ b/src/main/services/backup-service.ts
@@ -163,8 +163,16 @@ export class BackupService {
       const filesToDelete = autoBackups.slice(0, autoBackups.length - retention);
       for (const filename of filesToDelete) {
         const fullPath = path.join(backupDirectory, filename);
-        fs.rmSync(fullPath, { force: true });
-        log.info(`[BackupService] Deleted old auto-backup: ${filename}`);
+        try {
+          fs.rmSync(fullPath, { force: true });
+          log.info(`[BackupService] Deleted old auto-backup: ${filename}`);
+        } catch (deleteError) {
+          // Non-fatal: continue pruning remaining files (mirrors manual backup path)
+          log.warn(
+            `[BackupService] Failed to delete old auto-backup ${filename}:`,
+            deleteError
+          );
+        }
       }
     } catch (error) {
       log.warn("[BackupService] Auto-backup retention cleanup failed:", error);

--- a/tests/unit/TEST_COVERAGE.md
+++ b/tests/unit/TEST_COVERAGE.md
@@ -2,7 +2,7 @@
 
 ## Overview
 
-Vitest covers unit logic, integration flows (IPC + SQLite), and property-based fuzzing. The default `npm test` run executes **203 tests** across **29 files** (unit + integration + property). Helper suites under `tests/helpers/` and `tests/utils/` are separate and not counted in that total.
+Vitest covers unit logic, integration flows (IPC + SQLite), and property-based fuzzing. The default `npm test` run executes **209 tests** across **30 files** (unit + integration + property). Helper suites under `tests/helpers/` and `tests/utils/` are separate and not counted in that total.
 
 ## Test files (unit)
 
@@ -11,6 +11,7 @@ Vitest covers unit logic, integration flows (IPC + SQLite), and property-based f
 | `hooks/useGalleryInfiniteScroll.test.ts` | 7 | Infinite scroll pagination |
 | `hooks/useWorkerFilteredPosts.test.ts` | 7 | Worker post → Post field mapping |
 | `lib/filter-utils.test.ts` | 29 | AI tags, video detection |
+| `lib/backup-retention-size-cap.test.ts` | 6 | Backup size-cap prune (no over-delete / keep newest over cap) |
 | `utils/decrypted-credentials.test.ts` | 10 | API key decrypt fail-safe |
 | `utils/parse-credentials.test.ts` | 6 | Credential paste parsing |
 | `utils/react-query-cache.test.ts` | 8 | Browse pagination / cursor helpers |

--- a/tests/unit/lib/backup-retention-size-cap.test.ts
+++ b/tests/unit/lib/backup-retention-size-cap.test.ts
@@ -1,0 +1,94 @@
+import { describe, expect, it } from "vitest";
+import { markBackupsExceedingSizeCap } from "@/main/lib/backup-retention-size-cap";
+
+const MB = 1024 * 1024;
+
+function file(name: string, sizeMb: number) {
+  return {
+    name,
+    fullPath: `/backups/${name}`,
+    size: sizeMb * MB,
+  };
+}
+
+describe("markBackupsExceedingSizeCap", () => {
+  it("keeps newest+oldest when middle overflows but A+C fit under cap (audit counter-example)", () => {
+    // Newest-first: A=90, B=50, C=1; cap=100. Buggy runningTotal deleted C too.
+    const files = [
+      file("A-newest.db", 90),
+      file("B-middle.db", 50),
+      file("C-oldest.db", 1),
+    ];
+    const toDelete = new Set<string>();
+
+    markBackupsExceedingSizeCap(files, 100 * MB, toDelete);
+
+    expect(toDelete.has(files[0].fullPath)).toBe(false);
+    expect(toDelete.has(files[1].fullPath)).toBe(true);
+    expect(toDelete.has(files[2].fullPath)).toBe(false);
+  });
+
+  it("does not delete the only newest file when it alone exceeds the cap", () => {
+    const files = [file("only.db", 150)];
+    const toDelete = new Set<string>();
+
+    markBackupsExceedingSizeCap(files, 100 * MB, toDelete);
+
+    expect(toDelete.size).toBe(0);
+  });
+
+  it("keeps oversized newest and still prunes older files", () => {
+    const files = [
+      file("A-newest.db", 150),
+      file("B-older.db", 40),
+      file("C-oldest.db", 10),
+    ];
+    const toDelete = new Set<string>();
+
+    markBackupsExceedingSizeCap(files, 100 * MB, toDelete);
+
+    expect(toDelete.has(files[0].fullPath)).toBe(false);
+    expect(toDelete.has(files[1].fullPath)).toBe(true);
+    expect(toDelete.has(files[2].fullPath)).toBe(true);
+  });
+
+  it("respects prior count-based toDelete marks and only sizes retained candidates", () => {
+    const files = [
+      file("A-newest.db", 40),
+      file("B-middle.db", 40),
+      file("C-oldest.db", 40),
+    ];
+    const toDelete = new Set<string>([files[2].fullPath]);
+
+    markBackupsExceedingSizeCap(files, 100 * MB, toDelete);
+
+    expect(toDelete.has(files[0].fullPath)).toBe(false);
+    expect(toDelete.has(files[1].fullPath)).toBe(false);
+    expect(toDelete.has(files[2].fullPath)).toBe(true);
+  });
+
+  it("is a no-op when maxTotalBytes is zero or negative", () => {
+    const files = [file("A.db", 90), file("B.db", 90)];
+    const toDelete = new Set<string>();
+
+    markBackupsExceedingSizeCap(files, 0, toDelete);
+    markBackupsExceedingSizeCap(files, -1, toDelete);
+
+    expect(toDelete.size).toBe(0);
+  });
+
+  it("prunes oldest when cumulative retained size would exceed the cap", () => {
+    const files = [
+      file("A-newest.db", 40),
+      file("B-middle.db", 40),
+      file("C-oldest.db", 40),
+    ];
+    const toDelete = new Set<string>();
+
+    markBackupsExceedingSizeCap(files, 100 * MB, toDelete);
+
+    expect(toDelete.has(files[0].fullPath)).toBe(false);
+    expect(toDelete.has(files[1].fullPath)).toBe(false);
+    expect(toDelete.has(files[2].fullPath)).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary
- Fix `BACKUP_RETENTION_MAX_TOTAL_MB` over-delete: `runningTotal` only counts retained files; newest eligible backup is always kept even when alone over the cap.
- Mirror manual-path per-file delete error handling on auto-backup prune (`cleanupOldAutoBackups`) so one failed `rmSync` does not abort the rest.
- Extract pure helper + unit tests (including the A=90/B=50/C=1 counter-example); sync docs.

## Test plan
- [x] `npx vitest run tests/unit/lib/backup-retention-size-cap.test.ts` (6/6)
- [x] `npm run validate` (typecheck/lint)
- [x] Manual counter-example walkthrough: A+C retained under 100MB cap, B deleted; single oversized newest kept