### PR TITLE
docs: annotate raw-SQL timestamp units and fix database.md drift

### DIFF
--- a/docs/database.md
+++ b/docs/database.md
@@ -21,6 +21,8 @@
 
 This document is a maintainer-focused database reference. RuleDesk uses **SQLite** as the local database for storing metadata, tracked artists, posts, and settings. The database is accessed directly in the **Main Process** using **Drizzle ORM** for type-safe queries. WAL (Write-Ahead Logging) mode is enabled for concurrent reads.
 
+**Timestamp units (critical for raw SQL):** Drizzle `mode: "timestamp"` stores **Unix seconds** in SQLite; `mode: "timestamp_ms"` stores **milliseconds**. IPC may expose `Date.getTime()` (ms) after serialization — that is the wire format, not the on-disk unit. Raw SQL cutoffs must match the column’s storage unit (`Date.now()` only against ms columns).
+
 **📖 Related Documentation:**
 
 - [User Guide](./user-guide.md) - End-user flows that depend on local data
@@ -62,8 +64,8 @@ Stores information about tracked artists/users.
 | `sync_status`     | TEXT (NOT NULL, DEFAULT 'idle')   | Current sync state (`idle`, `syncing`, `error`) |
 | `last_error`      | TEXT (NULL)                       | Last sync error message                     |
 | `last_sync_incomplete` | INTEGER (BOOLEAN, NOT NULL, DEFAULT 0) | 1 when pagination did not finish; cursor must not advance until cleared |
-| `last_checked`    | INTEGER (NULL)                    | Timestamp of last API poll (timestamp mode) |
-| `created_at`      | INTEGER (NOT NULL)                | Creation timestamp (timestamp mode, ms)     |
+| `last_checked`    | INTEGER (NULL)                    | Last API poll (`mode: "timestamp"` = **seconds**) |
+| `created_at`      | INTEGER (NOT NULL)                | Creation time (`mode: "timestamp"` = **seconds**) |
 
 **Schema Definition:**
 
@@ -123,10 +125,10 @@ Caches post metadata for filtering, statistics, and download management. Support
 | `rating`       | TEXT                                   | Content rating (safe, questionable, explicit) |
 | `tags`         | TEXT                                   | Space-separated tags                          |
 | `media_type`   | TEXT (NULL)                            | Media type: "image" or "video" (indexed)     |
-| `published_at` | INTEGER (NOT NULL)                     | Publication timestamp (timestamp mode, ms)    |
-| `created_at`   | INTEGER (NOT NULL)                     | When added to local database (timestamp ms)   |
+| `published_at` | INTEGER (NOT NULL)                     | Publication time (`mode: "timestamp"` = **seconds**) |
+| `created_at`   | INTEGER (NOT NULL)                     | Local insert time (`mode: "timestamp"` = **seconds**) |
 | `is_viewed`    | INTEGER (BOOLEAN, NOT NULL, DEFAULT 0) | Whether post has been viewed                  |
-| `last_viewed_at` | INTEGER (NULL)                       | Last time post was viewed (timestamp mode, ms) |
+| `last_viewed_at` | INTEGER (NULL)                       | Last view (`mode: "timestamp"` = **seconds**) |
 | `view_count`   | INTEGER (NOT NULL, DEFAULT 0)          | Number of times post was viewed               |
 | `is_favorited` | INTEGER (BOOLEAN, NOT NULL, DEFAULT 0) | Whether post has been favorited               |
 
@@ -219,7 +221,7 @@ Stores application settings including API credentials and user preferences.
 | `is_safe_mode`       | INTEGER (BOOLEAN, DEFAULT 1)           | Safe mode flag (blur NSFW content)           |
 | `is_adult_confirmed` | INTEGER (BOOLEAN, DEFAULT 0)           | Adult confirmation flag (18+ confirmation)   |
 | `is_adult_verified`  | INTEGER (BOOLEAN, DEFAULT 0, NOT NULL) | Adult verification flag (legal confirmation) |
