### PR TITLE
fix: artist never-synced badge + optional auto-sync on add

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,6 +173,8 @@ Post cards in gallery views include informative overlays:
 
 When enabled in **Settings → Sync**, the app starts a full **Sync All** after the main window is ready (if no sync is already running). Progress uses the same sync pipeline as manual sync.
 
+Optional **Sync new artist automatically** (off by default) queues `repairArtist` for each newly added artist via the same exclusive sync mutex — it does not block the add-artist IPC response.
+
 ### ✅ Periodic background sync
 
 **Settings → Sync → Sync interval** controls how often a background full sync runs (Disabled, 15 / 30 / 60 / 120 minutes). The main process enforces a **minimum interval of 5 minutes** (`MIN_INTERVAL_MINUTES` in `SyncScheduler`); values below that are treated as disabled. Rate limiting and backoff in `SyncService` / `ProviderThrottle` apply to scheduled runs as well as manual ones.
@@ -196,6 +198,7 @@ Settings are organized into tabs for faster scanning and lower cognitive load:
 ### Sync
 
 - **Sync on startup** - Toggle automatic sync when app opens
+- **Sync new artist automatically** - Queue sync for an artist right after it is added (off by default)
 - **Sync interval** - Disabled, 15 / 30 / 60 / 120 minutes
 - **Sync now** - Manual trigger in the sidebar with live `Last sync` relative time
 

--- a/docs/api-guide.md
+++ b/docs/api-guide.md
@@ -232,6 +232,7 @@ interface IpcBridge {
     apiKey?: string;
     proxyUrl?: string | null;
     autoSyncOnStartup?: boolean;
+    autoSyncOnArtistAdd?: boolean;
     syncIntervalMinutes?: number;
   }) => Promise<boolean>;
   confirmLegal: () => Promise<IpcSettings>;
@@ -577,6 +578,7 @@ type IpcSettings = {
   downloadFolderStructure: "flat" | "{artist_id}";
   theme: "system" | "light" | "dark";
   autoSyncOnStartup: boolean;
+  autoSyncOnArtistAdd: boolean;
   syncIntervalMinutes: number;
   backupRetention: number;
 };
