### PR TITLE
chore: dedupe backup retention and spy 429 throttle notify

### DIFF
--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -227,7 +227,7 @@ Items explicitly scheduled for product/engineering (beyond small bugs).
 | **Navigation & layout** | **Optional** polish: tooltips, item order tuning, and small-window density improvements (see [Navigation, layout, shell](#d-navigation-layout-shell)). |
 | **Backups** | `keep last N` is implemented; optional **total-size cap** is also supported via `BACKUP_RETENTION_MAX_TOTAL_MB` env for deployments that need hard storage ceilings (retained-only size accounting; newest backup always kept even if alone over cap). UI exposure for this cap remains optional future UX work. |
 | **Engineering** | Ongoing tooling hygiene; remaining shared validation consolidation as needed. |
-| **Testing** | Assert host-gate feedback: `vi.spyOn(ProviderThrottle.prototype, "notifyRateLimited")` in both `rule34-provider-fetch-posts.test.ts` and `gelbooru-provider-fetch-posts.test.ts` on HTTP 429 (coverage gap noted after [#126](https://github.com/KazeKaze93/RuleDesk/pull/126); reject `kind` alone is insufficient). |
+| **Testing** | Host-gate feedback covered: `vi.spyOn(ProviderThrottle.prototype, "notifyRateLimited")` asserts real 429 notify calls in `rule34-provider-fetch-posts.test.ts` and `gelbooru-provider-fetch-posts.test.ts` (closed after coverage gap noted post-[#126](https://github.com/KazeKaze93/RuleDesk/pull/126)). |
 | **Media filters (P3)** | Browse worker video regex (`mp4\|webm\|mov` in `data-processor.worker.ts`) is narrower than canonical `VIDEO_EXTENSIONS` in `src/shared/utils/media.ts` — align when touching the worker. |
 | **Product** | **Smart Collections AI** (research). |
 

--- a/src/main/ipc/controllers/MaintenanceController.ts
+++ b/src/main/ipc/controllers/MaintenanceController.ts
@@ -5,7 +5,6 @@ import fs from "fs";
 import Database from "better-sqlite3";
 import log from "electron-log";
 import { z } from "zod";
-import { eq } from "drizzle-orm";
 import { BaseController } from "../../core/ipc/BaseController";
 import { container, DI_TOKENS } from "../../core/di/Container";
 import { registerDatabaseInContainerAfterReinit } from "../../core/di/databaseRegistration";
@@ -16,7 +15,6 @@ import {
   initializeDatabase,
 } from "../../db/client";
 import { maintenanceQueue } from "../../db/maintenance-queue";
-import { settings, SETTINGS_ID } from "../../db/schema";
 import type { SyncService } from "../../services/sync-service";
 import { isErrnoException } from "../../../shared/utils/type-guards";
 import type { BackupService, AutoBackupInterval } from "../../services/backup-service";
@@ -28,6 +26,7 @@ import {
   restoreBackupSidecar,
   writeBackupSidecar,
 } from "../../lib/backup-sidecar";
+import { getBackupRetention } from "../../lib/backup-retention";
 import { markBackupsExceedingSizeCap } from "../../lib/backup-retention-size-cap";
 import { IdSchema } from "../../../shared/schemas/ipc";
 import {
@@ -37,9 +36,6 @@ import {
   type RunVacuumResponse,
 } from "../../../shared/schemas/maintenance";
 
-const DEFAULT_BACKUP_RETENTION = 5;
-const MIN_BACKUP_RETENTION = 1;
-const MAX_BACKUP_RETENTION = 20;
 const MAX_TOTAL_BACKUP_BYTES = (() => {
   const rawValue = process.env.BACKUP_RETENTION_MAX_TOTAL_MB;
   if (!rawValue) {
@@ -79,24 +75,6 @@ export class MaintenanceController extends BaseController {
    */
   public setMainWindow(window: BrowserWindow): void {
     this.mainWindow = window;
-  }
-
-  private getBackupRetention(): number {
-    const db = container.resolve(DI_TOKENS.DB);
-    const currentSettings = db
-      .select({
-        backupRetention: settings.backupRetention,
-      })
-      .from(settings)
-      .where(eq(settings.id, SETTINGS_ID))
-      .limit(1)
-      .all()[0];
-
-    const retention = currentSettings?.backupRetention ?? DEFAULT_BACKUP_RETENTION;
-    return Math.max(
-      MIN_BACKUP_RETENTION,
-      Math.min(MAX_BACKUP_RETENTION, retention)
-    );
   }
 
   private getSyncService(): SyncService {
@@ -346,7 +324,7 @@ export class MaintenanceController extends BaseController {
 
   private async cleanupOldBackups(backupDir: string): Promise<void> {
     try {
-      const backupRetention = this.getBackupRetention();
+      const backupRetention = getBackupRetention();
       const entries = await fs.promises.readdir(backupDir);
       const escapedBackupPrefix = BACKUP_FILE_PREFIX.replace(
         /[.*+?^${}()|[\]\\]/g,

--- a/src/main/lib/backup-retention.ts
+++ b/src/main/lib/backup-retention.ts
@@ -1,0 +1,29 @@
+import { eq } from "drizzle-orm";
+import { getDb } from "../db/client";
+import { settings, SETTINGS_ID } from "../db/schema";
+
+export const DEFAULT_BACKUP_RETENTION = 5;
+export const MIN_BACKUP_RETENTION = 1;
+export const MAX_BACKUP_RETENTION = 20;
+
+/**
+ * Read `settings.backupRetention` and clamp to the supported range.
+ * Shared by manual cleanup (MaintenanceController) and auto-backup prune (BackupService).
+ */
+export function getBackupRetention(): number {
+  const db = getDb();
+  const currentSettings = db
+    .select({
+      backupRetention: settings.backupRetention,
+    })
+    .from(settings)
+    .where(eq(settings.id, SETTINGS_ID))
+    .limit(1)
+    .all()[0];
+
+  const retention = currentSettings?.backupRetention ?? DEFAULT_BACKUP_RETENTION;
+  return Math.max(
+    MIN_BACKUP_RETENTION,
+    Math.min(MAX_BACKUP_RETENTION, retention)
+  );
+}

--- a/src/main/services/backup-service.ts
+++ b/src/main/services/backup-service.ts
@@ -3,10 +3,8 @@ import { createRequire } from "node:module";
 import path from "node:path";
 import log from "electron-log";
 import { getDatabasePaths } from "../db/paths";
-import { getDb } from "../db/client";
 import { maintenanceQueue } from "../db/maintenance-queue";
-import { settings, SETTINGS_ID } from "../db/schema";
-import { eq } from "drizzle-orm";
+import { getBackupRetention } from "../lib/backup-retention";
 import type { SyncService } from "./sync-service";
 
 export type AutoBackupInterval = "never" | "daily" | "weekly";
@@ -21,9 +19,6 @@ const AUTO_BACKUP_INTERVAL_MS: Record<Exclude<AutoBackupInterval, "never">, numb
   weekly: 7 * 24 * 60 * 60 * 1000,
 };
 const AUTO_BACKUP_FILE_REGEX = /^data\.backup\.\d{4}-\d{2}-\d{2}\.bin$/;
-const DEFAULT_BACKUP_RETENTION = 5;
-const MIN_BACKUP_RETENTION = 1;
-const MAX_BACKUP_RETENTION = 20;
 
 type BackupStoreContract = {
   get<K extends keyof BackupStoreSchema>(key: K): BackupStoreSchema[K];
@@ -134,23 +129,9 @@ export class BackupService {
     }
   }
 
-  private getBackupRetention(): number {
-    const db = getDb();
-    const currentSettings = db
-      .select({
-        backupRetention: settings.backupRetention,
-      })
-      .from(settings)
-      .where(eq(settings.id, SETTINGS_ID))
-      .limit(1)
-      .all()[0];
-    const retention = currentSettings?.backupRetention ?? DEFAULT_BACKUP_RETENTION;
-    return Math.max(MIN_BACKUP_RETENTION, Math.min(MAX_BACKUP_RETENTION, retention));
-  }
-
   private cleanupOldAutoBackups(backupDirectory: string): void {
     try {
-      const retention = this.getBackupRetention();
+      const retention = getBackupRetention();
       const autoBackups = fs
         .readdirSync(backupDirectory)
         .filter((filename) => AUTO_BACKUP_FILE_REGEX.test(filename))

--- a/tests/unit/TEST_COVERAGE.md
+++ b/tests/unit/TEST_COVERAGE.md
@@ -26,8 +26,8 @@ Vitest covers unit logic, integration flows (IPC + SQLite), and property-based f
 | `controllers/posts-tag-query.test.ts` | 5 | Tag query helpers |
 | `store/searchStore.test.ts` | 3 | Search store |
 | `shared/provider-search-ipc-payload.test.ts` | 8 | Provider IPC error parsing |
-| `providers/rule34-provider-fetch-posts.test.ts` | 5 | fetchPosts error classification |
-| `providers/gelbooru-provider-fetch-posts.test.ts` | 5 | Gelbooru fetchPosts 429 → rate_limit gate |
+| `providers/rule34-provider-fetch-posts.test.ts` | 5 | fetchPosts error classification + `notifyRateLimited` spy on 429 |
+| `providers/gelbooru-provider-fetch-posts.test.ts` | 5 | Gelbooru fetchPosts 429 → rate_limit + `notifyRateLimited` spy |
 | `services/tag-resolve-coordinator.test.ts` | 3 | Tag resolve dedup / rate limit |
 | `services/secure-storage.test.ts` | 3 | `SecureStorage` encrypt/decrypt (sole crypto path) |
 | `services/video-proxy-server.test.ts` | 8 | Video proxy allowlist / cache / eviction |

--- a/tests/unit/providers/gelbooru-provider-fetch-posts.test.ts
+++ b/tests/unit/providers/gelbooru-provider-fetch-posts.test.ts
@@ -1,6 +1,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import axios, { AxiosError } from "axios";
 import { GelbooruProvider } from "@/main/providers/gelbooru-provider";
+import { ProviderThrottle } from "@/main/providers/provider-throttle";
 
 vi.mock("electron-log", () => ({
   default: {
@@ -77,6 +78,7 @@ describe("GelbooruProvider.fetchPosts rate-limit classification", () => {
   });
 
   it("throws rate_limit error on HTTP 429 and does not return []", async () => {
+    const notifySpy = vi.spyOn(ProviderThrottle.prototype, "notifyRateLimited");
     axiosGetMock.mockResolvedValueOnce({
       status: 429,
       headers: { "retry-after": "12", "content-type": "text/plain" },
@@ -90,10 +92,13 @@ describe("GelbooruProvider.fetchPosts rate-limit classification", () => {
       retryAfterMs: 12_000,
     });
 
+    expect(notifySpy).toHaveBeenCalledWith(12_000);
     expect(axiosGetMock).toHaveBeenCalledTimes(1);
+    notifySpy.mockRestore();
   });
 
   it("treats invalid Retry-After as undefined retryAfterMs on 429", async () => {
+    const notifySpy = vi.spyOn(ProviderThrottle.prototype, "notifyRateLimited");
     axiosGetMock.mockResolvedValueOnce({
       status: 429,
       headers: { "retry-after": "not-a-number" },
@@ -106,6 +111,9 @@ describe("GelbooruProvider.fetchPosts rate-limit classification", () => {
       kind: "rate_limit",
       retryAfterMs: undefined,
     });
+
+    expect(notifySpy).toHaveBeenCalledWith(undefined);
+    notifySpy.mockRestore();
   });
 
   it("returns [] for non-JSON content-type on HTTP 200 (XML fallback path)", async () => {

--- a/tests/unit/providers/rule34-provider-fetch-posts.test.ts
+++ b/tests/unit/providers/rule34-provider-fetch-posts.test.ts
@@ -2,6 +2,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import axios, { AxiosError } from "axios";
 import { RULE34_MISSING_AUTHENTICATION_MARKER } from "@/shared/constants/rule34-api";
 import { Rule34Provider } from "@/main/providers/rule34-provider";
+import { ProviderThrottle } from "@/main/providers/provider-throttle";
 
 vi.mock("electron-log", () => ({
   default: {
@@ -54,6 +55,7 @@ describe("Rule34Provider.fetchPosts error classification", () => {
   });
 
   it("throws rate_limit error on HTTP 429 without XML fallback", async () => {
+    const notifySpy = vi.spyOn(ProviderThrottle.prototype, "notifyRateLimited");
     axiosGetMock.mockResolvedValueOnce({
       status: 429,
       headers: { "retry-after": "12" },
@@ -65,7 +67,9 @@ describe("Rule34Provider.fetchPosts error classification", () => {
       retryAfterMs: 12_000,
     });
 
+    expect(notifySpy).toHaveBeenCalledWith(12_000);
     expect(axiosGetMock).toHaveBeenCalledTimes(1);
+    notifySpy.mockRestore();
   });
 
   it("throws parse error for garbage body after XML fallback fails", async () => {


### PR DESCRIPTION
## Summary
- Extract shared `getBackupRetention()` (clamp 1..20, default 5) so manual and auto backup prune paths no longer duplicate constants/logic
- Add `vi.spyOn(ProviderThrottle.prototype, notifyRateLimited)` to existing Rule34/Gelbooru 429 tests (including `undefined` Retry-After)
- Close roadmap Testing backlog item for host-gate spy coverage

## Test plan
- [x] `npm test -- tests/unit/providers/rule34-provider-fetch-posts.test.ts tests/unit/providers/gelbooru-provider-fetch-posts.test.ts tests/unit/lib/backup-retention-size-cap.test.ts` (16/16)
- [x] `npm run typecheck`
- [x] Review confirms no behavior change; `getDb()` unification safe vs DI re-register after VACUUM
