### PR TITLE
chore: remove dead rating/date/orientation filter plumbing

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -646,7 +646,7 @@ const posts = await db.query.posts.findMany({
    - **Provider search failures** (auth, rate limit, network, parse): `Rule34Provider` throws typed `ProviderSearchError`; `SearchController` rethrows via `throwProviderSearchIpcError()` (enumerable `code` / `providerKind` on `Error`, no `stack` or raw API body to renderer). Renderer parses with `parseProviderSearchErrorPayload()` in `src/shared/utils/provider-search-ipc.ts` and shows `BrowseErrorState` (centered empty-state layout; auth → **Open Settings**).
    - **Worker filter/sort failures** (client-side only): partial failure uses a neutral `Alert` above loaded posts; fatal query failure uses `BrowseErrorState`.
    - **Preload constraint:** `src/main/bridge.ts` must stay thin — do **not** import shared Zod/schemas in preload (breaks `contextBridge.exposeInMainWorld` → perpetual Loading).
-   - **Removed:** orientation filter (no UI; dead code removed from store, worker, and gallery pages).
+   - **Removed:** local rating / date-range / orientation filters (no UI; dead plumbing removed from `searchStore`, worker `FilterConfig`, IPC `PostFilterSchema` / `PostFiltersSchema`, gallery pages, and viewer query keys). Post `rating` as data (column, badges, Stats, Safe Mode blur) is unchanged. Booru search metatags (`rating:`, `width:`, `aspectratio:`) are unchanged.
    - Unit tests: `tests/unit/hooks/useWorkerFilteredPosts.test.ts`, `tests/unit/utils/react-query-cache.test.ts`.
 
 13. **Bridge** (`src/main/bridge.ts`, built to `out/preload/bridge.cjs`)
@@ -1817,7 +1817,7 @@ Root:
 ### A. Filters (Advanced Search) — ongoing
 
 - ✅ `FiltersPanel` + `searchStore` drive AI, media, and source filters on main surfaces.
-- ℹ️ Removed panel controls (rating/date range/orientation) are intentionally out of current scope.
+- ℹ️ Local rating / date-range / orientation filters are out of scope: UI was already removed; store, worker, IPC filter schemas, and gallery apply-paths no longer accept those fields. Post `rating` data and booru search metatags are unchanged.
 - Full detail: [roadmap — Navigation & UX](./roadmap.md#-navigation--ux-revamp).
 
 ### B. Download Manager ✅ Implemented (Core Features)

--- a/docs/database.md
+++ b/docs/database.md
@@ -138,7 +138,7 @@ Caches post metadata for filtering, statistics, and download management. Support
 
 - `postIdIdx` - Index on `post_id` for efficient lookups
 - `artistIdIdx` - Index on `artist_id` for artist-based queries
-- `posts_rating_idx` - Index on `rating` for rating filters
+- `posts_rating_idx` - Index on `rating` for Stats aggregation and rating-column lookups
 - `isViewedIdx` - Index on `is_viewed` for view status filtering
 - `posts_last_viewed_at_idx` - Index on `last_viewed_at` for recently viewed sorting
 - `publishedAtIdx` - Index on `published_at` for date-based sorting

--- a/src/main/bridge.ts
+++ b/src/main/bridge.ts
@@ -69,7 +69,6 @@ export type { GetPostsRequest, AddArtistRequest, PostFilterRequest } from "./typ
 
 // Legacy interface for backward compatibility (can be removed if not used)
 export interface PostQueryFilters {
-  rating?: "s" | "q" | "e";
   tags?: string;
   sortBy?: "date" | "id" | "rating";
   isViewed?: boolean;

--- a/src/main/ipc/controllers/PlaylistController.ts
+++ b/src/main/ipc/controllers/PlaylistController.ts
@@ -1195,10 +1195,10 @@ export class PlaylistController extends BaseController {
   }
 
   /**
-   * Get posts in a playlist with filters (rating, media type)
+   * Get posts in a playlist with filters (media type)
    *
    * Uses JOIN to efficiently retrieve posts with their playlist entries.
-   * Supports playlist-scoped filtering by rating and media type.
+   * Supports playlist-scoped filtering by media type.
    *
    * @param _event - IPC event (unused)
    * @param params - Request parameters (playlistId, page, filters, limit)
@@ -1216,11 +1216,6 @@ export class PlaylistController extends BaseController {
 
       // Build WHERE conditions array
       const conditions = [eq(playlistEntries.playlistId, playlistId)];
-
-      // Add rating filter if provided
-      if (filters?.rating) {
-        conditions.push(eq(posts.rating, filters.rating));
-      }
 
       // Add media type filter if provided
       if (filters?.mediaType === "videos") {
@@ -1558,7 +1553,7 @@ export class PlaylistController extends BaseController {
    *
    * For static playlists: Uses JOIN with playlist_entries.
    * For smart playlists: Parses query_json and builds dynamic Drizzle query with tag filters.
-   * Integrates with global filters (rating, mediaType) from GlobalTopBar.
+   * Integrates with global filters (mediaType) from GlobalTopBar.
    *
    * @param _event - IPC event (unused)
    * @param params - Request parameters (playlistId, page, limit, filters)
@@ -1588,9 +1583,6 @@ export class PlaylistController extends BaseController {
 
       // Build global filter conditions (from GlobalTopBar)
       const globalConditions: SQL[] = [];
-      if (filters?.rating) {
-        globalConditions.push(eq(posts.rating, filters.rating));
-      }
       if (filters?.mediaType === "videos") {
         globalConditions.push(eq(posts.mediaType, "video"));
       } else if (filters?.mediaType === "images") {
@@ -1868,13 +1860,13 @@ export class PlaylistController extends BaseController {
    * Resolve smart playlist posts from remote API
    * 
    * Fetches posts from booru API using the tag query string.
-   * Applies global filters (rating, media type) after fetching.
+   * Applies global filters (media type) after fetching.
    * 
    * @param playlistId - Playlist ID
    * @param query - Smart playlist query
    * @param page - Page number (1-indexed)
    * @param limit - Number of posts per page
-   * @param filters - Global filters (rating, media type)
+   * @param filters - Global filters (media type)
    * @param sortOrder - Sort order (asc/desc)
    * @returns Array of posts from remote API
    */
@@ -1940,11 +1932,6 @@ export class PlaylistController extends BaseController {
             }
           }
 
-          // Apply rating filter
-          if (filters?.rating && post.rating !== filters.rating) {
-            return false;
-          }
-          
           // Apply media type filter
           if (filters?.mediaType) {
             const isVideo = isVideoUrl(post.fileUrl);

--- a/src/main/ipc/controllers/PostsController.ts
+++ b/src/main/ipc/controllers/PostsController.ts
@@ -426,7 +426,7 @@ export class PostsController extends BaseController {
    * Centralized logic to avoid code duplication (DRY principle)
    *
    * @param artistId - Optional artist ID filter
-   * @param filters - Optional post filters (tags, rating, isViewed, isFavorited)
+   * @param filters - Optional post filters (tags, isViewed, isFavorited)
    * @returns Array of Drizzle SQL conditions for use with and()
    */
   private buildPostFilterConditions(
@@ -444,10 +444,6 @@ export class PostsController extends BaseController {
     // Empty string "" would become '""' and cause SQLITE_ERROR: fts5: syntax error
     if (filters?.tags && filters.tags.trim().length > 0) {
       conditions.push(this.createTagFilterCondition(filters.tags));
-    }
-
-    if (filters?.rating !== undefined) {
-      conditions.push(eq(posts.rating, filters.rating));
     }
 
     if (filters?.isFavorited !== undefined) {

--- a/src/main/ipc/controllers/UpdatesController.ts
+++ b/src/main/ipc/controllers/UpdatesController.ts
@@ -27,10 +27,6 @@ const buildUpdatesUnreadConditions = (
 ): SQL[] => {
   const conditions: SQL[] = [eq(posts.isViewed, false)];
 
-  if (filters?.rating !== undefined) {
-    conditions.push(eq(posts.rating, filters.rating));
-  }
-
   if (filters?.isFavorited !== undefined) {
     conditions.push(eq(posts.isFavorited, filters.isFavorited));
   }

--- a/src/renderer.d.ts
+++ b/src/renderer.d.ts
@@ -34,7 +34,6 @@ export interface BackupResponse {
 }
 
 export interface PostQueryFilters {
-  rating?: "s" | "q" | "e";
   tags?: string;
   sortBy?: "date" | "id" | "rating";
   isViewed?: boolean;

--- a/src/renderer/components/pages/Browse.tsx
+++ b/src/renderer/components/pages/Browse.tsx
@@ -106,21 +106,15 @@ export const Browse = () => {
   // Use atomic selectors - faster than useShallow for 3 fields
   // Each selector only re-renders when its specific field changes
   const aiFilter = useSearchStore((state) => state.filters.aiFilter);
-  const rating = useSearchStore((state) => state.filters.rating);
   const mediaType = useSearchStore((state) => state.filters.mediaType);
   const source = useSearchStore((state) => state.filters.source);
-  const dateFrom = useSearchStore((state) => state.filters.dateFrom);
-  const dateTo = useSearchStore((state) => state.filters.dateTo);
 
   const isRemoteBrowseSource = source === "all";
   const usesDefaultRemoteFilters =
     isRemoteBrowseSource &&
     tags.length === 0 &&
     aiFilter === "all" &&
-    rating === "all" &&
-    mediaType === "all" &&
-    !dateFrom &&
-    !dateTo;
+    mediaType === "all";
 
   // Use the new infinite scroll hook
   // For external API (Browse), we need custom getNextPageParam logic
@@ -246,15 +240,12 @@ export const Browse = () => {
   // Worker-based processing with custom hook to avoid cascade renders
   const filterConfig: WorkerFilterConfig = useMemo(() => ({
     aiFilter,
-    rating,
     mediaType,
     source,
-    dateFrom,
-    dateTo,
     sortOrder,
     trackedTagsSet: trackedTagsArray,
     tags,
-  }), [aiFilter, rating, mediaType, source, dateFrom, dateTo, sortOrder, trackedTagsArray, tags]);
+  }), [aiFilter, mediaType, source, sortOrder, trackedTagsArray, tags]);
 
   const {
     data: workerPosts = [],

--- a/src/renderer/components/pages/Favorites.tsx
+++ b/src/renderer/components/pages/Favorites.tsx
@@ -32,48 +32,20 @@ import { createVirtuosoGridFactories } from "../gallery/virtuoso-factories";
 // This matches the default limit in GetPostsSchema
 const POSTS_PER_PAGE = 50;
 
-const getPublishedDate = (publishedAt: Date | number | null): Date | null => {
-  if (publishedAt instanceof Date) {
-    return Number.isNaN(publishedAt.getTime()) ? null : publishedAt;
-  }
-  if (typeof publishedAt === "number") {
-    const parsed = new Date(publishedAt);
-    return Number.isNaN(parsed.getTime()) ? null : parsed;
-  }
-  return null;
-};
-
 const shouldIncludePostInFavoritesQueue = (
   post: Post,
   filters: {
     aiFilter: "all" | "hide" | "only";
-    rating: "all" | "s" | "q" | "e";
     mediaType: "all" | "images" | "videos";
-    dateFrom: Date | null;
-    dateTo: Date | null;
   }
 ): boolean => {
   if (filters.aiFilter === "hide" && hasAiGeneratedTag(post.tags)) return false;
   if (filters.aiFilter === "only" && !hasAiGeneratedTag(post.tags)) return false;
 
-  if (filters.rating !== "all") {
-    const postRating =
-      typeof post.rating === "string" ? post.rating.trim().toLowerCase().charAt(0) : "";
-    if (postRating !== filters.rating) return false;
-  }
-
   if (filters.mediaType !== "all") {
     const isVideo = isVideoPost(post.fileUrl);
     if (filters.mediaType === "videos" && !isVideo) return false;
     if (filters.mediaType === "images" && isVideo) return false;
-  }
-
-  if (filters.dateFrom || filters.dateTo) {
-    const date = getPublishedDate(post.publishedAt);
-    if (date) {
-      if (filters.dateFrom && date < filters.dateFrom) return false;
-      if (filters.dateTo && date > filters.dateTo) return false;
-    }
   }
 
   return true;
@@ -141,8 +113,7 @@ export const Favorites = () => {
       initialPageParam: 1,
     });
   
-  const { aiFilter, mediaType, dateFrom, dateTo } = filters;
-  const rating = useSearchStore((state) => state.filters.rating);
+  const { aiFilter, mediaType } = filters;
 
   const allPosts = useMemo(() => {
     let posts = data?.pages.flatMap((page) => page) || [];
@@ -155,14 +126,6 @@ export const Favorites = () => {
       posts = posts.filter((post) => hasAiGeneratedTag(post.tags));
     }
 
-    // Filter by rating
-    if (rating !== "all") {
-      posts = posts.filter((post) => {
-        const postRating = typeof post.rating === "string" ? post.rating.trim().toLowerCase().charAt(0) : "";
-        return postRating === rating;
-      });
-    }
-    
     // Filter by media type
     if (mediaType !== "all") {
       posts = posts.filter((post) => {
@@ -171,16 +134,6 @@ export const Favorites = () => {
       });
     }
 
-    if (dateFrom || dateTo) {
-      posts = posts.filter((post) => {
-        const date = getPublishedDate(post.publishedAt);
-        if (!date) return true;
-        if (dateFrom && date < dateFrom) return false;
-        if (dateTo && date > dateTo) return false;
-        return true;
-      });
-    }
-    
     // Sort by publishedAt (date of post creation)
     return [...posts].sort((a, b) => {
       const dateA = a.publishedAt instanceof Date 
@@ -196,7 +149,7 @@ export const Favorites = () => {
       
       return sortOrder === "desc" ? dateB - dateA : dateA - dateB;
     });
-  }, [data, sortOrder, aiFilter, rating, mediaType, dateFrom, dateTo]);
+  }, [data, sortOrder, aiFilter, mediaType]);
   const selectedPosts = useMemo(
     () => allPosts.filter((post) => selectedIds.has(getBulkSelectId(post))),
     [allPosts, selectedIds]
@@ -252,10 +205,7 @@ export const Favorites = () => {
             .filter((post) =>
               shouldIncludePostInFavoritesQueue(post, {
                 aiFilter,
-                rating,
                 mediaType,
-                dateFrom,
-                dateTo,
               })
             )
             .map((p) => p.id);

--- a/src/renderer/components/pages/PlaylistsPage.tsx
+++ b/src/renderer/components/pages/PlaylistsPage.tsx
@@ -95,34 +95,14 @@ const isInvalidPlaylistError = (message: string): boolean => {
   );
 };
 
-const getPublishedDate = (publishedAt: Date | number | null): Date | null => {
-  if (publishedAt instanceof Date) {
-    return Number.isNaN(publishedAt.getTime()) ? null : publishedAt;
-  }
-  if (typeof publishedAt === "number") {
-    const parsed = new Date(publishedAt);
-    return Number.isNaN(parsed.getTime()) ? null : parsed;
-  }
-  return null;
-};
-
 const shouldIncludePostInPlaylistQueue = (
   post: Post,
   filters: {
     aiFilter: "all" | "hide" | "only";
-    dateFrom: Date | null;
-    dateTo: Date | null;
   }
 ): boolean => {
   if (filters.aiFilter === "hide" && hasAiGeneratedTag(post.tags)) return false;
   if (filters.aiFilter === "only" && !hasAiGeneratedTag(post.tags)) return false;
-  if (filters.dateFrom || filters.dateTo) {
-    const date = getPublishedDate(post.publishedAt);
-    if (date) {
-      if (filters.dateFrom && date < filters.dateFrom) return false;
-      if (filters.dateTo && date > filters.dateTo) return false;
-    }
-  }
   return true;
 };
 
@@ -244,23 +224,17 @@ const PlaylistGallery: React.FC<PlaylistGalleryProps> = ({ playlist, onBack }) =
   );
   const queryClient = useQueryClient();
 
-  const ratingLetter = filters.rating;
-
   // Build filters for API call from search store state
   const apiFilters = useMemo(() => {
-    const result: { rating?: "s" | "q" | "e"; mediaType?: "all" | "images" | "videos" } = {};
+    const result: { mediaType?: "all" | "images" | "videos" } = {};
 
-    if (ratingLetter === "s" || ratingLetter === "q" || ratingLetter === "e") {
-      result.rating = ratingLetter;
-    }
-    
     // Map mediaType filter from current search store state
     if (filters.mediaType && filters.mediaType !== "all") {
       result.mediaType = filters.mediaType;
     }
     
     return result;
-  }, [filters.mediaType, ratingLetter]);
+  }, [filters.mediaType]);
 
   const {
     data,
@@ -273,7 +247,6 @@ const PlaylistGallery: React.FC<PlaylistGalleryProps> = ({ playlist, onBack }) =
       "playlist-posts",
       playlist.id,
       filters.mediaType,
-      ratingLetter,
       filters.aiFilter,
       sortOrder,
     ],
@@ -303,18 +276,8 @@ const PlaylistGallery: React.FC<PlaylistGalleryProps> = ({ playlist, onBack }) =
       posts = posts.filter((post) => hasAiGeneratedTag(post.tags));
     }
 
-    if (filters.dateFrom || filters.dateTo) {
-      posts = posts.filter((post) => {
-        const date = getPublishedDate(post.publishedAt);
-        if (!date) return true;
-        if (filters.dateFrom && date < filters.dateFrom) return false;
-        if (filters.dateTo && date > filters.dateTo) return false;
-        return true;
-      });
-    }
-
     return posts;
-  }, [data, filters.aiFilter, filters.dateFrom, filters.dateTo]);
+  }, [data, filters.aiFilter]);
   const [localPosts, setLocalPosts] = useState<Post[]>([]);
   const sensors = useSensors(
     useSensor(PointerSensor, {
@@ -357,8 +320,6 @@ const PlaylistGallery: React.FC<PlaylistGalleryProps> = ({ playlist, onBack }) =
           .filter((post) =>
             shouldIncludePostInPlaylistQueue(post, {
               aiFilter: filters.aiFilter,
-              dateFrom: filters.dateFrom,
-              dateTo: filters.dateTo,
             })
           )
           .map((post) => (post.id === 0 && post.postId ? post.postId : post.id));
@@ -389,7 +350,6 @@ const PlaylistGallery: React.FC<PlaylistGalleryProps> = ({ playlist, onBack }) =
         kind: "playlist",
         playlistId: playlist.id,
         mediaType: filters.mediaType,
-        rating: ratingLetter,
         aiFilter: filters.aiFilter,
         sortOrder,
         provider, // Pass provider to origin for shadow insert operations

--- a/src/renderer/components/pages/Updates.tsx
+++ b/src/renderer/components/pages/Updates.tsx
@@ -36,17 +36,6 @@ import { createVirtuosoGridFactories } from "../gallery/virtuoso-factories";
 // --- Constants ---
 const POSTS_PER_PAGE = 50;
 
-const getPublishedDate = (publishedAt: Date | number | null): Date | null => {
-  if (publishedAt instanceof Date) {
-    return Number.isNaN(publishedAt.getTime()) ? null : publishedAt;
-  }
-  if (typeof publishedAt === "number") {
-    const parsed = new Date(publishedAt);
-    return Number.isNaN(parsed.getTime()) ? null : parsed;
-  }
-  return null;
-};
-
 // --- Helper function for updating InfiniteData cache ---
 /**
  * Updates a single post in InfiniteData cache by postId
@@ -224,8 +213,7 @@ export const Updates = () => {
       initialPageParam: 1,
     });
 
-  const { aiFilter, mediaType, dateFrom, dateTo } = filters;
-  const rating = useSearchStore((state) => state.filters.rating);
+  const { aiFilter, mediaType } = filters;
 
   useEffect(() => {
     let isMounted = true;
@@ -269,14 +257,13 @@ export const Updates = () => {
   });
 
   const { data: totalUnreadCount = 0 } = useQuery({
-    queryKey: ["updates", "totalUnreadCount", tags, aiFilter, rating, mediaType],
+    queryKey: ["updates", "totalUnreadCount", tags, aiFilter, mediaType],
     queryFn: () =>
       window.api.getUpdatesTotalUnreadCount({
         filters: {
           sinceTracking: true,
           tags: tags.length > 0 ? tags.join(" ") : undefined,
           aiFilter: aiFilter === "all" ? undefined : aiFilter,
-          rating: rating === "all" ? undefined : rating,
           mediaType: mediaType === "all" ? undefined : mediaType,
         },
       }),
@@ -303,14 +290,6 @@ export const Updates = () => {
       posts = posts.filter((post) => hasAiGeneratedTag(post.tags));
     }
 
-    // Filter by rating
-    if (rating !== "all") {
-      posts = posts.filter((post) => {
-        const postRating = typeof post.rating === "string" ? post.rating.trim().toLowerCase().charAt(0) : "";
-        return postRating === rating;
-      });
-    }
-    
     // Filter by media type
     if (mediaType !== "all") {
       posts = posts.filter((post) => {
@@ -319,16 +298,6 @@ export const Updates = () => {
       });
     }
 
-    if (dateFrom || dateTo) {
-      posts = posts.filter((post) => {
-        const date = getPublishedDate(post.publishedAt);
-        if (!date) return true;
-        if (dateFrom && date < dateFrom) return false;
-        if (dateTo && date > dateTo) return false;
-        return true;
-      });
-    }
-    
     // Sort by publishedAt (date of post creation)
     return [...posts].sort((a, b) => {
       const dateA = a.publishedAt instanceof Date 
@@ -344,7 +313,7 @@ export const Updates = () => {
       
       return sortOrder === "desc" ? dateB - dateA : dateA - dateB;
     });
-  }, [data, sortOrder, aiFilter, rating, mediaType, dateFrom, dateTo]);
+  }, [data, sortOrder, aiFilter, mediaType]);
   const selectedPosts = useMemo(
     () => allPosts.filter((post) => selectedIds.has(getBulkSelectId(post))),
     [allPosts, selectedIds]

--- a/src/renderer/features/artists/ArtistGallery.tsx
+++ b/src/renderer/features/artists/ArtistGallery.tsx
@@ -26,17 +26,6 @@ interface ArtistGalleryProps {
   onBack: () => void;
 }
 
-const getPublishedDate = (publishedAt: Date | number | null): Date | null => {
-  if (publishedAt instanceof Date) {
-    return Number.isNaN(publishedAt.getTime()) ? null : publishedAt;
-  }
-  if (typeof publishedAt === "number") {
-    const parsed = new Date(publishedAt);
-    return Number.isNaN(parsed.getTime()) ? null : parsed;
-  }
-  return null;
-};
-
 // --- Компоненты для виртуализации (Grid/Masonry Layout) ---
 
 const GridContainer = forwardRef<
@@ -118,21 +107,17 @@ export const ArtistGallery: React.FC<ArtistGalleryProps> = ({
   // Use atomic selectors to prevent unnecessary re-renders
   const sortOrder = useSearchStore((state) => state.sortOrder);
   const aiFilter = useSearchStore((state) => state.filters.aiFilter);
-  const rating = useSearchStore((state) => state.filters.rating);
   const mediaType = useSearchStore((state) => state.filters.mediaType);
   const source = useSearchStore((state) => state.filters.source);
-  const dateFrom = useSearchStore((state) => state.filters.dateFrom);
-  const dateTo = useSearchStore((state) => state.filters.dateTo);
   const viewType = useSearchStore((state) => state.viewType);
 
   const { data: totalPosts = 0 } = useQuery({
-    queryKey: ["posts-count", artist.id, aiFilter, rating, mediaType, source],
+    queryKey: ["posts-count", artist.id, aiFilter, mediaType, source],
     queryFn: async () => {
       const count = await window.api.getArtistPostsCount({
         artistId: artist.id,
         filters: {
           aiFilter: aiFilter === "all" ? undefined : aiFilter,
-          rating: rating === "all" ? undefined : rating,
           mediaType: mediaType === "all" ? undefined : mediaType,
           isFavorited: source === "favorites" ? true : undefined,
         },
@@ -151,7 +136,7 @@ export const ArtistGallery: React.FC<ArtistGalleryProps> = ({
     isLoading,
     handleEndReached,
   } = useGalleryInfiniteScroll({
-    queryKey: ["posts", artist.id, aiFilter, rating, mediaType, source, sortOrder],
+    queryKey: ["posts", artist.id, aiFilter, mediaType, source, sortOrder],
     initialPageParam: 1,
     fetchFn: async (pageParam) => {
       return await window.api.getArtistPosts({
@@ -164,7 +149,6 @@ export const ArtistGallery: React.FC<ArtistGalleryProps> = ({
           tags: undefined,
           // AI and Media Type filters applied only if not in 'all' mode
           aiFilter: aiFilter === "all" ? undefined : aiFilter,
-          rating: rating === "all" ? undefined : rating,
           mediaType: mediaType === "all" ? undefined : mediaType,
           isFavorited: source === "favorites" ? true : undefined,
         },
@@ -172,21 +156,7 @@ export const ArtistGallery: React.FC<ArtistGalleryProps> = ({
     },
   });
 
-  const allPosts = useMemo(() => {
-    let posts = rawPosts;
-
-    if (dateFrom || dateTo) {
-      posts = posts.filter((post) => {
-        const date = getPublishedDate(post.publishedAt);
-        if (!date) return true;
-        if (dateFrom && date < dateFrom) return false;
-        if (dateTo && date > dateTo) return false;
-        return true;
-      });
-    }
-
-    return posts;
-  }, [rawPosts, dateFrom, dateTo]);
+  const allPosts = rawPosts;
 
   const listAriaBusy = isLoading || isFetchingNextPage;
   const ListComponent = viewType === "masonry" ? MasonryVirtuosoList : GridVirtuosoList;
@@ -277,7 +247,6 @@ export const ArtistGallery: React.FC<ArtistGalleryProps> = ({
         artistId: artist.id,
         tags: undefined, // No tag filtering in artist gallery
         aiFilter: aiFilter === "all" ? undefined : aiFilter,
-        rating,
         mediaType: mediaType === "all" ? undefined : mediaType,
         source,
         sortOrder,
@@ -299,12 +268,11 @@ export const ArtistGallery: React.FC<ArtistGalleryProps> = ({
       isRandom: false,
       filters: {
         aiFilter: aiFilter === "all" ? undefined : aiFilter,
-        rating: rating === "all" ? undefined : rating,
         mediaType: mediaType === "all" ? undefined : mediaType,
         isFavorited: source === "favorites" ? true : undefined,
       },
     }),
-    [artist.id, aiFilter, rating, mediaType, source]
+    [artist.id, aiFilter, mediaType, source]
   );
   const {
     downloadAll,

--- a/src/renderer/features/viewer/ViewerDialog.tsx
+++ b/src/renderer/features/viewer/ViewerDialog.tsx
@@ -260,7 +260,6 @@ const PostNotFoundFallback = ({
             "playlist-posts",
             queue.origin.playlistId,
             queue.origin.mediaType ?? "all",
-            queue.origin.rating ?? "all",
             queue.origin.aiFilter ?? "all",
             queue.origin.sortOrder ?? "desc",
           ];
@@ -410,10 +409,9 @@ const useCurrentPost = (
       }
       case "artist": {
         // CRITICAL: Match query key from ArtistGallery.tsx
-        // QueryKey includes: ["posts", artistId, aiFilter, rating, mediaType, source, sortOrder]
+        // QueryKey includes: ["posts", artistId, aiFilter, mediaType, source, sortOrder]
         // This ensures cache lookup matches the query key used for fetching artist posts
         const aiFilter = origin.aiFilter ?? "all";
-        const rating = origin.rating ?? "all";
         const mediaType = origin.mediaType ?? "all";
         const source = origin.source ?? "all";
         const sortOrder = origin.sortOrder ?? "desc";
@@ -421,7 +419,6 @@ const useCurrentPost = (
           "posts",
           origin.artistId,
           aiFilter,
-          rating,
           mediaType,
           source,
           sortOrder,
@@ -439,7 +436,6 @@ const useCurrentPost = (
           "playlist-posts",
           origin.playlistId,
           origin.mediaType ?? "all",
-          origin.rating ?? "all",
           origin.aiFilter ?? "all",
           origin.sortOrder ?? "desc",
         ] as const;
@@ -1751,17 +1747,15 @@ export const ViewerDialog = () => {
         "playlist-posts",
         queue.origin.playlistId,
         queue.origin.mediaType ?? "all",
-        queue.origin.rating ?? "all",
         queue.origin.aiFilter ?? "all",
         queue.origin.sortOrder ?? "desc",
       ];
     } else if (queue.origin.kind === "artist") {
       const aiFilter = queue.origin.aiFilter ?? "all";
-      const rating = queue.origin.rating ?? "all";
       const mediaType = queue.origin.mediaType ?? "all";
       const source = queue.origin.source ?? "all";
       const sortOrder = queue.origin.sortOrder ?? "desc";
-      queryKey = ["posts", queue.origin.artistId, aiFilter, rating, mediaType, source, sortOrder];
+      queryKey = ["posts", queue.origin.artistId, aiFilter, mediaType, source, sortOrder];
     } else if (queue.origin.kind === "favorites") {
       queryKey = ["posts", "favorites", queue.origin.tags ?? []];
     } else if (queue.origin.kind === "updates") {
@@ -1822,17 +1816,16 @@ export const ViewerDialog = () => {
     // Query keys are consistent with component query keys.
     // Keep this mapping in sync with page query keys to avoid cache drift.
     // - Search: ["search", tags, source]
-    // - Artist: ["posts", artistId, aiFilter, rating, mediaType, source, sortOrder]
+    // - Artist: ["posts", artistId, aiFilter, mediaType, source, sortOrder]
     // - Favorites/Updates: ["posts", <tab>, tags]
-    // - Playlist: ["playlist-posts", playlistId, mediaType, rating, aiFilter, sortOrder]
+    // - Playlist: ["playlist-posts", playlistId, mediaType, aiFilter, sortOrder]
     let queryKey: unknown[] = [];
     if (queue.origin.kind === "artist") {
       const aiFilter = queue.origin.aiFilter ?? "all";
-      const rating = queue.origin.rating ?? "all";
       const mediaType = queue.origin.mediaType ?? "all";
       const source = queue.origin.source ?? "all";
       const sortOrder = queue.origin.sortOrder ?? "desc";
-      queryKey = ["posts", queue.origin.artistId, aiFilter, rating, mediaType, source, sortOrder];
+      queryKey = ["posts", queue.origin.artistId, aiFilter, mediaType, source, sortOrder];
     } else if (queue.origin.kind === "favorites") {
       queryKey = ["posts", "favorites", queue.origin.tags ?? []];
     } else if (queue.origin.kind === "updates") {
@@ -1844,7 +1837,6 @@ export const ViewerDialog = () => {
         "playlist-posts",
         queue.origin.playlistId,
         queue.origin.mediaType ?? "all",
-        queue.origin.rating ?? "all",
         queue.origin.aiFilter ?? "all",
         queue.origin.sortOrder ?? "desc",
       ];

--- a/src/renderer/hooks/useWorkerProcessor.ts
+++ b/src/renderer/hooks/useWorkerProcessor.ts
@@ -7,11 +7,8 @@ import type { WorkerPost } from "../../shared/types/post";
  */
 export interface WorkerFilterConfig {
   aiFilter: "all" | "hide" | "only";
-  rating: "all" | "s" | "q" | "e";
   mediaType: "all" | "images" | "videos";
   source: "all" | "favorites" | "subscriptions";
-  dateFrom: Date | null;
-  dateTo: Date | null;
   sortOrder: "asc" | "desc";
   trackedTagsSet?: string[];
   tags?: string[];

--- a/src/renderer/store/searchStore.ts
+++ b/src/renderer/store/searchStore.ts
@@ -7,14 +7,10 @@ type MediaType = "all" | "images" | "videos";
 type SourceType = "all" | "favorites" | "subscriptions";
 type ViewType = "grid" | "masonry";
 type AiFilterType = "all" | "hide" | "only";
-type RatingType = "all" | "s" | "q" | "e";
 interface PostFilters {
   aiFilter: AiFilterType;
-  rating: RatingType;
   mediaType: MediaType;
   source: SourceType;
-  dateFrom: Date | null;
-  dateTo: Date | null;
 }
 
 export function buildBooruTagListForIpc(
@@ -59,11 +55,8 @@ export interface SearchState {
 
 const DEFAULT_FILTERS: PostFilters = {
   aiFilter: "all",
-  rating: "all",
   mediaType: "all",
   source: "all",
-  dateFrom: null,
-  dateTo: null,
 };
 
 const MAX_TOKEN_LENGTH = 200;

--- a/src/renderer/store/viewerStore.ts
+++ b/src/renderer/store/viewerStore.ts
@@ -15,7 +15,6 @@ export type ViewerOrigin =
       artistId: number;
       tags?: string[];
       aiFilter?: "all" | "hide" | "only";
-      rating?: "all" | "s" | "q" | "e";
       mediaType?: "all" | "images" | "videos";
       source?: "all" | "favorites" | "subscriptions";
       sortOrder?: "asc" | "desc";
@@ -24,7 +23,6 @@ export type ViewerOrigin =
       kind: "playlist";
       playlistId: number;
       mediaType?: "all" | "images" | "videos";
-      rating?: "all" | "s" | "q" | "e";
       aiFilter?: "all" | "hide" | "only";
       sortOrder?: "asc" | "desc";
       provider?: "rule34" | "gelbooru";

--- a/src/renderer/workers/data-processor.worker.ts
+++ b/src/renderer/workers/data-processor.worker.ts
@@ -38,11 +38,8 @@ interface WorkerResponse<T = unknown> {
 // Filter configuration type
 interface FilterConfig {
   aiFilter: "all" | "hide" | "only";
-  rating: "all" | "s" | "q" | "e";
   mediaType: "all" | "images" | "videos";
   source: "all" | "favorites" | "subscriptions";
-  dateFrom: Date | null;
-  dateTo: Date | null;
   sortOrder: "asc" | "desc";
   trackedTagsSet?: string[]; // Array of tracked tag strings (lowercase)
   tags?: string[]; // Active search tags for source filter
@@ -107,19 +104,6 @@ function getTimestamp(publishedAt: Date | number | null | undefined): number {
   return 0;
 }
 
-function getPublishedDate(
-  publishedAt: Date | number | null | undefined
-): Date | null {
-  if (publishedAt instanceof Date) {
-    return Number.isNaN(publishedAt.getTime()) ? null : publishedAt;
-  }
-  if (typeof publishedAt === "number") {
-    const parsed = new Date(publishedAt);
-    return Number.isNaN(parsed.getTime()) ? null : parsed;
-  }
-  return null;
-}
-
 /**
  * Filter and sort posts in a single efficient pass
  * Uses single-pass filter + sort for optimal performance
@@ -130,11 +114,8 @@ function filterAndSortPosts(
 ): WorkerPost[] {
   const {
     aiFilter,
-    rating,
     mediaType,
     source,
-    dateFrom,
-    dateTo,
     sortOrder,
     trackedTagsSet,
     tags,
@@ -150,12 +131,6 @@ function filterAndSortPosts(
     if (aiFilter === "hide" && hasAiGeneratedTag(post.tags)) return false;
     if (aiFilter === "only" && !hasAiGeneratedTag(post.tags)) return false;
 
-    // Rating filter
-    if (rating !== "all") {
-      const postRating = typeof post.rating === "string" ? post.rating.trim().toLowerCase().charAt(0) : "";
-      if (postRating !== rating) return false;
-    }
-    
     // Media type filter
     if (mediaType !== "all") {
       const isVideo = isVideoPost(post.fileUrl);
@@ -163,13 +138,6 @@ function filterAndSortPosts(
       if (mediaType === "images" && isVideo) return false;
     }
 
-    // Date range filter
-    const publishedDate = getPublishedDate(post.publishedAt);
-    if (publishedDate) {
-      if (dateFrom && publishedDate < dateFrom) return false;
-      if (dateTo && publishedDate > dateTo) return false;
-    }
-    
     // Source filter - only apply if there's an active search
     if (hasActiveSearch) {
       if (source === "favorites" && !post.isFavorited) return false;

--- a/src/shared/schemas/ipc.ts
+++ b/src/shared/schemas/ipc.ts
@@ -19,6 +19,5 @@ export const PaginationSchema = z.object({
 export const RatingSchema = z.enum(["s", "q", "e"]);
 export const MediaTypeSchema = z.enum(["all", "images", "videos"]);
 export const PostFiltersSchema = z.object({
-  rating: RatingSchema.optional(),
   mediaType: MediaTypeSchema.optional(),
 });

--- a/src/shared/schemas/playlist.ts
+++ b/src/shared/schemas/playlist.ts
@@ -158,7 +158,7 @@ export type MovePostsBetweenManualPlaylistsRequest = z.infer<
  * Get Playlist Posts Schema
  *
  * Single source of truth for GetPlaylistPosts validation and typing.
- * Supports playlist-scoped filtering by rating and media type.
+ * Supports playlist-scoped filtering by media type.
  */
 export const GetPlaylistPostsSchema = z.object({
   playlistId: IdSchema,
@@ -181,7 +181,7 @@ export type GetPlaylistPostsRequest = z.infer<typeof GetPlaylistPostsSchema>;
  *
  * Single source of truth for ResolvePlaylistPosts validation and typing.
  * Used to resolve posts for both static and smart playlists.
- * Includes optional rating and mediaType filters from renderer state.
+ * Includes optional mediaType filter from renderer state.
  */
 export const ResolvePlaylistPostsSchema = z.object({
   playlistId: IdSchema,

--- a/src/shared/schemas/post.ts
+++ b/src/shared/schemas/post.ts
@@ -49,7 +49,6 @@ export type PostData = z.infer<typeof PostDataSchema>;
 export const PostFilterSchema = z
   .object({
     tags: z.string().optional(),
-    rating: RatingSchema.optional(),
     isFavorited: z.boolean().optional(),
     isViewed: z.boolean().optional(),
     sinceTracking: z.boolean().optional(),


### PR DESCRIPTION
## Summary
- Remove dead local filter plumbing for rating, date range, and orientation. The Filters panel already only exposes Source / AI / Media; store, worker, gallery pages, viewer query keys, and IPC `PostFilterSchema` / `PostFiltersSchema` still carried unused fields that could never be set from UI.
- Post `rating` as data is unchanged (column, index, badges, Stats, Safe Mode blur). Booru search metatags (`rating:`, `width:`, `aspectratio:`) are unchanged.
- ViewerDialog query keys were kept in sync with ArtistGallery / PlaylistsPage after dropping the rating slot, to avoid a silent React Query cache miss.

## Test plan
- [ ] Restart Electron Main (IPC controllers changed; renderer HMR is not enough)
- [ ] Browse: toggle Source (All / Favorites / Subscriptions), AI Posts, Media — lists update as before
- [ ] Clear Filters resets Source/AI/Media and does not throw
- [ ] Open a post in the viewer from Browse — image loads, rating badge still visible
- [ ] Open one playlist — gallery renders; open a post from it
- [ ] Safe Mode still blurs q/e; Stats rating pie still populated