### PR TITLE
fix: sync CDN allowlists to real Gelbooru/Rule34 hosts via provider registry

### DIFF
--- a/docs/api-guide.md
+++ b/docs/api-guide.md
@@ -405,7 +405,7 @@ await window.api.wipeAllData();
 
 ### `getVideoProxyUrl(fileUrl: string)`
 
-Returns a `http://127.0.0.1` URL served by the main-process `VideoProxyServer` that forwards Range requests to the original HTTPS CDN and writes complete responses under `{userData}/video-cache/` via **atomic tmp + rename** (incomplete/aborted downloads never become cache hits). Cache size is bounded by `VIDEO_CACHE_MAX_BYTES` with eviction from the maintenance scheduler and a deferred sweep after proxy `start()`. The renderer should use the returned value as the `<video src>` (with a temporary fallback to the direct CDN URL while this promise resolves). Input is validated with `z.string().url()`. Only the same host allowlist enforced by the proxy is permitted; other URLs are rejected with HTTP 400 if passed through the proxy.
+Returns a `http://127.0.0.1` URL served by the main-process `VideoProxyServer` that forwards Range requests to the original HTTPS CDN and writes complete responses under `{userData}/video-cache/` via **atomic tmp + rename** (incomplete/aborted downloads never become cache hits). Cache size is bounded by `VIDEO_CACHE_MAX_BYTES` with eviction from the maintenance scheduler and a deferred sweep after proxy `start()`. The renderer should use the returned value as the `<video src>` (with a temporary fallback to the direct CDN URL while this promise resolves). Input is validated with `z.string().url()`. The proxy allowlist is the exact hostnames from `provider.allowedDomains` (via `getAllProviderDomains()`); other URLs are rejected with HTTP 400 if passed through the proxy.
 
 **Returns:** `Promise<string>`
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -608,6 +608,7 @@ const posts = await db.query.posts.findMany({
    - Provider pattern abstraction for multi-booru support
    - `IBooruProvider` interface for standardized booru operations
    - Implementations: `Rule34Provider`, `GelbooruProvider`
+   - `allowedDomains` is the single host list for CSP (`getAllProviderDomains`) and video-proxy `isAllowedCdnUrl` (exact hostname match, no suffix wildcard). Gelbooru media CDN is `img4.gelbooru.com`; `gelbooru.com` is the API/site host.
    - Methods: `checkAuth`, `fetchPosts`, `searchTags`, `formatTag`
    - Shared request pacing via `ProviderThrottle` (~1200ms + jitter) and session UA via `pickRandomUA()`
    - **Priorities:** `user` (Sync `fetchPosts`, Browse/search `fetchPosts`, autocomplete) drains before `background` (tag-resolve). Same min-interval; order only.
@@ -617,7 +618,7 @@ const posts = await db.query.posts.findMany({
 
    - Local HTTP proxy for video playback with on-disk `video-cache/` under `.rdcache`
    - Atomic cache writes (tmp+rename), abort cleanup, eviction capped by `VIDEO_CACHE_MAX_BYTES` (2 GiB) in `src/main/config/constants.ts`
-   - Allowlists Rule34 media hosts; does not rewrite stored post URLs at sync time
+   - Host allowlist is derived from `provider.allowedDomains` (exact match, cached at module load). Does not rewrite stored post URLs at sync time.
 
 10. **Updater Service** (`src/main/services/updater-service.ts`)
 
@@ -1760,7 +1761,7 @@ Root:
 - **Database Backup/Restore:** Manual backup and restore with integrity checks; automatic rotation of timestamped backup files using configurable `backupRetention` (`1..20`)
 - **DB Maintenance (VACUUM):** User-visible status, manual trigger, and persisted schedule (`manual`, `weekly`, `monthly`)
 - **Context Isolation:** Enabled globally with sandbox mode
-- **CSP:** Strict Content Security Policy in production, relaxed for development (HMR support)
+- **CSP:** Built from `getAllProviderDomains()` (`img-src` / `media-src` / `connect-src`); production is strict, development is relaxed for HMR
 - **IPC Architecture:** Controller-based IPC handlers with `BaseController` for centralized error handling
 
 **Data Integrity & Sync:**

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -228,6 +228,7 @@ Items explicitly scheduled for product/engineering (beyond small bugs).
 | **Backups** | `keep last N` is implemented; optional **total-size cap** is also supported via `BACKUP_RETENTION_MAX_TOTAL_MB` env for deployments that need hard storage ceilings (retained-only size accounting; newest backup always kept even if alone over cap). UI exposure for this cap remains optional future UX work. |
 | **Engineering** | Ongoing tooling hygiene; remaining shared validation consolidation as needed. |
 | **Testing** | Host-gate feedback covered: `vi.spyOn(ProviderThrottle.prototype, "notifyRateLimited")` asserts real 429 notify calls in `rule34-provider-fetch-posts.test.ts` and `gelbooru-provider-fetch-posts.test.ts` (closed after coverage gap noted post-[#126](https://github.com/KazeKaze93/RuleDesk/pull/126)). |
+| **Testing** | Live Gelbooru video-proxy check was not run (Gelbooru API key required); unit tests cover allowlist logic only. |
 | **Media filters (P3)** | Browse worker video regex (`mp4\|webm\|mov` in `data-processor.worker.ts`) is narrower than canonical `VIDEO_EXTENSIONS` in `src/shared/utils/media.ts` — align when touching the worker. |
 | **Product** | **Smart Collections AI** (research). |
 

--- a/src/main/config/allowed-hosts.ts
+++ b/src/main/config/allowed-hosts.ts
@@ -1,7 +1,11 @@
 /**
- * Allowed hosts for external URL opening
- * This whitelist prevents opening arbitrary URLs and protects against XSS/SSRF attacks
- * 
+ * Allowed hosts for shell.openExternal (user-initiated browser tabs).
+ * This whitelist prevents opening arbitrary URLs and protects against XSS/SSRF attacks.
+ *
+ * Intentionally separate from provider.allowedDomains: that list is what the app
+ * may fetch (CSP + video-proxy). This list is what the user may open themselves.
+ * Do not sync the two — different trust boundaries (user click vs app-originated request).
+ *
  * To add new hosts, add them to this array. Only HTTPS URLs are allowed.
  */
 

--- a/src/main/providers/gelbooru-provider.ts
+++ b/src/main/providers/gelbooru-provider.ts
@@ -72,11 +72,10 @@ function axiosHeadersToRetryAfterRecord(
 export class GelbooruProvider implements IBooruProvider {
   readonly id = "gelbooru";
   readonly name = "Gelbooru";
+  /** `gelbooru.com` is the API/site host; `img4.gelbooru.com` is the live media CDN. */
   readonly allowedDomains = [
     "gelbooru.com",
-    "img1.gelbooru.com",
-    "img2.gelbooru.com",
-    "img3.gelbooru.com",
+    "img4.gelbooru.com",
   ];
   private readonly baseUrl = "https://gelbooru.com/index.php";
   private readonly throttle = new ProviderThrottle();

--- a/src/main/providers/rule34-provider.ts
+++ b/src/main/providers/rule34-provider.ts
@@ -45,6 +45,7 @@ interface R34AutocompleteItem {
 export class Rule34Provider implements IBooruProvider {
   readonly id = "rule34";
   readonly name = "Rule34.xxx";
+  /** Exact hosts for CSP and video-proxy; no suffix wildcard. */
   readonly allowedDomains = [
     "rule34.xxx",
     "api.rule34.xxx",

--- a/src/main/providers/types.ts
+++ b/src/main/providers/types.ts
@@ -20,7 +20,10 @@ export interface ProviderSettings {
 export interface IBooruProvider {
   id: string;
   name: string;
-  /** Domains this provider is allowed to load media/connect from */
+  /**
+   * Exact hostnames this provider may load media/connect from.
+   * Single source for CSP (`getAllProviderDomains`) and video-proxy `isAllowedCdnUrl`.
+   */
   readonly allowedDomains: string[];
   /** Validates provided credentials against the API */
   checkAuth(settings: ProviderSettings): Promise<boolean>;

--- a/src/main/services/video-proxy-server.ts
+++ b/src/main/services/video-proxy-server.ts
@@ -9,6 +9,7 @@ import { app } from "electron";
 import log from "electron-log";
 import type { AddressInfo } from "node:net";
 import { tryParseHttpsUrlHostname } from "../../shared/utils/url-host";
+import { getAllProviderDomains } from "../providers";
 import {
   VIDEO_CACHE_EVICT_AFTER_START_MS,
   VIDEO_CACHE_MAX_BYTES,
@@ -17,7 +18,8 @@ import {
 
 const VIDEO_PATH = "/video";
 const PROXY_HOST = "127.0.0.1";
-const GELBOORU_IMG_HOSTS = new Set<string>(["img2.gelbooru.com", "img3.gelbooru.com", "img4.gelbooru.com"]);
+/** Cached at module load — `isAllowedCdnUrl` is on the video request hot path. */
+const ALLOWED_CDN_HOSTS = new Set(getAllProviderDomains());
 
 const VIDEO_CONTENT_TYPE = "video/mp4";
 const CACHE_BIN_SUFFIX = ".bin";
@@ -41,13 +43,7 @@ function isAllowedCdnUrl(urlString: string): boolean {
   if (!host) {
     return false;
   }
-  if (GELBOORU_IMG_HOSTS.has(host)) {
-    return true;
-  }
-  if (host === "rule34.xxx" || host.endsWith(".rule34.xxx")) {
-    return true;
-  }
-  return false;
+  return ALLOWED_CDN_HOSTS.has(host);
 }
 
 type RangeResult =

--- a/tests/unit/providers/gelbooru-provider-fetch-posts.test.ts
+++ b/tests/unit/providers/gelbooru-provider-fetch-posts.test.ts
@@ -1,6 +1,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import axios, { AxiosError } from "axios";
 import { GelbooruProvider } from "@/main/providers/gelbooru-provider";
+import { getAllProviderDomains } from "@/main/providers";
 import { ProviderThrottle } from "@/main/providers/provider-throttle";
 
 vi.mock("electron-log", () => ({
@@ -29,9 +30,9 @@ const axiosGetMock = vi.spyOn(axios, "get");
 
 const SAMPLE_GELBOORU_POST = {
   id: 42,
-  file_url: "https://img3.gelbooru.com/images/ab/cd/abcd1234.jpg",
-  sample_url: "https://img3.gelbooru.com/samples/ab/cd/sample_abcd1234.jpg",
-  preview_url: "https://img3.gelbooru.com/thumbnails/ab/cd/thumbnail_abcd1234.jpg",
+  file_url: "https://img4.gelbooru.com/images/ab/cd/abcd1234.jpg",
+  sample_url: "https://img4.gelbooru.com/samples/ab/cd/sample_abcd1234.jpg",
+  preview_url: "https://img4.gelbooru.com/thumbnails/ab/cd/thumbnail_abcd1234.jpg",
   tags: "solo 1girl",
   rating: "q",
   score: 10,
@@ -43,6 +44,18 @@ const SAMPLE_GELBOORU_POST = {
 describe("GelbooruProvider.fetchPosts rate-limit classification", () => {
   const provider = new GelbooruProvider();
   const settings = { userId: "1", apiKey: "test-key" };
+
+  it("lists only the live API host and img4 CDN", () => {
+    expect(provider.allowedDomains).toEqual([
+      "gelbooru.com",
+      "img4.gelbooru.com",
+    ]);
+    const domains = getAllProviderDomains();
+    expect(domains).toContain("img4.gelbooru.com");
+    expect(domains).not.toContain("img1.gelbooru.com");
+    expect(domains).not.toContain("img2.gelbooru.com");
+    expect(domains).not.toContain("img3.gelbooru.com");
+  });
 
   beforeEach(() => {
     axiosGetMock.mockReset();

--- a/tests/unit/services/video-proxy-server.test.ts
+++ b/tests/unit/services/video-proxy-server.test.ts
@@ -21,7 +21,27 @@ vi.mock("electron-log", () => ({
     error: vi.fn(),
     warn: vi.fn(),
     debug: vi.fn(),
+    transports: {
+      main: { level: false },
+      renderer: { level: false },
+      file: { level: "info", resolvePathFn: vi.fn() },
+      console: { format: "" },
+    },
+    errorHandler: { startCatching: vi.fn() },
   },
+}));
+
+vi.mock("@/main/lib/logger", () => ({
+  logger: {
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    debug: vi.fn(),
+  },
+}));
+
+vi.mock("@/main/lib/proxy", () => ({
+  getProxyAgent: vi.fn(() => undefined),
 }));
 
 import { VideoProxyServer } from "../../../src/main/services/video-proxy-server";
@@ -220,14 +240,29 @@ describe("VideoProxyServer cache integrity", () => {
     expect(fs.readdirSync(cacheDir)).toEqual([]);
   });
 
-  it("rejects disallowed CDN hosts with 400", async () => {
-    const url = proxy.getProxyUrl("https://evil.example/video.mp4");
+  async function proxyStatus(fileUrl: string): Promise<number> {
+    const url = proxy.getProxyUrl(fileUrl);
     const result = await new Promise<{ status: number }>((resolve, reject) => {
       http.get(url, (res) => {
         void readResponse(res).then((r) => resolve({ status: r.status }), reject);
       }).on("error", reject);
     });
-    expect(result.status).toBe(400);
+    return result.status;
+  }
+
+  it("rejects disallowed CDN hosts with 400", async () => {
+    expect(await proxyStatus("https://evil.example/video.mp4")).toBe(400);
+  });
+
+  it.each([
+    ["https://img4.gelbooru.com/images/x.webm", 200],
+    ["https://wimg.rule34.xxx/video.mp4", 200],
+    ["https://img1.gelbooru.com/images/x.webm", 400],
+    ["https://img2.gelbooru.com/images/x.webm", 400],
+    ["https://img3.gelbooru.com/images/x.webm", 400],
+    ["https://cdn-unknown.rule34.xxx/video.mp4", 400],
+  ])("provider-derived allowlist %s -> %i", async (fileUrl, status) => {
+    expect(await proxyStatus(fileUrl)).toBe(status);
   });
 
   it("does not leave truncated cache when client aborts mid-download", async () => {


### PR DESCRIPTION
## Summary
- Gelbooru `allowedDomains` now lists the live hosts only (`gelbooru.com` API + `img4.gelbooru.com` CDN). Dead `img1`/`img2`/`img3` are gone.
- Video-proxy `isAllowedCdnUrl` is an exact-match Set from `getAllProviderDomains()` (cached at module load). Rule34 no longer uses a `*.rule34.xxx` suffix wildcard.
- `ALLOWED_HOSTS` (openExternal) is unchanged; comment documents why it stays a separate trust boundary.
- Live Gelbooru video-proxy check was not run (API key required). Tracked in `docs/roadmap.md`.

## Test plan
- [x] `npm run typecheck` / `lint` / `test` (246 passed)
- [x] Unit: `img4.gelbooru.com` allowed; `img1`/`img2`/`img3` and `cdn-unknown.rule34.xxx` rejected
- [ ] Live Gelbooru image/video through the proxy (needs Gelbooru API key; not a merge blocker)
