### PR TITLE
fix: scope video-proxy allowlist to CDN hosts, exclude API/apex domains

### DIFF
--- a/docs/api-guide.md
+++ b/docs/api-guide.md
@@ -405,7 +405,7 @@ await window.api.wipeAllData();
 
 ### `getVideoProxyUrl(fileUrl: string)`
 
-Returns a `http://127.0.0.1` URL served by the main-process `VideoProxyServer` that forwards Range requests to the original HTTPS CDN and writes complete responses under `{userData}/video-cache/` via **atomic tmp + rename** (incomplete/aborted downloads never become cache hits). Cache size is bounded by `VIDEO_CACHE_MAX_BYTES` with eviction from the maintenance scheduler and a deferred sweep after proxy `start()`. The renderer should use the returned value as the `<video src>` (with a temporary fallback to the direct CDN URL while this promise resolves). Input is validated with `z.string().url()`. The proxy allowlist is the exact hostnames from `provider.allowedDomains` (via `getAllProviderDomains()`); other URLs are rejected with HTTP 400 if passed through the proxy.
+Returns a `http://127.0.0.1` URL served by the main-process `VideoProxyServer` that forwards Range requests to the original HTTPS CDN and writes complete responses under `{userData}/video-cache/` via **atomic tmp + rename** (incomplete/aborted downloads never become cache hits). Cache size is bounded by `VIDEO_CACHE_MAX_BYTES` with eviction from the maintenance scheduler and a deferred sweep after proxy `start()`. The renderer should use the returned value as the `<video src>` (with a temporary fallback to the direct CDN URL while this promise resolves). Input is validated with `z.string().url()`. The proxy allowlist is the exact media-CDN hostnames from `provider.cdnDomains` (via `getAllProviderCdnDomains()`); API/apex hosts remain in CSP via `getAllProviderDomains()` but are rejected with HTTP 400 if passed through the proxy.
 
 **Returns:** `Promise<string>`
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -608,7 +608,7 @@ const posts = await db.query.posts.findMany({
    - Provider pattern abstraction for multi-booru support
    - `IBooruProvider` interface for standardized booru operations
    - Implementations: `Rule34Provider`, `GelbooruProvider`
-   - `allowedDomains` is the single host list for CSP (`getAllProviderDomains`) and video-proxy `isAllowedCdnUrl` (exact hostname match, no suffix wildcard). Gelbooru media CDN is `img4.gelbooru.com`; `gelbooru.com` is the API/site host.
+   - `allowedDomains` is the full host list for CSP (`getAllProviderDomains`: API + CDN). `cdnDomains` is the media-CDN subset for video-proxy `isAllowedCdnUrl` (`getAllProviderCdnDomains`; exact hostname match, no suffix wildcard). Gelbooru media CDN is `img4.gelbooru.com`; `gelbooru.com` is the API/site host and is not proxied.
    - Methods: `checkAuth`, `fetchPosts`, `searchTags`, `formatTag`
    - Shared request pacing via `ProviderThrottle` (~1200ms + jitter) and session UA via `pickRandomUA()`
    - **Priorities:** `user` (Sync `fetchPosts`, Browse/search `fetchPosts`, autocomplete) drains before `background` (tag-resolve). Same min-interval; order only.
@@ -618,7 +618,7 @@ const posts = await db.query.posts.findMany({
 
    - Local HTTP proxy for video playback with on-disk `video-cache/` under `.rdcache`
    - Atomic cache writes (tmp+rename), abort cleanup, eviction capped by `VIDEO_CACHE_MAX_BYTES` (2 GiB) in `src/main/config/constants.ts`
-   - Host allowlist is derived from `provider.allowedDomains` (exact match, cached at module load). Does not rewrite stored post URLs at sync time.
+   - Host allowlist is derived from `provider.cdnDomains` via `getAllProviderCdnDomains` (exact match, cached at module load). API/apex hosts such as `api.rule34.xxx` and `gelbooru.com` are CSP-only. Does not rewrite stored post URLs at sync time.
 
 10. **Updater Service** (`src/main/services/updater-service.ts`)
 

--- a/src/main/config/allowed-hosts.ts
+++ b/src/main/config/allowed-hosts.ts
@@ -2,8 +2,9 @@
  * Allowed hosts for shell.openExternal (user-initiated browser tabs).
  * This whitelist prevents opening arbitrary URLs and protects against XSS/SSRF attacks.
  *
- * Intentionally separate from provider.allowedDomains: that list is what the app
- * may fetch (CSP + video-proxy). This list is what the user may open themselves.
+ * Intentionally separate from provider.allowedDomains / provider.cdnDomains:
+ * those lists are what the app may fetch (CSP vs video-proxy). This list is
+ * what the user may open themselves.
  * Do not sync the two — different trust boundaries (user click vs app-originated request).
  *
  * To add new hosts, add them to this array. Only HTTPS URLs are allowed.

--- a/src/main/providers/gelbooru-provider.ts
+++ b/src/main/providers/gelbooru-provider.ts
@@ -77,6 +77,10 @@ export class GelbooruProvider implements IBooruProvider {
     "gelbooru.com",
     "img4.gelbooru.com",
   ];
+  /** Media CDN only — video-proxy must not fetch the API/apex host. */
+  readonly cdnDomains = [
+    "img4.gelbooru.com",
+  ];
   private readonly baseUrl = "https://gelbooru.com/index.php";
   private readonly throttle = new ProviderThrottle();
   private readonly sessionUA = pickRandomUA();

--- a/src/main/providers/index.ts
+++ b/src/main/providers/index.ts
@@ -21,6 +21,10 @@ export function getAllProviderDomains(): string[] {
   return [...new Set(PROVIDERS.flatMap((provider) => provider.allowedDomains))];
 }
 
+export function getAllProviderCdnDomains(): string[] {
+  return [...new Set(PROVIDERS.flatMap((provider) => provider.cdnDomains))];
+}
+
 export type {
   IBooruProvider,
   BooruPost,

--- a/src/main/providers/rule34-provider.ts
+++ b/src/main/providers/rule34-provider.ts
@@ -45,10 +45,18 @@ interface R34AutocompleteItem {
 export class Rule34Provider implements IBooruProvider {
   readonly id = "rule34";
   readonly name = "Rule34.xxx";
-  /** Exact hosts for CSP and video-proxy; no suffix wildcard. */
+  /** Exact hosts for CSP (`getAllProviderDomains`); API + CDN, no suffix wildcard. */
   readonly allowedDomains = [
     "rule34.xxx",
     "api.rule34.xxx",
+    "img.rule34.xxx",
+    "wimg.rule34.xxx",
+    "us.rule34.xxx",
+    "api-cdn.rule34.xxx",
+  ];
+  /** Media CDN hosts for video-proxy; excludes the API host. */
+  readonly cdnDomains = [
+    "rule34.xxx",
     "img.rule34.xxx",
     "wimg.rule34.xxx",
     "us.rule34.xxx",

--- a/src/main/providers/types.ts
+++ b/src/main/providers/types.ts
@@ -21,10 +21,15 @@ export interface IBooruProvider {
   id: string;
   name: string;
   /**
-   * Exact hostnames this provider may load media/connect from.
-   * Single source for CSP (`getAllProviderDomains`) and video-proxy `isAllowedCdnUrl`.
+   * Exact hostnames this provider may load media/connect from (API + CDN).
+   * Source for CSP via `getAllProviderDomains`.
    */
   readonly allowedDomains: string[];
+  /**
+   * Media CDN hostnames for the video-proxy SSRF gate (via `getAllProviderCdnDomains`).
+   * Subset of `allowedDomains`; excludes API endpoints the proxy must not fetch.
+   */
+  readonly cdnDomains: string[];
   /** Validates provided credentials against the API */
   checkAuth(settings: ProviderSettings): Promise<boolean>;
   /** Fetches posts based on tags and page. Callers must pass an explicit page size. */

--- a/src/main/services/video-proxy-server.ts
+++ b/src/main/services/video-proxy-server.ts
@@ -9,7 +9,7 @@ import { app } from "electron";
 import log from "electron-log";
 import type { AddressInfo } from "node:net";
 import { tryParseHttpsUrlHostname } from "../../shared/utils/url-host";
-import { getAllProviderDomains } from "../providers";
+import { getAllProviderCdnDomains } from "../providers";
 import {
   VIDEO_CACHE_EVICT_AFTER_START_MS,
   VIDEO_CACHE_MAX_BYTES,
@@ -19,7 +19,7 @@ import {
 const VIDEO_PATH = "/video";
 const PROXY_HOST = "127.0.0.1";
 /** Cached at module load — `isAllowedCdnUrl` is on the video request hot path. */
-const ALLOWED_CDN_HOSTS = new Set(getAllProviderDomains());
+const ALLOWED_CDN_HOSTS = new Set(getAllProviderCdnDomains());
 
 const VIDEO_CONTENT_TYPE = "video/mp4";
 const CACHE_BIN_SUFFIX = ".bin";

--- a/tests/unit/providers/gelbooru-provider-fetch-posts.test.ts
+++ b/tests/unit/providers/gelbooru-provider-fetch-posts.test.ts
@@ -1,7 +1,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import axios, { AxiosError } from "axios";
 import { GelbooruProvider } from "@/main/providers/gelbooru-provider";
-import { getAllProviderDomains } from "@/main/providers";
+import { getAllProviderCdnDomains, getAllProviderDomains } from "@/main/providers";
 import { ProviderThrottle } from "@/main/providers/provider-throttle";
 
 vi.mock("electron-log", () => ({
@@ -50,11 +50,17 @@ describe("GelbooruProvider.fetchPosts rate-limit classification", () => {
       "gelbooru.com",
       "img4.gelbooru.com",
     ]);
+    expect(provider.cdnDomains).toEqual(["img4.gelbooru.com"]);
     const domains = getAllProviderDomains();
     expect(domains).toContain("img4.gelbooru.com");
+    expect(domains).toContain("gelbooru.com");
     expect(domains).not.toContain("img1.gelbooru.com");
     expect(domains).not.toContain("img2.gelbooru.com");
     expect(domains).not.toContain("img3.gelbooru.com");
+    const cdnDomains = getAllProviderCdnDomains();
+    expect(cdnDomains).toContain("img4.gelbooru.com");
+    expect(cdnDomains).not.toContain("gelbooru.com");
+    expect(cdnDomains).not.toContain("api.rule34.xxx");
   });
 
   beforeEach(() => {

--- a/tests/unit/providers/rule34-provider-fetch-posts.test.ts
+++ b/tests/unit/providers/rule34-provider-fetch-posts.test.ts
@@ -32,6 +32,18 @@ describe("Rule34Provider.fetchPosts error classification", () => {
   const provider = new Rule34Provider();
   const settings = { userId: "1", apiKey: "test-key" };
 
+  it("keeps API host in CSP allowlist but out of video-proxy CDN list", () => {
+    expect(provider.allowedDomains).toContain("api.rule34.xxx");
+    expect(provider.cdnDomains).not.toContain("api.rule34.xxx");
+    expect(provider.cdnDomains).toEqual([
+      "rule34.xxx",
+      "img.rule34.xxx",
+      "wimg.rule34.xxx",
+      "us.rule34.xxx",
+      "api-cdn.rule34.xxx",
+    ]);
+  });
+
   beforeEach(() => {
     axiosGetMock.mockReset();
   });

--- a/tests/unit/services/video-proxy-server.test.ts
+++ b/tests/unit/services/video-proxy-server.test.ts
@@ -257,11 +257,21 @@ describe("VideoProxyServer cache integrity", () => {
   it.each([
     ["https://img4.gelbooru.com/images/x.webm", 200],
     ["https://wimg.rule34.xxx/video.mp4", 200],
+    ["https://us.rule34.xxx/video.mp4", 200],
+    ["https://api-cdn.rule34.xxx/video.mp4", 200],
+    ["https://img.rule34.xxx/video.mp4", 200],
     ["https://img1.gelbooru.com/images/x.webm", 400],
     ["https://img2.gelbooru.com/images/x.webm", 400],
     ["https://img3.gelbooru.com/images/x.webm", 400],
     ["https://cdn-unknown.rule34.xxx/video.mp4", 400],
-  ])("provider-derived allowlist %s -> %i", async (fileUrl, status) => {
+  ])("provider-derived CDN allowlist %s -> %i", async (fileUrl, status) => {
+    expect(await proxyStatus(fileUrl)).toBe(status);
+  });
+
+  it.each([
+    ["https://api.rule34.xxx/index.php?page=dapi&s=post&q=index", 400],
+    ["https://gelbooru.com/index.php?page=dapi&s=post&q=index", 400],
+  ])("rejects API/apex hosts that CSP allows but video-proxy must not fetch %s", async (fileUrl, status) => {
     expect(await proxyStatus(fileUrl)).toBe(status);
   });
 


### PR DESCRIPTION
## Summary
- Split provider host lists: `allowedDomains` stays the full CSP source (API + CDN); new `cdnDomains` is the media-CDN subset for the video-proxy SSRF gate.
- Video-proxy now reads `getAllProviderCdnDomains()` (load-time `ALLOWED_CDN_HOSTS` cache unchanged). CSP `buildCspPolicy` still uses `getAllProviderDomains()` — not touched.
- Rule34 `cdnDomains` omits `api.rule34.xxx`; Gelbooru `cdnDomains` is only `img4.gelbooru.com`.

## Test plan
- [x] Video-proxy allows `img4.gelbooru.com`, `wimg` / `us` / `api-cdn` / `img.rule34.xxx`
- [x] New regression: `rejects API/apex hosts that CSP allows but video-proxy must not fetch` — `api.rule34.xxx` and `gelbooru.com` return 400
- [x] CSP still covers API + CDN via `getAllProviderDomains()`
- [x] `npm run typecheck` / `lint` / `test` green (252 tests)