-| `tos_accepted_at`    | INTEGER (TIMESTAMP, NULL)              | Terms of Service acceptance timestamp        |
+| `tos_accepted_at`    | INTEGER (TIMESTAMP, NULL)              | ToS acceptance (`mode: "timestamp"` = **seconds**; IPC exposes ms) |
 | `download_folder`    | TEXT (NULL)                            | Default download folder                       |
 | `duplicate_file_behavior` | TEXT (DEFAULT 'skip')            | Duplicate file behavior                       |
 | `download_folder_structure` | TEXT (DEFAULT 'flat')          | Download folder structure                     |
@@ -228,7 +230,7 @@ Stores application settings including API credentials and user preferences.
 | `sync_interval_minutes` | INTEGER (NOT NULL, DEFAULT 0)       | Periodic sync interval in minutes             |
 | `backup_retention`   | INTEGER (NOT NULL, DEFAULT 5)          | Number of backups to keep                     |
 | `vacuum_schedule`    | TEXT (DEFAULT 'manual')                | User-visible VACUUM policy (`manual`, `weekly`, `monthly`) |
-| `last_vacuum_at`     | INTEGER (NULL)                         | Timestamp of last VACUUM run (ms)            |
+| `last_vacuum_at`     | INTEGER (NULL)                         | Last VACUUM run (**milliseconds** via `Date.now()`; bare int, no Drizzle mode) |
 | `last_vacuum_status` | TEXT (NULL)                            | Last VACUUM result (`success`/`error`)       |
 | `last_vacuum_error`  | TEXT (NULL)                            | Last VACUUM error text (sanitized)           |
 
@@ -306,8 +308,8 @@ Stores playlist/collection information for curated post collections.
 | `query_json`  | TEXT (DEFAULT '')                 | JSON-encoded smart playlist query              |
 | `query_schema_version` | INTEGER (NOT NULL, DEFAULT 1) | Version of smart playlist query DSL for safe parsing/migrations |
 | `icon_name`   | TEXT (DEFAULT '')                 | Icon name for playlist display                 |
-| `created_at`  | INTEGER (TIMESTAMP, NOT NULL)     | Creation timestamp (timestamp mode, ms)        |
-| `updated_at`  | INTEGER (TIMESTAMP, NOT NULL)     | Update timestamp (timestamp mode, ms)          |
+| `created_at`  | INTEGER (TIMESTAMP, NOT NULL)     | Creation time (`mode: "timestamp"` = **seconds**) |
+| `updated_at`  | INTEGER (TIMESTAMP, NOT NULL)     | Update time (`mode: "timestamp"` = **seconds**)   |
 
 **Indexes:**
 
@@ -361,7 +363,7 @@ Junction table linking playlists to posts. Uses composite primary key to prevent
 | ------------- | --------------------------------- | ---------------------------------------------- |
 | `playlist_id` | INTEGER (NOT NULL, FK)            | Foreign key to `playlists.id` (CASCADE DELETE) |
 | `post_id`     | INTEGER (NOT NULL, FK)            | Foreign key to `posts.id` (CASCADE DELETE)     |
-| `added_at`    | INTEGER (TIMESTAMP, NOT NULL)     | Timestamp when post was added (timestamp mode, ms) |
+| `added_at`    | INTEGER (TIMESTAMP, NOT NULL)     | When post was added (`mode: "timestamp"` = **seconds**) |
 | `position`    | INTEGER (NOT NULL, DEFAULT 0)     | Manual ordering position                         |
 
 **Primary Key:**
@@ -425,7 +427,7 @@ Local tag blocklist (Settings → Blacklist). Not modeled in Drizzle `schema.ts`
 | ------------ | --------------------------- | ------------------------------------ |
 | `id`         | INTEGER (PK, AutoIncrement) | Primary key                          |
 | `tag`        | TEXT (NOT NULL, UNIQUE)     | Normalized tag (lowercase, trimmed)  |