@@ -656,6 +658,7 @@ Saves settings to the database. Supports partial updates (credentials, sync opti
 - `creds.apiKey?: string` - Rule34.xxx API Key (encrypted before storage)
 - `creds.proxyUrl?: string | null` - Optional outbound proxy URL
 - `creds.autoSyncOnStartup?: boolean` - Auto-sync startup toggle
+- `creds.autoSyncOnArtistAdd?: boolean` - Auto-sync newly added artists (default off)
 - `creds.syncIntervalMinutes?: number` - Periodic sync interval in minutes
 - `creds.backupRetention?: number` - Number of backups to keep (1..20)
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1048,6 +1048,7 @@ sequenceDiagram
        .returning();
      ```
    - Database returns the new artist with generated ID
+   - If Settings `autoSyncOnArtistAdd` is enabled and API credentials are configured, Main fire-and-forgets `SyncService.repairArtist(id)` (queued via `runExclusive`; does not block the IPC response). Default is off.
    - Response flows back to Renderer
 
 6. **Cache invalidation** - On success, component invalidates React Query cache:

--- a/docs/database.md
+++ b/docs/database.md
@@ -258,6 +258,9 @@ export const settings = sqliteTable("settings", {
   autoSyncOnStartup: integer("auto_sync_on_startup", { mode: "boolean" })
     .default(false)
     .notNull(),
+  autoSyncOnArtistAdd: integer("auto_sync_on_artist_add", { mode: "boolean" })
+    .default(false)
+    .notNull(),
   syncIntervalMinutes: integer("sync_interval_minutes").default(0).notNull(),
   backupRetention: integer("backup_retention").default(5).notNull(),
   vacuumSchedule: text("vacuum_schedule").default("manual"),

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -26,7 +26,7 @@ This document reflects the current roadmap for RuleDesk `v17.x` and is aligned w
 - ✅ Playlists, favorites, downloads, backup/restore, and full-screen viewer are implemented.
 - ✅ Playlists now include import/export, manual drag-and-drop reorder, and smart hybrid local+remote resolution.
 - ✅ Database is optimized for scale: WAL mode, FTS5, composite indexes, and migration workflow.
-- ✅ **Sync automation:** auto-sync on startup, periodic background sync (presets in Settings, minimum interval enforced in `SyncScheduler`), and sync scheduler restart when settings are saved.
+- ✅ **Sync automation:** auto-sync on startup, optional auto-sync when adding an artist (`autoSyncOnArtistAdd`, default off → `repairArtist` via `runExclusive`), periodic background sync (presets in Settings, minimum interval enforced in `SyncScheduler`), and sync scheduler restart when settings are saved.
 - ✅ **DB maintenance:** passive `WAL` checkpoint + `PRAGMA optimize` after startup (delayed) and on a daily timer (`MaintenanceScheduler`).
 - ✅ **Backup retention:** after each successful backup, older files are pruned based on `backupRetention` from Settings (`1..20`).
 - ✅ **User-visible DB maintenance:** Settings now exposes VACUUM status (last run timestamp/status/error), manual trigger, and schedule (`manual` / `weekly` / `monthly`).
@@ -231,6 +231,7 @@ Items explicitly scheduled for product/engineering (beyond small bugs).
 | **Testing** | Live Gelbooru video-proxy check was not run (Gelbooru API key required); unit tests cover allowlist logic only. |
 | **Media filters (P3)** | Browse worker video regex (`mp4\|webm\|mov` in `data-processor.worker.ts`) is narrower than canonical `VIDEO_EXTENSIONS` in `src/shared/utils/media.ts` — align when touching the worker. |
 | **Product** | **Smart Collections AI** (research). |
+| **Sync UX** | Live per-artist `syncStatus` (`syncing` / `error` / idle) written by `SyncService` during sync, with optional IPC push or query invalidation for a real-time **Syncing…** badge — separate from the static `lastChecked === null` → **Not synced yet** fix. |
 
 **Providers:** new sites must implement **`ProviderThrottle`**-class behavior; Rule34 and Gelbooru already share `ProviderThrottle` — not a “gap” unless adding a **third** backend.
 

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -139,7 +139,7 @@ That's it! You're now ready to use RuleDesk.
 
 4. Click **"Add"**
 
-The artist will appear in your tracked list!
+The artist will appear in your tracked list. Until the first successful sync finishes, the status badge shows **Not synced yet** (not green **Synced**). If **Sync new artist automatically** is enabled in Settings → Sync, RuleDesk queues that sync right after you add the artist.
 
 **Tip:** You can use the search box to find tags. Type a few letters and RuleDesk will suggest matching tags.
 
@@ -163,7 +163,8 @@ The artist will appear in your tracked list!
 
 1. Open **Settings** (sidebar) → **Sync**
 2. Enable **Sync on startup** if you want a full sync every time the app starts
-3. Set **Sync interval** to run background sync while the app is open (or leave **Disabled** and use **Sync All** in the sidebar when you want)
+3. Enable **Sync new artist automatically** if you want each newly added artist to sync immediately after tracking starts (off by default)
+4. Set **Sync interval** to run background sync while the app is open (or leave **Disabled** and use **Sync All** in the sidebar when you want)
 
 You can still run **Sync All** manually at any time; automatic runs use the same engine and rate limits.
 
@@ -439,6 +440,7 @@ Settings are split into tabs:
 ### Sync
 
 - **Sync on startup** - Run sync automatically when app starts
+- **Sync new artist automatically** - After adding an artist, queue a sync for that artist (off by default; uses the same exclusive sync queue as Repair)
 - **Sync interval** - Disabled, 15 / 30 / 60 / 120 minutes
 - **Sync now** - Manual sync trigger in the sidebar
 - **Last sync status** - Relative timestamp under the sidebar sync button (`never`, `X min ago`, etc.)

--- a/drizzle/0034_add_auto_sync_on_artist_add.sql
+++ b/drizzle/0034_add_auto_sync_on_artist_add.sql
@@ -1,0 +1,1 @@
+ALTER TABLE settings ADD COLUMN auto_sync_on_artist_add INTEGER NOT NULL DEFAULT 0;

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -232,6 +232,13 @@
       "when": 1778100000000,
       "tag": "0033_fix_fts_external_content_delete",
       "breakpoints": true
+    },
+    {
+      "idx": 34,
+      "version": "6",
+      "when": 1778200000000,
+      "tag": "0034_add_auto_sync_on_artist_add",
+      "breakpoints": true
     }
   ]
 }

--- a/src/main/db/schema.ts
+++ b/src/main/db/schema.ts
@@ -147,6 +147,9 @@ export const settings = sqliteTable("settings", {
   autoSyncOnStartup: integer("auto_sync_on_startup", { mode: "boolean" })
     .default(false)
     .notNull(),
+  autoSyncOnArtistAdd: integer("auto_sync_on_artist_add", { mode: "boolean" })
+    .default(false)
+    .notNull(),
   syncIntervalMinutes: integer("sync_interval_minutes").default(0).notNull(),
   backupRetention: integer("backup_retention").default(5).notNull(),
   vacuumSchedule: text("vacuum_schedule").default("manual"),

--- a/src/main/ipc/controllers/ArtistsController.ts
+++ b/src/main/ipc/controllers/ArtistsController.ts
@@ -4,7 +4,7 @@ import { z } from "zod";
 import { eq, or, sql } from "drizzle-orm";
 import { BaseController } from "../../core/ipc/BaseController";
 import { container, DI_TOKENS } from "../../core/di/Container";
-import { artists } from "../../db/schema";
+import { artists, settings, SETTINGS_ID } from "../../db/schema";
 import { escapeLikePattern } from "../../db/utils";
 import type { InferSelectModel, InferInsertModel } from "drizzle-orm";
 import {
@@ -15,6 +15,7 @@ import {
 import { IPC_CHANNELS } from "../channels";
 import type { BetterSQLite3Database } from "drizzle-orm/better-sqlite3";
 import type * as schema from "../../db/schema";
+import type { SyncService } from "../../services/sync-service";
 import { toIpcSafe } from "../../utils/ipc-serialization";
 import { getTrackedArtistsWithStats } from "../../db/queries/artists";
 import {
@@ -71,6 +72,10 @@ export class ArtistsController extends BaseController {
   // Query style: Drizzle Builder API only in this controller.
   private getDb(): AppDatabase {
     return container.resolve(DI_TOKENS.DB);
+  }
+
+  private getSyncService(): SyncService {
+    return container.resolve(DI_TOKENS.SYNC_SERVICE);
   }
 
   /**
@@ -200,12 +205,60 @@ export class ArtistsController extends BaseController {
       const inserted = result[0];
       log.info(`[ArtistsController] Artist added/updated: ${inserted.name}`);
 
+      this.maybeQueueAutoSyncOnArtistAdd(inserted.id);
+
       // Convert Date objects to numbers for Electron 39+ IPC serialization
       return toIpcSafe(inserted);
     } catch (error) {
       const msg = error instanceof Error ? error.message : String(error);
       log.error("[ArtistsController] Failed to add artist:", error);
       throw new Error(`Database error: ${msg}`);
+    }
+  }
+
+  /**
+   * Fire-and-forget repair sync when Settings.autoSyncOnArtistAdd is enabled.
+   * Uses repairArtist (runExclusive) — never syncArtist directly (FTS trigger races).
+   */
+  private maybeQueueAutoSyncOnArtistAdd(artistId: number): void {
+    try {
+      const db = this.getDb();
+      const currentSettings = db
+        .select()
+        .from(settings)
+        .where(eq(settings.id, SETTINGS_ID))
+        .limit(1)
+        .all()[0];
+
+      if (!currentSettings?.autoSyncOnArtistAdd) {
+        return;
+      }
+
+      const hasUserId = (currentSettings.userId ?? "").trim().length > 0;
+      const hasApiKey = (currentSettings.encryptedApiKey ?? "").trim().length > 0;
+      if (!hasUserId || !hasApiKey) {
+        log.debug(
+          `[ArtistsController] Skipping auto-sync on add for artist ${artistId}: credentials not configured`
+        );
+        return;
+      }
+
+      log.info(
+        `[ArtistsController] Queueing auto-sync on add for artist ${artistId}`
+      );
+      void this.getSyncService()
+        .repairArtist(artistId)
+        .catch((error: unknown) => {
+          log.error(
+            `[ArtistsController] Auto-sync on add failed for artist ${artistId}:`,
+            error
+          );
+        });
+    } catch (error) {
+      log.error(
+        `[ArtistsController] Failed to evaluate auto-sync on add for artist ${artistId}:`,
+        error
+      );
     }
   }
 

--- a/src/main/ipc/controllers/SettingsController.ts
+++ b/src/main/ipc/controllers/SettingsController.ts
@@ -106,6 +106,7 @@ function mapSettingsToIpc(
       z.enum(["flat", "{artist_id}"]).safeParse(dbSettings.downloadFolderStructure).data ?? "flat",
     theme: ThemePreferenceSchema.safeParse(dbSettings.theme).data ?? "system",
     autoSyncOnStartup: !!dbSettings.autoSyncOnStartup,
+    autoSyncOnArtistAdd: !!dbSettings.autoSyncOnArtistAdd,
     syncIntervalMinutes: dbSettings.syncIntervalMinutes ?? 0,
     backupRetention: dbSettings.backupRetention ?? 5,
   };
@@ -325,6 +326,8 @@ export class SettingsController extends BaseController {
           // Using explicit .set() for all fields to ensure they are updated
           const finalAutoSyncOnStartup =
             data.autoSyncOnStartup ?? existing.autoSyncOnStartup ?? false;
+          const finalAutoSyncOnArtistAdd =
+            data.autoSyncOnArtistAdd ?? existing.autoSyncOnArtistAdd ?? false;
           const finalSyncIntervalMinutes =
             data.syncIntervalMinutes ?? existing.syncIntervalMinutes ?? 0;
           const finalBackupRetention =
@@ -342,6 +345,7 @@ export class SettingsController extends BaseController {
               tosAcceptedAt: existing.tosAcceptedAt ?? null,
               theme: existing.theme ?? "system",
               autoSyncOnStartup: finalAutoSyncOnStartup,
+              autoSyncOnArtistAdd: finalAutoSyncOnArtistAdd,
               syncIntervalMinutes: finalSyncIntervalMinutes,
               backupRetention: finalBackupRetention,
             })
@@ -362,6 +366,7 @@ export class SettingsController extends BaseController {
               tosAcceptedAt: null,
               theme: "system",
               autoSyncOnStartup: data.autoSyncOnStartup ?? false,
+              autoSyncOnArtistAdd: data.autoSyncOnArtistAdd ?? false,
               syncIntervalMinutes: data.syncIntervalMinutes ?? 0,
               backupRetention: data.backupRetention ?? 5,
             })

--- a/src/renderer.d.ts
+++ b/src/renderer.d.ts
@@ -58,6 +58,7 @@ export interface IpcSettings {
   downloadFolderStructure: "flat" | "{artist_id}";
   theme: "system" | "light" | "dark";
   autoSyncOnStartup: boolean;
+  autoSyncOnArtistAdd: boolean;
   syncIntervalMinutes: number;
   backupRetention: number;
 }
@@ -76,6 +77,7 @@ export interface IpcApi extends IpcBridge {
     apiKey?: string;
     proxyUrl?: string | null;
     autoSyncOnStartup?: boolean;
+    autoSyncOnArtistAdd?: boolean;
     syncIntervalMinutes?: number;
     backupRetention?: number;
     provider?: ProviderId;

--- a/src/renderer/features/artists/components/ArtistListRow.tsx
+++ b/src/renderer/features/artists/components/ArtistListRow.tsx
@@ -2,6 +2,7 @@ import React, { useState } from "react";
 import {
   AlertTriangle,
   CheckCircle2,
+  Circle,
   Hash,
   RefreshCw,
   Search,
@@ -81,6 +82,17 @@ export const ArtistListRow: React.FC<ArtistListRowProps> = ({
             {artist.lastError}
           </TooltipContent>
         </Tooltip>
+      );
+    }
+
+    // lastChecked is set only after a successful pagination end (see SyncService).
+    // Null means the artist has never completed a sync — do not treat default idle as Synced.
+    if (artist.lastChecked === null) {
+      return (
+        <Badge variant="secondary" className="h-6 shrink-0 gap-1 text-xs">
+          <Circle className="w-3 h-3" />
+          Not synced yet
+        </Badge>
       );
     }
 

--- a/src/renderer/features/settings/Settings.tsx
+++ b/src/renderer/features/settings/Settings.tsx
@@ -48,6 +48,7 @@ export const Settings = () => {
   >("flat");
   const [databaseLocation, setDatabaseLocation] = useState<string>("");
   const [autoSyncOnStartup, setAutoSyncOnStartup] = useState(false);
+  const [autoSyncOnArtistAdd, setAutoSyncOnArtistAdd] = useState(false);
   const [syncIntervalMinutes, setSyncIntervalMinutes] = useState("0");
   const [backupRetention, setBackupRetention] = useState("5");
   const [autoBackupInterval, setAutoBackupInterval] = useState<AutoBackupInterval>("never");
@@ -82,6 +83,9 @@ export const Settings = () => {
       if (s?.downloadFolderStructure) setDownloadFolderStructure(s.downloadFolderStructure);
       if (s?.autoSyncOnStartup !== undefined) {
         setAutoSyncOnStartup(s.autoSyncOnStartup);
+      }
+      if (s?.autoSyncOnArtistAdd !== undefined) {
+        setAutoSyncOnArtistAdd(s.autoSyncOnArtistAdd);
       }
       if (s?.syncIntervalMinutes !== undefined) {
         setSyncIntervalMinutes(String(s.syncIntervalMinutes));
@@ -302,6 +306,17 @@ export const Settings = () => {
     }
   };
 
+  const handleAutoSyncOnArtistAddChange = async (checked: boolean): Promise<void> => {
+    const previousValue = autoSyncOnArtistAdd;
+    setAutoSyncOnArtistAdd(checked);
+    try {
+      await window.api.saveSettings({ autoSyncOnArtistAdd: checked });
+    } catch (error) {
+      log.error("[Settings] Failed to save auto sync on artist add:", error);
+      setAutoSyncOnArtistAdd(previousValue);
+    }
+  };
+
   const handleSyncIntervalChange = async (value: string): Promise<void> => {
     const previousValue = syncIntervalMinutes;
     setSyncIntervalMinutes(value);
@@ -512,9 +527,13 @@ export const Settings = () => {
         <TabsContent value="sync">
           <SettingsSyncTab
             autoSyncOnStartup={autoSyncOnStartup}
+            autoSyncOnArtistAdd={autoSyncOnArtistAdd}
             syncIntervalMinutes={syncIntervalMinutes}
             onAutoSyncChange={(checked) => {
               void handleAutoSyncOnStartupChange(checked);
+            }}
+            onAutoSyncOnArtistAddChange={(checked) => {
+              void handleAutoSyncOnArtistAddChange(checked);
             }}
             onSyncIntervalChange={(value) => {
               void handleSyncIntervalChange(value);

--- a/src/renderer/features/settings/SettingsSyncTab.tsx
+++ b/src/renderer/features/settings/SettingsSyncTab.tsx
@@ -11,15 +11,19 @@ import {
 
 interface SettingsSyncTabProps {
   autoSyncOnStartup: boolean;
+  autoSyncOnArtistAdd: boolean;
   syncIntervalMinutes: string;
   onAutoSyncChange: (checked: boolean) => void;
+  onAutoSyncOnArtistAddChange: (checked: boolean) => void;
   onSyncIntervalChange: (value: string) => void;
 }
 
 export const SettingsSyncTab = ({
   autoSyncOnStartup,
+  autoSyncOnArtistAdd,
   syncIntervalMinutes,
   onAutoSyncChange,
+  onAutoSyncOnArtistAddChange,
   onSyncIntervalChange,
 }: SettingsSyncTabProps) => {
   return (
@@ -40,6 +44,20 @@ export const SettingsSyncTab = ({
             id="auto-sync-on-startup"
             checked={autoSyncOnStartup}
             onCheckedChange={onAutoSyncChange}
+          />
+        </section>
+
+        <section className="flex items-start justify-between gap-4 rounded-md border p-4">
+          <section className="space-y-1">
+            <Label htmlFor="auto-sync-on-artist-add">Sync new artist automatically</Label>
+            <p className="text-sm text-muted-foreground">
+              Automatically sync a new artist right after adding it.
+            </p>
+          </section>
+          <Switch
+            id="auto-sync-on-artist-add"
+            checked={autoSyncOnArtistAdd}
+            onCheckedChange={onAutoSyncOnArtistAddChange}
           />
         </section>
 

--- a/src/shared/schemas/settings.ts
+++ b/src/shared/schemas/settings.ts
@@ -78,6 +78,7 @@ export const SaveSettingsSchema = z.object({
     .optional(),
   proxyUrl: z.string().url().nullable().optional(),
   autoSyncOnStartup: z.boolean().optional(),
+  autoSyncOnArtistAdd: z.boolean().optional(),
   syncIntervalMinutes: z.number().int().min(0).max(1440).optional(),
   backupRetention: z.number().int().min(1).max(20).optional(),
   provider: z.enum(PROVIDER_IDS).optional(),
@@ -108,6 +109,7 @@ export const IpcSettingsSchema = z.object({
   downloadFolderStructure: z.enum(["flat", "{artist_id}"]).default("flat"),
   theme: ThemePreferenceSchema.default("system"),
   autoSyncOnStartup: z.boolean(),
+  autoSyncOnArtistAdd: z.boolean(),
   syncIntervalMinutes: z.number().int().min(0),
   backupRetention: z.number().int().min(1).max(20).default(5),
 });
@@ -134,6 +136,7 @@ export const DEFAULT_IPC_SETTINGS: IpcSettings = {
   downloadFolderStructure: "flat",
   theme: "system",
   autoSyncOnStartup: false,
+  autoSyncOnArtistAdd: false,
   syncIntervalMinutes: 0,
   backupRetention: 5,
 };

--- a/tests/integration/controllers/ArtistsController.test.ts
+++ b/tests/integration/controllers/ArtistsController.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import { createMockDb } from '../../helpers/mock-db';
 import { ARTIST_TYPES, PROVIDER_IDS } from '@/shared/constants';
 import { container, DI_TOKENS } from '@/main/core/di/Container';
-import { artists } from '@/main/db/schema';
+import { artists, settings, SETTINGS_ID } from '@/main/db/schema';
 import { eq } from 'drizzle-orm';
 
 // Mock Electron BEFORE imports
@@ -46,6 +46,7 @@ import type { AddArtistRequest } from '@/shared/schemas/artist';
 describe('ArtistsController Integration', () => {
   let mockDb: ReturnType<typeof createMockDb>;
   let controller: ArtistsController;
+  let repairArtist: ReturnType<typeof vi.fn>;
 
   beforeEach(() => {
     // CRITICAL: Clear DI container before each test to prevent state leakage
@@ -58,6 +59,9 @@ describe('ArtistsController Integration', () => {
     // Register mock DB in DI container
     // Container.register expects the instance directly, not wrapped in an object
     container.register(DI_TOKENS.DB, mockDb.db);
+
+    repairArtist = vi.fn().mockResolvedValue(undefined);
+    container.register(DI_TOKENS.SYNC_SERVICE, { repairArtist });
 
     // Instantiate controller (will use the fresh DB from container)
     controller = new ArtistsController();
@@ -106,6 +110,7 @@ describe('ArtistsController Integration', () => {
       // Verify return value
       expect(result.name).toBe('Test Artist');
       expect(result.tag).toBe('test_artist_tag');
+      expect(repairArtist).not.toHaveBeenCalled();
     });
 
     it('should update existing artist when tag already exists', async () => {
@@ -234,6 +239,72 @@ describe('ArtistsController Integration', () => {
         expect(inserted).toHaveLength(1);
         expect(inserted[0].type).toBe(type);
       }
+    });
+
+    it('does not queue repairArtist when autoSyncOnArtistAdd is disabled', async () => {
+      await mockDb.db
+        .insert(settings)
+        .values({
+          id: SETTINGS_ID,
+          userId: '123',
+          encryptedApiKey: 'encrypted',
+          autoSyncOnArtistAdd: false,
+        })
+        .run();
+
+      const result = await controller.handleAddArtist(null, {
+        name: 'No Auto Sync',
+        tag: 'no_auto_sync_tag',
+        provider: 'rule34',
+        type: 'tag',
+      });
+
+      expect(result.id).toBeDefined();
+      expect(repairArtist).not.toHaveBeenCalled();
+    });
+
+    it('queues repairArtist with inserted id when autoSyncOnArtistAdd is enabled', async () => {
+      await mockDb.db
+        .insert(settings)
+        .values({
+          id: SETTINGS_ID,
+          userId: '123',
+          encryptedApiKey: 'encrypted',
+          autoSyncOnArtistAdd: true,
+        })
+        .run();
+
+      const result = await controller.handleAddArtist(null, {
+        name: 'Auto Sync Artist',
+        tag: 'auto_sync_tag',
+        provider: 'rule34',
+        type: 'tag',
+      });
+
+      expect(result.id).toBeDefined();
+      expect(repairArtist).toHaveBeenCalledTimes(1);
+      expect(repairArtist).toHaveBeenCalledWith(result.id);
+    });
+
+    it('skips repairArtist when autoSyncOnArtistAdd is on but credentials are missing', async () => {
+      await mockDb.db
+        .insert(settings)
+        .values({
+          id: SETTINGS_ID,
+          userId: '',
+          encryptedApiKey: '',
+          autoSyncOnArtistAdd: true,
+        })
+        .run();
+
+      await controller.handleAddArtist(null, {
+        name: 'Missing Creds',
+        tag: 'missing_creds_tag',
+        provider: 'rule34',
+        type: 'tag',
+      });
+
+      expect(repairArtist).not.toHaveBeenCalled();
     });
   });
 });

--- a/tests/integration/controllers/SettingsController.test.ts
+++ b/tests/integration/controllers/SettingsController.test.ts
@@ -67,6 +67,7 @@ describe("SettingsController Integration", () => {
         tosAcceptedAt: null,
         theme: "system",
         autoSyncOnStartup: false,
+        autoSyncOnArtistAdd: false,
         syncIntervalMinutes: 30,
       })
       .run();
@@ -106,6 +107,31 @@ describe("SettingsController Integration", () => {
     expect(updated).toBeDefined();
     expect(updated?.syncIntervalMinutes).toBe(30);
     expect(updated?.autoSyncOnStartup).toBe(true);
+    expect(updated?.autoSyncOnArtistAdd).toBe(false);
+    expect(scheduler.restart).toHaveBeenCalledWith(30);
+  });
+
+  it("keeps other sync fields when saving autoSyncOnArtistAdd", async () => {
+    const saveCall = vi
+      .mocked(ipcMain.handle)
+      .mock.calls.find(([channel]) => channel === IPC_CHANNELS.SETTINGS.SAVE);
+
+    expect(saveCall).toBeDefined();
+    if (!saveCall) {
+      throw new Error("SETTINGS.SAVE handler was not registered");
+    }
+
+    const invokeHandler = saveCall[1];
+    await invokeHandler(undefined, { autoSyncOnArtistAdd: true });
+
+    const updated = await mockDb.db.query.settings.findFirst({
+      where: eq(settings.id, SETTINGS_ID),
+    });
+
+    expect(updated).toBeDefined();
+    expect(updated?.syncIntervalMinutes).toBe(30);
+    expect(updated?.autoSyncOnStartup).toBe(false);
+    expect(updated?.autoSyncOnArtistAdd).toBe(true);
     expect(scheduler.restart).toHaveBeenCalledWith(30);
   });
 });


### PR DESCRIPTION
## Summary
- Artists list badge shows **Not synced yet** when `lastChecked` is null instead of false-positive **Synced**
- New Settings → Sync toggle `autoSyncOnArtistAdd` (default off) fire-and-forgets `repairArtist(id)` after add
- Live `syncStatus` Syncing indicator left as a separate roadmap item

## Test plan
- [x] typecheck / lint / vitest (267)
- [ ] New artist without sync → Not synced yet
- [ ] After successful sync → Synced
- [ ] Toggle off → no repairArtist; toggle on → repairArtist queued
- [ ] Add during Sync All → queued via runExclusive (no FTS race)