-| `created_at` | INTEGER (NOT NULL)          | Insert time (`unixepoch()` default)  |
+| `created_at` | INTEGER (NOT NULL)          | Insert time (**seconds**, `unixepoch()` default) |
 
 **Limits:** Maximum **100** tags (`MAX_BLACKLIST_TAGS` in `blacklist.ts`). Soft-deleted from feeds in Main after fetch / in local queries.
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -171,6 +171,7 @@ Both P0 rows (#1–#2) are closed — the full v17 audit pack landed (after one 
 
 | Branch | Status | Notes |
 |--------|--------|-------|
+| `audit/raw-sql-timestamp-units` | 🔄 in progress | Full raw-SQL timestamp unit inventory: **no P0 mismatch**; comment-only Units annotations + `docs/database.md` seconds vs ms correction (no logic changes) |
 | `fix/ipc-handlers-compliance` | ✅ merged | [#124](https://github.com/KazeKaze93/RuleDesk/pull/124) — Legacy `ipcMain.handle` → BaseController; silent catch removed. (Branch renamed: remote `audit` ref blocks `audit/*`) |
 | `fix-frontend-virtuoso-gallery-audit` | ✅ merged | [#125](https://github.com/KazeKaze93/RuleDesk/pull/125) — decorative tests; VirtuosoGrid factory dedupe; totalCount audit (clean); raw HTML→shadcn |
 | `audit-booru-favorites-warmed-db` | ✅ merged | [#129](https://github.com/KazeKaze93/RuleDesk/pull/129) — UA/Cloudflare fingerprint hypothesis for empty `sync:booru-favorites` **refuted** (no favorites sync path; providers already send browser-style UA). README account-favorites claim corrected in [#128](https://github.com/KazeKaze93/RuleDesk/pull/128). (Remote hyphen name: flat `audit` ref blocks `audit/*`) |

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -171,7 +171,7 @@ Both P0 rows (#1–#2) are closed — the full v17 audit pack landed (after one 
 
 | Branch | Status | Notes |
 |--------|--------|-------|
-| `audit/raw-sql-timestamp-units` | 🔄 in progress | Full raw-SQL timestamp unit inventory: **no P0 mismatch**; comment-only Units annotations + `docs/database.md` seconds vs ms correction (no logic changes) |
+| `audit/raw-sql-timestamp-units` | ✅ merged | [#132](https://github.com/KazeKaze93/RuleDesk/pull/132) — Full raw-SQL timestamp unit inventory: **no P0 mismatch**; comment-only Units annotations + `docs/database.md` seconds vs ms correction. (Remote hyphen: `audit-raw-sql-timestamp-units`) |
 | `fix/ipc-handlers-compliance` | ✅ merged | [#124](https://github.com/KazeKaze93/RuleDesk/pull/124) — Legacy `ipcMain.handle` → BaseController; silent catch removed. (Branch renamed: remote `audit` ref blocks `audit/*`) |
 | `fix-frontend-virtuoso-gallery-audit` | ✅ merged | [#125](https://github.com/KazeKaze93/RuleDesk/pull/125) — decorative tests; VirtuosoGrid factory dedupe; totalCount audit (clean); raw HTML→shadcn |
 | `audit-booru-favorites-warmed-db` | ✅ merged | [#129](https://github.com/KazeKaze93/RuleDesk/pull/129) — UA/Cloudflare fingerprint hypothesis for empty `sync:booru-favorites` **refuted** (no favorites sync path; providers already send browser-style UA). README account-favorites claim corrected in [#128](https://github.com/KazeKaze93/RuleDesk/pull/128). (Remote hyphen name: flat `audit` ref blocks `audit/*`) |

--- a/drizzle/0010_add_fts5_cache_invalidation.sql
+++ b/drizzle/0010_add_fts5_cache_invalidation.sql
@@ -12,11 +12,13 @@ CREATE TABLE IF NOT EXISTS fts5_cache_invalidation (
 );
 
 -- Initialize the single row if it doesn't exist
+-- Units: milliseconds (julianday → epoch ms); must match Date.now() cache stamps in PlaylistController.
 INSERT OR IGNORE INTO fts5_cache_invalidation (id, invalidated_at) 
 VALUES (1, CAST((julianday('now') - 2440587.5) * 86400000 AS INTEGER));
 
 -- Trigger: INSERT - Invalidate cache when new post is inserted into posts_fts
 -- This trigger fires AFTER posts_fts_insert, ensuring FTS5 index is updated first
+-- Units: milliseconds (same julianday formula as column DEFAULT).
 CREATE TRIGGER IF NOT EXISTS fts5_cache_invalidate_insert 
 AFTER INSERT ON posts_fts BEGIN
   UPDATE fts5_cache_invalidation 
@@ -26,6 +28,7 @@ END;
 
 -- Trigger: UPDATE - Invalidate cache when post is updated in posts_fts
 -- This trigger fires AFTER posts_fts_update, ensuring FTS5 index is updated first
+-- Units: milliseconds (same julianday formula as column DEFAULT).
 CREATE TRIGGER IF NOT EXISTS fts5_cache_invalidate_update 
 AFTER UPDATE ON posts_fts BEGIN
   UPDATE fts5_cache_invalidation 
@@ -35,6 +38,7 @@ END;
 
 -- Trigger: DELETE - Invalidate cache when post is deleted from posts_fts
 -- This trigger fires AFTER posts_fts_delete, ensuring FTS5 index is updated first
+-- Units: milliseconds (same julianday formula as column DEFAULT).
 CREATE TRIGGER IF NOT EXISTS fts5_cache_invalidate_delete 
 AFTER DELETE ON posts_fts BEGIN
   UPDATE fts5_cache_invalidation 

--- a/drizzle/0020_add_playlist_entry_position.sql
+++ b/drizzle/0020_add_playlist_entry_position.sql
@@ -1,6 +1,7 @@
 ALTER TABLE playlist_entries ADD COLUMN position INTEGER NOT NULL DEFAULT 0;
 
--- Initialize positions based on current addedAt order
+-- Initialize positions based on current addedAt order.
+-- Units: same-column compare on added_at (Drizzle mode "timestamp" = Unix seconds); no cutoff math.
 UPDATE playlist_entries
 SET position = (
   SELECT COUNT(*)

--- a/drizzle/0023_add_playlists_updated_at.sql
+++ b/drizzle/0023_add_playlists_updated_at.sql
@@ -1,5 +1,6 @@
 ALTER TABLE playlists ADD COLUMN updated_at integer NOT NULL DEFAULT 0;
 CREATE INDEX IF NOT EXISTS playlists_updatedAt_idx ON playlists(updated_at);
+-- Units: copy seconds→seconds (both columns are Drizzle mode "timestamp").
 UPDATE playlists
 SET updated_at = created_at
 WHERE updated_at = 0;

--- a/drizzle/0025_add_tag_blacklist.sql
+++ b/drizzle/0025_add_tag_blacklist.sql
@@ -1,6 +1,7 @@
 CREATE TABLE IF NOT EXISTS tag_blacklist (
   id INTEGER PRIMARY KEY AUTOINCREMENT,
   tag TEXT NOT NULL UNIQUE,
+  -- Units: Unix seconds (SQLite unixepoch()). Not in Drizzle schema — keep raw SQL in seconds.
   created_at INTEGER NOT NULL DEFAULT (unixepoch())
 );
 

--- a/drizzle/0031_tag_metadata_status.sql
+++ b/drizzle/0031_tag_metadata_status.sql
@@ -1,3 +1,4 @@
 ALTER TABLE `tag_metadata` ADD `status` text DEFAULT 'found' NOT NULL;--> statement-breakpoint
 ALTER TABLE `tag_metadata` ADD `resolved_at` integer DEFAULT 0 NOT NULL;--> statement-breakpoint
+-- Units: milliseconds (strftime seconds * 1000). Matches schema mode timestamp_ms / Date.now() cutoffs.
 UPDATE `tag_metadata` SET `resolved_at` = CAST((strftime('%s', 'now') * 1000) AS INTEGER) WHERE `resolved_at` = 0;

--- a/src/main/db/client.ts
+++ b/src/main/db/client.ts
@@ -263,6 +263,7 @@ export async function initializeDatabase(): Promise<AppDatabase> {
           }
           
           // Create __drizzle_migrations table if it doesn't exist
+          // Units: __drizzle_migrations.created_at is written with Date.now() = milliseconds (journal only).
           sqliteInstance.exec(`
             CREATE TABLE IF NOT EXISTS __drizzle_migrations (
               id INTEGER PRIMARY KEY AUTOINCREMENT,
@@ -316,6 +317,7 @@ export async function initializeDatabase(): Promise<AppDatabase> {
                 // Create the cache invalidation table but skip triggers if they fail
                 try {
                   // Create the cache invalidation table (this part works)
+                  // Units: invalidated_at = milliseconds via julianday epoch-ms formula (matches migration 0010).
                   sqliteInstance.exec(`
                     CREATE TABLE IF NOT EXISTS fts5_cache_invalidation (
                       id INTEGER PRIMARY KEY CHECK (id = 1),

--- a/src/main/db/queries/artists.ts
+++ b/src/main/db/queries/artists.ts
@@ -44,7 +44,7 @@ export function getTrackedArtistsWithStats(db: AppDatabase): TrackedArtistWithSt
       lastChecked: artists.lastChecked,
       createdAt: artists.createdAt,
       postsCount: sql<number>`COALESCE(COUNT(${posts.id}), 0)`.as("postsCount"),
-      lastPostAt: sql<number | null>`MAX(${posts.createdAt})`.as("lastPostAt"),
+      lastPostAt: sql<number | null>`MAX(${posts.createdAt})`.as("lastPostAt"), // Units: seconds (posts.created_at mode "timestamp"); opaque aggregate, no cutoff.
     })
     .from(artists)
     .leftJoin(posts, eq(artists.id, posts.artistId))
@@ -55,7 +55,7 @@ export function getTrackedArtistsWithStats(db: AppDatabase): TrackedArtistWithSt
       )
     )
     .groupBy(artists.id)
-    .orderBy(desc(sql`COALESCE(${artists.lastChecked}, ${artists.createdAt})`))
+    .orderBy(desc(sql`COALESCE(${artists.lastChecked}, ${artists.createdAt})`)) // Units: both seconds (mode "timestamp"); ORDER BY only.
     .limit(MAX_TRACKED_ARTISTS)
     .all();
 

--- a/src/main/db/queries/blacklist.ts
+++ b/src/main/db/queries/blacklist.ts
@@ -9,6 +9,7 @@ const normalizeTag = (tag: string): string => tag.trim().toLowerCase();
 
 export function getAllBlacklistedTags(): string[] {
   const sqlite = getSqliteInstance();
+  // Units: tag_blacklist.created_at is Unix seconds (DEFAULT unixepoch()); ORDER BY only — no cutoff.
   const rows = sqlite
     .prepare<[], BlacklistTagRow>(
       "SELECT tag FROM tag_blacklist ORDER BY created_at DESC, id DESC"
@@ -30,6 +31,7 @@ export function addTagToBlacklist(tag: string): void {
     throw new Error(`Blacklist limit reached (${MAX_BLACKLIST_TAGS} tags maximum).`);
   }
 
+  // Units: created_at filled by DEFAULT (unixepoch()) = seconds; do not bind Date.now() here.
   sqlite
     .prepare("INSERT OR IGNORE INTO tag_blacklist (tag) VALUES (?)")
     .run(normalizedTag);

--- a/src/main/ipc/controllers/PlaylistController.ts
+++ b/src/main/ipc/controllers/PlaylistController.ts
@@ -154,7 +154,7 @@ export class PlaylistController extends BaseController {
   // Initialized lazily on first use and invalidated when posts_fts changes
   private fts5CountCache: number | null = null;
   private fts5CountCacheInitialized: boolean = false;
-  private fts5CountCacheTimestamp: number | null = null; // Timestamp when cache was last updated
+  private fts5CountCacheTimestamp: number | null = null; // Units: ms (invalidated_at / Date.now() fallback)
   
   // Cache FTS5 table existence check (schema doesn't change at runtime)
   // Initialized once at setup() to avoid blocking synchronous calls
@@ -435,8 +435,8 @@ export class PlaylistController extends BaseController {
     const sqlite = getSqliteInstance();
     
     try {
-      // Get current invalidation timestamp from database
-      // If table doesn't exist, this will throw and we'll fall back to simple caching
+      // Units: invalidated_at is milliseconds (julianday formula / Date.now() fallback stamps).
+      // Compare only against same-unit cache stamps — never against Drizzle mode "timestamp" columns.
       const invalidationStmt = sqlite.prepare<[], { invalidated_at: number }>(
         "SELECT invalidated_at FROM fts5_cache_invalidation WHERE id = 1"
       );
@@ -494,6 +494,7 @@ export class PlaylistController extends BaseController {
       } else {
         // Table exists but no row (should not happen, but handle gracefully)
         log.warn("[PlaylistController] fts5_cache_invalidation table exists but has no row, initializing cache without invalidation tracking");
+        // Units: Date.now() ms stamp for in-memory cache only (matches invalidated_at unit).
         this.fallbackToCountQuery(sqlite, Date.now());
       }
     } catch (error) {
@@ -507,6 +508,7 @@ export class PlaylistController extends BaseController {
         );
         // Fall back to simple caching without invalidation tracking
         if (!this.fts5CountCacheInitialized) {
+          // Units: Date.now() ms stamp for in-memory cache only (matches invalidated_at unit).
           this.fallbackToCountQuery(sqlite, Date.now());
         }
       } else {
@@ -622,6 +624,7 @@ export class PlaylistController extends BaseController {
       // Only perform if cache invalidation table exists (migration applied)
       try {
         const sqlite = getSqliteInstance();
+        // Units: invalidated_at is milliseconds (julianday / Date.now() stamps).
         const invalidationStmt = sqlite.prepare<[], { invalidated_at: number }>(
           "SELECT invalidated_at FROM fts5_cache_invalidation WHERE id = 1"
         );

--- a/src/main/services/sync-service.ts
+++ b/src/main/services/sync-service.ts
@@ -792,6 +792,7 @@ export class SyncService {
         `);
 
         try {
+          // Units: invalidated_at milliseconds (julianday → epoch ms); must match migration 0010 / PlaylistController Date.now() stamps.
           sqlite.exec(`
             CREATE TRIGGER IF NOT EXISTS fts5_cache_invalidate_insert
             AFTER INSERT ON posts_fts BEGIN

--- a/tests/helpers/mock-db.ts
+++ b/tests/helpers/mock-db.ts
@@ -51,6 +51,7 @@ export function createMockDb() {
   // Create __drizzle_migrations table if it doesn't exist
   // This table is created by drizzle's migrate function, but we need it for manual tracking
   // SQLite doesn't support SERIAL, use INTEGER PRIMARY KEY AUTOINCREMENT instead
+  // Units: __drizzle_migrations.created_at is written with Date.now() = milliseconds (journal only).
   sqlite.exec(`
     CREATE TABLE IF NOT EXISTS __drizzle_migrations (
       id INTEGER PRIMARY KEY AUTOINCREMENT,
@@ -104,6 +105,7 @@ export function createMockDb() {
         // but still create the cache invalidation table
         try {
           // Create the cache invalidation table (this part works)
+          // Units: invalidated_at = milliseconds via julianday epoch-ms formula (matches migration 0010).
           sqlite.exec(`
             CREATE TABLE IF NOT EXISTS fts5_cache_invalidation (
               id INTEGER PRIMARY KEY CHECK (id = 1),


### PR DESCRIPTION
## Summary
- Comment-only `Units:` annotations on every raw-SQL timestamp site (migrations, client/mock-db, blacklist, FTS invalidation, PlaylistController, artists aggregates).
- Fix stale `docs/database.md` labels: Drizzle `mode: timestamp` → **seconds**; keep **milliseconds** only for `resolved_at` / `last_vacuum_at` (and document IPC `getTime()` as wire format).
- Full audit found **no P0 unit mismatch** in production raw SQL; no logic changes.

## Test plan
- [x] Diff review: comments/docs only (13 files)
- [x] Schema cross-check: `timestamp` vs `timestamp_ms` vs bare int
- [ ] Optional: `npm test` after `npm run db:rebuild:all` in worktree (ABI env)

EOF