### PR TITLE
feat: refresh Artists list live during per-artist sync

### DIFF
--- a/README.md
+++ b/README.md
@@ -175,7 +175,7 @@ When enabled in **Settings → Sync**, the app starts a full **Sync All** after 
 
 Optional **Sync new artist automatically** (off by default) queues `repairArtist` for each newly added artist via the same exclusive sync mutex — it does not block the add-artist IPC response.
 
-Each artist row stores `syncStatus` (`idle` / `syncing` / `error`) and `lastError`. A hard kill mid-sync cannot leave **Syncing** forever: the next DB init resets stuck `syncing` → `idle`. Live **Syncing** on the Artists list during a run still depends on a later UI refresh (IPC invalidation).
+Each artist row stores `syncStatus` (`idle` / `syncing` / `error`) and `lastError`. A hard kill mid-sync cannot leave **Syncing** forever: the next DB init resets stuck `syncing` → `idle`. The Artists list badge updates live: `AppLayout` invalidates `["artists"]` on `sync:artist` and repair start/end (DB remains source of truth).
 
 ### ✅ Periodic background sync
 

--- a/docs/api-guide.md
+++ b/docs/api-guide.md
@@ -356,6 +356,9 @@ interface IpcBridge {
   onSyncEnd: (callback: () => void) => () => void;
   onSyncProgress: (callback: (message: string) => void) => () => void;
   onSyncError: (callback: SyncErrorCallback) => () => void;
+  onSyncArtist: (callback: () => void) => () => void;
+  onRepairStart: (callback: (artistName: string) => void) => () => void;
+  onRepairEnd: (callback: () => void) => () => void;
 }
 ```
 
@@ -994,7 +997,7 @@ if (success) {
 
 **IPC Channel:** `db:sync-all`
 
-**Note:** This is an asynchronous operation. The method returns immediately, and synchronization runs in the background. Use event listeners (`onSyncStart`, `onSyncEnd`, `onSyncProgress`, `onSyncError`) to track progress. Check artist `newPostsCount` to see results.
+**Note:** This is an asynchronous operation. The method returns immediately, and synchronization runs in the background. Use event listeners (`onSyncStart`, `onSyncEnd`, `onSyncProgress`, `onSyncError`, `onSyncArtist`, `onRepairStart`, `onRepairEnd`) to track progress. Check artist `newPostsCount` / `syncStatus` to see results.
 
 ---
 
@@ -1882,6 +1885,46 @@ const unsubscribe = window.api.onSyncProgress((message) => {
 ```
 
 **IPC Channel:** `sync:progress`
+
+Payload is always a **string** (human-readable progress). Do not change this shape — Sidebar / `SyncStatusBadge` use it only to toggle global `isSyncing`. Per-artist `syncStatus` uses `onSyncArtist` / repair events + DB refetch.
+
+---
+
+#### `onSyncArtist(callback: () => void)`
+
+Fired after per-artist `syncStatus` is written (start **and** end of `syncArtist`). Void payload — renderer invalidates `["artists"]` and refetches from DB (source of truth). Not a substitute for `onSyncProgress`.
+
+**Returns:** `() => void` - Unsubscribe function
+
+**Example:**
+
+```typescript
+const unsubscribe = window.api.onSyncArtist(() => {
+  void queryClient.invalidateQueries({ queryKey: ["artists"] });
+});
+```
+
+**IPC Channel:** `sync:artist`
+
+---
+
+#### `onRepairStart(callback: (artistName: string) => void)`
+
+Fired when a repair/auto-sync-on-add run starts, **after** `syncStatus` is `"syncing"`.
+
+**Returns:** `() => void` - Unsubscribe function
+
+**IPC Channel:** `sync:repair:start`
+
+---
+
+#### `onRepairEnd(callback: () => void)`
+
+Fired when repair/auto-sync-on-add finishes (`idle` or `error` already persisted).
+
+**Returns:** `() => void` - Unsubscribe function
+
+**IPC Channel:** `sync:repair:end`
 
 ---
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -97,6 +97,7 @@
 | `settings:save-download-settings` | `SETTINGS.SAVE_DOWNLOAD_SETTINGS` | `z.tuple([SaveDownloadSettingsPayloadSchema])` | no | `SettingsController` | `src/main/ipc/controllers/SettingsController.ts` |
 | `settings:save-theme` | `SETTINGS.SAVE_THEME` | `z.tuple([ThemePreferenceSchema])` | no | `SettingsController` | `src/main/ipc/controllers/SettingsController.ts` |
 | `stats:get-extended` | `STATS.GET_EXTENDED` | `[]` (no args) | yes | `StatsController` | `src/main/ipc/controllers/StatsController.ts` |
+| `sync:artist` | `SYNC.ARTIST` | — | — | — | _No `handle` registration found (event channel or registered outside scanned paths)._ |
 | `sync:end` | `SYNC.END` | — | — | — | _No `handle` registration found (event channel or registered outside scanned paths)._ |
 | `sync:error` | `SYNC.ERROR` | — | — | — | _No `handle` registration found (event channel or registered outside scanned paths)._ |
 | `sync:progress` | `SYNC.PROGRESS` | — | — | — | _No `handle` registration found (event channel or registered outside scanned paths)._ |
@@ -114,7 +115,7 @@
 
 ## Coverage
 
-- Channels in `channels.ts`: **100**
+- Channels in `channels.ts`: **101**
 - Channels with at least one scanned `handle` registration: **85**
 - Handler rows extracted: **85**
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -487,7 +487,7 @@ const posts = await db.query.posts.findMany({
    - Updates artist post counts
    - `syncAllArtists()` and `repairArtist()` run through `runExclusive()` — a promise-chain mutex: if one operation is in flight, the next **waits** until it finishes (no silent drop). Covered by `tests/integration/services/SyncService.queue.test.ts` (timing: repair’s `syncArtist` runs only after full sync completes).
    - Cooperative cancel: `requestCancel()` / `SyncCancelledError` / `waitUntilIdle()` — app quit drains in-flight sync (up to `SYNC_SHUTDOWN_DRAIN_MS`) before `closeDatabase()`. Hard kill still bypasses cancel; runtime-droppable FTS triggers (`posts_fts_insert`, `posts_fts_update`) are recovered on DB init via `ensureFtsTriggers` (`src/main/db/fts-triggers.ts`), then `rebuildFtsIndex` (`VALUES('rebuild')`). Successful initial/repair sync calls `backfillArtistFtsIndex` (also `rebuild` — blind artist `INSERT…SELECT` leaves stale terms after repair conflicts) before restoring triggers. While those triggers are dropped, `PostsController` AI filter (`hide`/`only`) does not use FTS `MATCH` — `areRuntimeDroppableFtsTriggersPresent` reads `sqlite_master` and falls back to exact-token `instr` on `posts.tags` so hide cannot fail-open. `getIsSyncing()` is not that signal (incremental sync keeps triggers live). Same init path also runs `resetStaleSyncingArtists` (`UPDATE artists SET sync_status = 'idle' WHERE sync_status = 'syncing'`) so a hard-kill cannot leave a permanent **Syncing** badge; `'error'`, `lastError`, and `lastSyncIncomplete` are left alone.
-   - Per-artist `syncStatus` (`idle` / `syncing` / `error`) and `lastError` are written by `SyncService.setArtistSyncStatus`: `"syncing"` at the start of `syncArtist` (before network / FTS drop); `"idle"` + `lastError: null` on successful pagination end (same tx as `lastPostId` / `lastChecked`) and on incomplete-without-throw (`lastSyncIncomplete: true`) or cancel; `"error"` + message on provider/network rethrow. Not written on credentials early-return or invalid-provider fallback. Live renderer refresh of the badge is a separate follow-up (IPC invalidation / push).
+   - Per-artist `syncStatus` (`idle` / `syncing` / `error`) and `lastError` are written by `SyncService.setArtistSyncStatus`: `"syncing"` at the start of `syncArtist` (before network / FTS drop); `"idle"` + `lastError: null` on successful pagination end (same tx as `lastPostId` / `lastChecked`) and on incomplete-without-throw (`lastSyncIncomplete: true`) or cancel; `"error"` + message on provider/network rethrow. Not written on credentials early-return or invalid-provider fallback. After each persist, Main emits void `sync:artist` (and `sync:repair:start` after the syncing write when repairing). `AppLayout` invalidates React Query `["artists"]` on `sync:artist` / `sync:repair:start` / `sync:repair:end` (plus full feed refresh on `sync:end`). `sync:progress` remains a **string** for the global Sidebar/`SyncStatusBadge` indicator — do not overload it with artist status.
    - Emits IPC events for sync progress tracking
 
 4. **IPC Controllers** (`src/main/ipc/controllers/`)
@@ -1181,17 +1181,23 @@ sequenceDiagram
 
    g. **Updates artist** - Mid-batch and error paths update `newPostsCount` (and may set `lastSyncIncomplete`) without moving `lastPostId`. After natural pagination end (`postsData.length < PAGE_SIZE`), a single commit writes `lastPostId`, `lastChecked`, clears `lastSyncIncomplete`, and sets `syncStatus` to `idle`. Incomplete-without-throw keeps `syncStatus` `idle` with `lastSyncIncomplete`. Provider/network rethrow sets `syncStatus` `error` and `lastError` before rethrow; cancel returns `syncStatus` to `idle`. Cancel mid-pagination follows the same incomplete path (partial commit, cursor unchanged) then rethrows `SyncCancelledError`.
 
-   h. **Progress event** - Emits IPC event: `emit('sync:progress', 'Syncing artist_name...')`
+   h. **Progress event** - Emits IPC event: `emit('sync:progress', 'Checking artist_name...')` (string only — global Sidebar indicator). After per-artist `syncStatus` is written, emits void `sync:artist` so `AppLayout` can invalidate `["artists"]`. Repair emits `sync:repair:start` (after syncing write) and `sync:repair:end`.
 
-5. **UI updates in real-time** - React component listens to progress events:
+5. **UI updates in real-time** - Global shell listens to progress for the Sync All spinner; artist badges refetch via `onSyncArtist` / repair listeners:
 
    ```typescript
    useEffect(() => {
-     const unsubscribe = window.api.onSyncProgress((message) => {
-       setSyncMessage(message); // Update progress text
+     const unsubscribeProgress = window.api.onSyncProgress((message) => {
+       setSyncMessage(message);
      });
-     return () => unsubscribe();
-   }, []);
+     const unsubscribeArtist = window.api.onSyncArtist(() => {
+       void queryClient.invalidateQueries({ queryKey: ["artists"] });
+     });
+     return () => {
+       unsubscribeProgress();
+       unsubscribeArtist();
+     };
+   }, [queryClient]);
    ```
 
 6. **Completion** - When all artists are processed, service emits `sync:end` event. UI shows "Sync complete" message.

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -26,7 +26,7 @@ This document reflects the current roadmap for RuleDesk `v17.x` and is aligned w
 - ✅ Playlists, favorites, downloads, backup/restore, and full-screen viewer are implemented.
 - ✅ Playlists now include import/export, manual drag-and-drop reorder, and smart hybrid local+remote resolution.
 - ✅ Database is optimized for scale: WAL mode, FTS5, composite indexes, and migration workflow.
-- ✅ **Sync automation:** auto-sync on startup, optional auto-sync when adding an artist (`autoSyncOnArtistAdd`, default off → `repairArtist` via `runExclusive`), periodic background sync (presets in Settings, minimum interval enforced in `SyncScheduler`), and sync scheduler restart when settings are saved. Per-artist `syncStatus` / `lastError` persist during sync (**#148**); Artists list refreshes live via `sync:artist` / repair IPC (`feat/sync-status-live-ui`).
+- ✅ **Sync automation:** auto-sync on startup, optional auto-sync when adding an artist (`autoSyncOnArtistAdd`, default off → `repairArtist` via `runExclusive`), periodic background sync (presets in Settings, minimum interval enforced in `SyncScheduler`), and sync scheduler restart when settings are saved. Per-artist `syncStatus` / `lastError` persist during sync (**#148**); Artists list refreshes live via `sync:artist` / repair IPC (**#149**).
 - ✅ **DB maintenance:** passive `WAL` checkpoint + `PRAGMA optimize` after startup (delayed) and on a daily timer (`MaintenanceScheduler`).
 - ✅ **Backup retention:** after each successful backup, older files are pruned based on `backupRetention` from Settings (`1..20`).
 - ✅ **User-visible DB maintenance:** Settings now exposes VACUUM status (last run timestamp/status/error), manual trigger, and schedule (`manual` / `weekly` / `monthly`).
@@ -91,7 +91,7 @@ The short version: the core product is shipped, now we focus on parity gaps and 
 
 - ✅ **Auto-sync on startup** (toggle in Settings under Sync).
 - ✅ **Periodic sync** — interval selected in Settings (Disabled, 15 / 30 / 60 / 120 minutes). Values below the code minimum (`MIN_INTERVAL_MINUTES = 5`) are treated as disabled.
-- ✅ **Live per-artist badge** — `syncStatus` is written in Main; renderer invalidates `["artists"]` on `sync:artist` and repair start/end (DB remains source of truth). Hard-kill recovery: stuck `syncing` → `idle` on DB init (**#148**).
+- ✅ **Live per-artist badge** — `syncStatus` is written in Main; renderer invalidates `["artists"]` on `sync:artist` and repair start/end (DB remains source of truth) (**#149**). Hard-kill recovery: stuck `syncing` → `idle` on DB init (**#148**).
 
 ## 🛡️ Security & Reliability (Hardening)
 
@@ -172,7 +172,7 @@ Both P0 rows (#1–#2) are closed — the full v17 audit pack landed (after one 
 
 | Branch | Status | Notes |
 |--------|--------|-------|
-| `feat/sync-status-live-ui` | 🔄 started | Invalidate `["artists"]` on `sync:artist` + repair start/end; preload wires `REPAIR_*`; `sync:progress` payload unchanged |
+| `feat/sync-status-live-ui` | 🔄 in PR | [#149](https://github.com/KazeKaze93/RuleDesk/pull/149) — invalidate `["artists"]` on `sync:artist` + repair start/end; preload wires `REPAIR_*`; `sync:progress` payload unchanged |
 | `feat/sync-status-write-and-recovery` | ✅ merged | [#148](https://github.com/KazeKaze93/RuleDesk/pull/148) — persist per-artist `syncStatus` / `lastError`; `resetStaleSyncingArtists` on DB init |
 | `feat/remote-ai-filter-via-tags-injection` | ✅ merged | [#147](https://github.com/KazeKaze93/RuleDesk/pull/147) — Browse Source: All — Rule34 AI hide/only via tag injection into `searchBooru`; Gelbooru stays worker-only; defensive conflict → worker fallback |
 | `audit/raw-sql-timestamp-units` | ✅ merged | [#132](https://github.com/KazeKaze93/RuleDesk/pull/132) — Full raw-SQL timestamp unit inventory: **no P0 mismatch**; comment-only Units annotations + `docs/database.md` seconds vs ms correction. (Remote hyphen: `audit-raw-sql-timestamp-units`) |

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -26,7 +26,7 @@ This document reflects the current roadmap for RuleDesk `v17.x` and is aligned w
 - ✅ Playlists, favorites, downloads, backup/restore, and full-screen viewer are implemented.
 - ✅ Playlists now include import/export, manual drag-and-drop reorder, and smart hybrid local+remote resolution.
 - ✅ Database is optimized for scale: WAL mode, FTS5, composite indexes, and migration workflow.
-- ✅ **Sync automation:** auto-sync on startup, optional auto-sync when adding an artist (`autoSyncOnArtistAdd`, default off → `repairArtist` via `runExclusive`), periodic background sync (presets in Settings, minimum interval enforced in `SyncScheduler`), and sync scheduler restart when settings are saved.
+- ✅ **Sync automation:** auto-sync on startup, optional auto-sync when adding an artist (`autoSyncOnArtistAdd`, default off → `repairArtist` via `runExclusive`), periodic background sync (presets in Settings, minimum interval enforced in `SyncScheduler`), and sync scheduler restart when settings are saved. Per-artist `syncStatus` / `lastError` persist during sync (**#148**); Artists list refreshes live via `sync:artist` / repair IPC (`feat/sync-status-live-ui`).
 - ✅ **DB maintenance:** passive `WAL` checkpoint + `PRAGMA optimize` after startup (delayed) and on a daily timer (`MaintenanceScheduler`).
 - ✅ **Backup retention:** after each successful backup, older files are pruned based on `backupRetention` from Settings (`1..20`).
 - ✅ **User-visible DB maintenance:** Settings now exposes VACUUM status (last run timestamp/status/error), manual trigger, and schedule (`manual` / `weekly` / `monthly`).
@@ -91,6 +91,7 @@ The short version: the core product is shipped, now we focus on parity gaps and 
 
 - ✅ **Auto-sync on startup** (toggle in Settings under Sync).
 - ✅ **Periodic sync** — interval selected in Settings (Disabled, 15 / 30 / 60 / 120 minutes). Values below the code minimum (`MIN_INTERVAL_MINUTES = 5`) are treated as disabled.
+- ✅ **Live per-artist badge** — `syncStatus` is written in Main; renderer invalidates `["artists"]` on `sync:artist` and repair start/end (DB remains source of truth). Hard-kill recovery: stuck `syncing` → `idle` on DB init (**#148**).
 
 ## 🛡️ Security & Reliability (Hardening)
 
@@ -171,6 +172,8 @@ Both P0 rows (#1–#2) are closed — the full v17 audit pack landed (after one 
 
 | Branch | Status | Notes |
 |--------|--------|-------|
+| `feat/sync-status-live-ui` | 🔄 started | Invalidate `["artists"]` on `sync:artist` + repair start/end; preload wires `REPAIR_*`; `sync:progress` payload unchanged |
+| `feat/sync-status-write-and-recovery` | ✅ merged | [#148](https://github.com/KazeKaze93/RuleDesk/pull/148) — persist per-artist `syncStatus` / `lastError`; `resetStaleSyncingArtists` on DB init |
 | `feat/remote-ai-filter-via-tags-injection` | ✅ merged | [#147](https://github.com/KazeKaze93/RuleDesk/pull/147) — Browse Source: All — Rule34 AI hide/only via tag injection into `searchBooru`; Gelbooru stays worker-only; defensive conflict → worker fallback |
 | `audit/raw-sql-timestamp-units` | ✅ merged | [#132](https://github.com/KazeKaze93/RuleDesk/pull/132) — Full raw-SQL timestamp unit inventory: **no P0 mismatch**; comment-only Units annotations + `docs/database.md` seconds vs ms correction. (Remote hyphen: `audit-raw-sql-timestamp-units`) |
 | `fix/ipc-handlers-compliance` | ✅ merged | [#124](https://github.com/KazeKaze93/RuleDesk/pull/124) — Legacy `ipcMain.handle` → BaseController; silent catch removed. (Branch renamed: remote `audit` ref blocks `audit/*`) |
@@ -232,7 +235,6 @@ Items explicitly scheduled for product/engineering (beyond small bugs).
 | **Testing** | Live Gelbooru video-proxy check was not run (Gelbooru API key required); unit tests cover allowlist logic only. |
 | **Media filters (P3)** | Browse worker video regex (`mp4\|webm\|mov` in `data-processor.worker.ts`) is narrower than canonical `VIDEO_EXTENSIONS` in `src/shared/utils/media.ts` — align when touching the worker. |
 | **Product** | **Smart Collections AI** (research). |
-| **Sync UX** | **Write + hard-kill recovery done** (`SyncService` persists per-artist `syncStatus` / `lastError`; `resetStaleSyncingArtists` on DB init). **Still open:** live renderer refresh (**Syncing…** immediately) via IPC invalidation / push — separate from the static `lastChecked === null` → **Not synced yet** badge. |
 
 **Providers:** new sites must implement **`ProviderThrottle`**-class behavior; Rule34 and Gelbooru already share `ProviderThrottle` — not a “gap” unless adding a **third** backend.
 

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -139,7 +139,7 @@ That's it! You're now ready to use RuleDesk.
 
 4. Click **"Add"**
 
-The artist will appear in your tracked list. Until the first successful sync finishes, the status badge shows **Not synced yet** (not green **Synced**). After a sync run completes, the badge reflects that artist’s last result: **Synced**, **Error** (hover for the reason), or **Not synced yet**. A live **Syncing** spinner during an in-progress run is not shown until the list refreshes (for example after **Sync All** finishes). If **Sync new artist automatically** is enabled in Settings → Sync, RuleDesk queues that sync right after you add the artist.
+The artist will appear in your tracked list. Until the first successful sync finishes, the status badge shows **Not synced yet** (not green **Synced**). While that artist is being synced (Sync All, repair, or **Sync new artist automatically**), the badge switches to **Syncing**; when that artist finishes it becomes **Synced** or **Error** (hover for the reason) without waiting for every other artist. If **Sync new artist automatically** is enabled in Settings → Sync, RuleDesk queues that sync right after you add the artist.
 
 **Tip:** You can use the search box to find tags. Type a few letters and RuleDesk will suggest matching tags.
 

--- a/src/main/bridge.ts
+++ b/src/main/bridge.ts
@@ -135,6 +135,10 @@ export interface IpcBridge {
   onSyncEnd: (callback: () => void) => () => void;
   onSyncProgress: (callback: (message: string) => void) => () => void;
   onSyncError: (callback: SyncErrorCallback) => () => void;
+  /** Per-artist syncStatus was persisted (start or end). Void payload — refetch DB. */
+  onSyncArtist: (callback: () => void) => () => void;
+  onRepairStart: (callback: (artistName: string) => void) => () => void;
+  onRepairEnd: (callback: () => void) => () => void;
 
   markPostAsViewed: (postId: number, postData?: PostData) => Promise<boolean>;
 
@@ -443,6 +447,28 @@ const ipcBridge: IpcBridge = {
   onSyncProgress: (callback) => {
     const sub = (_: IpcRendererEvent, msg: string) => callback(msg);
     const channel = IPC_CHANNELS.SYNC.PROGRESS;
+    ipcRenderer.on(channel, sub);
+    return () => ipcRenderer.removeListener(channel, sub);
+  },
+
+  onSyncArtist: (callback) => {
+    const sub = () => callback();
+    const channel = IPC_CHANNELS.SYNC.ARTIST;
+    ipcRenderer.on(channel, sub);
+    return () => ipcRenderer.removeListener(channel, sub);
+  },
+
+  onRepairStart: (callback) => {
+    const channel = IPC_CHANNELS.SYNC.REPAIR_START;
+    const subscription = (_: IpcRendererEvent, artistName: string) =>
+      callback(artistName);
+    ipcRenderer.on(channel, subscription);
+    return () => ipcRenderer.removeListener(channel, subscription);
+  },
+
+  onRepairEnd: (callback) => {
+    const sub = () => callback();
+    const channel = IPC_CHANNELS.SYNC.REPAIR_END;
     ipcRenderer.on(channel, sub);
     return () => ipcRenderer.removeListener(channel, sub);
   },

--- a/src/main/ipc/channels.ts
+++ b/src/main/ipc/channels.ts
@@ -96,6 +96,8 @@ export const IPC_CHANNELS = {
     END: "sync:end",
     ERROR: "sync:error",
     PROGRESS: "sync:progress",
+    /** Void pulse after per-artist syncStatus is written (start + end). Not a progress string. */
+    ARTIST: "sync:artist",
     REPAIR_START: "sync:repair:start",
     REPAIR_END: "sync:repair:end",
   },

--- a/src/main/services/sync-service.ts
+++ b/src/main/services/sync-service.ts
@@ -433,9 +433,14 @@ export class SyncService {
       }
 
       if (artist && settingsData) {
-        this.sendEvent(IPC_CHANNELS.SYNC.REPAIR_START, artist.name);
-        // Repair: reset lastPostId to 0 and sync posts with safety limit
-        await this.syncArtist({ ...artist, lastPostId: 0 }, settingsData, MAX_PAGES_SAFETY_LIMIT);
+        // Repair: reset lastPostId to 0 and sync posts with safety limit.
+        // REPAIR_START is emitted from syncArtist after syncStatus is written.
+        await this.syncArtist(
+          { ...artist, lastPostId: 0 },
+          settingsData,
+          MAX_PAGES_SAFETY_LIMIT,
+          { notifyRepairStart: true }
+        );
       }
     } catch (e) {
       if (isSyncCancelledError(e)) {
@@ -464,11 +469,13 @@ export class SyncService {
    * @param artist - Artist to sync
    * @param settings - API credentials (userId, apiKey)
    * @param maxPages - Maximum pages to fetch (default: Infinity)
+   * @param options.notifyRepairStart - Emit REPAIR_START after syncing status is persisted
    */
   public async syncArtist(
     artist: Artist,
     settings: { userId: string; apiKey: string },
-    maxPages = Infinity
+    maxPages = Infinity,
+    options?: { notifyRepairStart?: boolean }
   ) {
     setArtistSyncStatus(
       getDb(),
@@ -476,6 +483,10 @@ export class SyncService {
       ARTIST_SYNC_STATUS.SYNCING,
       null
     );
+    if (options?.notifyRepairStart) {
+      this.sendEvent(IPC_CHANNELS.SYNC.REPAIR_START, artist.name);
+    }
+    this.sendEvent(IPC_CHANNELS.SYNC.ARTIST);
 
     // DYNAMIC PROVIDER SELECTION
     // Validate provider ID against known providers
@@ -516,16 +527,20 @@ export class SyncService {
     const isInitialSync = currentLastPostId === 0;
     
     // Unified sync method - handles both initial and incremental sync
-    return await this.syncPosts(
-      artist,
-      settings,
-      provider,
-      {
-        isInitial: isInitialSync,
-        currentLastPostId,
-        maxPages: isInitialSync ? maxPages : Infinity,
-      }
-    );
+    try {
+      return await this.syncPosts(
+        artist,
+        settings,
+        provider,
+        {
+          isInitial: isInitialSync,
+          currentLastPostId,
+          maxPages: isInitialSync ? maxPages : Infinity,
+        }
+      );
+    } finally {
+      this.sendEvent(IPC_CHANNELS.SYNC.ARTIST);
+    }
   }
 
   /**

--- a/src/renderer.d.ts
+++ b/src/renderer.d.ts
@@ -135,6 +135,9 @@ export interface IpcApi extends IpcBridge {
   onSyncEnd: (callback: () => void) => () => void;
   onSyncProgress: (callback: (message: string) => void) => () => void;
   onSyncError: (callback: SyncErrorCallback) => () => void;
+  onSyncArtist: (callback: () => void) => () => void;
+  onRepairStart: (callback: (artistName: string) => void) => () => void;
+  onRepairEnd: (callback: () => void) => () => void;
 
   markPostAsViewed: (postId: number, postData?: PostData) => Promise<boolean>;
 

--- a/src/renderer/components/layout/AppLayout.tsx
+++ b/src/renderer/components/layout/AppLayout.tsx
@@ -30,18 +30,29 @@ export const AppLayout = () => {
   }, [location.pathname]);
 
   useEffect(() => {
+    const invalidateArtists = () => {
+      void queryClient.invalidateQueries({ queryKey: ["artists"] });
+    };
+
     const unsubscribeSyncEnd = window.api.onSyncEnd(() => {
       // Sync writes new posts into DB, so all post-based feeds must refresh.
       // Smart playlists are dynamic queries over posts, so they must be invalidated too.
       void queryClient.invalidateQueries({ queryKey: ["posts"] });
       void queryClient.invalidateQueries({ queryKey: ["playlist-posts"] });
       void queryClient.invalidateQueries({ queryKey: ["playlists"] });
-      void queryClient.invalidateQueries({ queryKey: ["artists"] });
+      invalidateArtists();
       void queryClient.invalidateQueries({ queryKey: ["posts-count"] });
     });
 
+    const unsubscribeSyncArtist = window.api.onSyncArtist(invalidateArtists);
+    const unsubscribeRepairStart = window.api.onRepairStart(invalidateArtists);
+    const unsubscribeRepairEnd = window.api.onRepairEnd(invalidateArtists);
+
     return () => {
       unsubscribeSyncEnd();
+      unsubscribeSyncArtist();
+      unsubscribeRepairStart();
+      unsubscribeRepairEnd();
     };
   }, [queryClient]);
 

--- a/tests/integration/services/SyncService.test.ts
+++ b/tests/integration/services/SyncService.test.ts
@@ -1399,4 +1399,139 @@ describe('SyncService Integration', () => {
       fetchPostsSpy.mockRestore();
     }
   });
+
+  it('emits sync:artist after syncing is written and again after idle', async () => {
+    const artist = await mockDb.db.query.artists.findFirst({
+      where: eq(artists.tag, 'artist_name'),
+    });
+    if (!artist) {
+      throw new Error('Artist setup failed');
+    }
+
+    const settingsRecord = await mockDb.db.query.settings.findFirst({
+      where: eq(settings.id, SETTINGS_ID),
+    });
+    if (!settingsRecord) {
+      throw new Error('Settings setup failed');
+    }
+
+    const { safeStorage } = await import('electron');
+    const apiKey =
+      safeStorage.isEncryptionAvailable() && settingsRecord.encryptedApiKey
+        ? safeStorage.decryptString(
+            Buffer.from(settingsRecord.encryptedApiKey, 'base64')
+          )
+        : settingsRecord.encryptedApiKey || '';
+
+    const artistPulseStatuses: string[] = [];
+    const sendEventSpy = vi
+      .spyOn(service, 'sendEvent')
+      .mockImplementation((channel: string) => {
+        if (channel !== IPC_CHANNELS.SYNC.ARTIST) {
+          return;
+        }
+        const row = mockDb.db
+          .select({ syncStatus: artists.syncStatus })
+          .from(artists)
+          .where(eq(artists.id, artist.id))
+          .all()[0];
+        if (row) {
+          artistPulseStatuses.push(row.syncStatus);
+        }
+      });
+
+    const provider = getProvider('rule34');
+    const fetchPostsSpy = vi.spyOn(provider, 'fetchPosts').mockImplementation(
+      async () => [
+        {
+          id: 11,
+          fileUrl: 'https://cdn.example.com/11.jpg',
+          previewUrl: 'https://cdn.example.com/11-p.jpg',
+          sampleUrl: 'https://cdn.example.com/11-s.jpg',
+          tags: ['artist_name'],
+          rating: 's',
+          score: 0,
+          source: '',
+          width: 100,
+          height: 100,
+          createdAt: new Date('2025-01-01T00:00:00.000Z'),
+        },
+      ]
+    );
+
+    try {
+      await service.syncArtist(artist, {
+        userId: settingsRecord.userId || '',
+        apiKey,
+      });
+
+      expect(artistPulseStatuses[0]).toBe('syncing');
+      expect(artistPulseStatuses[artistPulseStatuses.length - 1]).toBe('idle');
+      expect(
+        sendEventSpy.mock.calls.filter(
+          (call) => call[0] === IPC_CHANNELS.SYNC.ARTIST
+        )
+      ).toHaveLength(2);
+    } finally {
+      sendEventSpy.mockRestore();
+      fetchPostsSpy.mockRestore();
+    }
+  });
+
+  it('emits repair start only after syncStatus is syncing', async () => {
+    const artist = await mockDb.db.query.artists.findFirst({
+      where: eq(artists.tag, 'artist_name'),
+    });
+    if (!artist) {
+      throw new Error('Artist setup failed');
+    }
+
+    let statusAtRepairStart: string | undefined;
+    const sendEventSpy = vi
+      .spyOn(service, 'sendEvent')
+      .mockImplementation((channel: string) => {
+        if (channel !== IPC_CHANNELS.SYNC.REPAIR_START) {
+          return;
+        }
+        const row = mockDb.db
+          .select({ syncStatus: artists.syncStatus })
+          .from(artists)
+          .where(eq(artists.id, artist.id))
+          .all()[0];
+        statusAtRepairStart = row?.syncStatus;
+      });
+
+    const provider = getProvider('rule34');
+    const fetchPostsSpy = vi.spyOn(provider, 'fetchPosts').mockImplementation(
+      async () => [
+        {
+          id: 21,
+          fileUrl: 'https://cdn.example.com/21.jpg',
+          previewUrl: 'https://cdn.example.com/21-p.jpg',
+          sampleUrl: 'https://cdn.example.com/21-s.jpg',
+          tags: ['artist_name'],
+          rating: 's',
+          score: 0,
+          source: '',
+          width: 100,
+          height: 100,
+          createdAt: new Date('2025-01-01T00:00:00.000Z'),
+        },
+      ]
+    );
+
+    try {
+      await service.repairArtist(artist.id);
+
+      expect(statusAtRepairStart).toBe('syncing');
+      expect(sendEventSpy).toHaveBeenCalledWith(
+        IPC_CHANNELS.SYNC.REPAIR_START,
+        artist.name
+      );
+      expect(sendEventSpy).toHaveBeenCalledWith(IPC_CHANNELS.SYNC.REPAIR_END);
+    } finally {
+      sendEventSpy.mockRestore();
+      fetchPostsSpy.mockRestore();
+    }
+  });
 });

--- a/tests/unit/TEST_COVERAGE.md
+++ b/tests/unit/TEST_COVERAGE.md
@@ -50,7 +50,7 @@ Vitest covers unit logic, integration flows (IPC + SQLite), and property-based f
 | `controllers/SearchController.blacklist.test.ts` | Browse blacklist filtering |
 | `controllers/SettingsController.test.ts` | Partial settings save |
 | `services/SyncService.queue.test.ts` | `runExclusive` — repair after full sync |
-| `services/SyncService.test.ts` | Sync pagination, graceful errors, auth → `SYNC.ERROR`, per-artist `syncStatus` / `lastError` |
+| `services/SyncService.test.ts` | Sync pagination, graceful errors, auth → `SYNC.ERROR`, per-artist `syncStatus` / `lastError`, `sync:artist` / repair event order |
 
 ## Running tests
 


### PR DESCRIPTION
## Summary
- Emit void `sync:artist` after per-artist `syncStatus` is persisted (start + end); wire `sync:repair:start` / `sync:repair:end` through preload.
- `AppLayout` invalidates `[artists]` on those events so the list badge tracks DB without waiting for full `sync:end`.
- `sync:progress` string payload and DB write logic from #148 are unchanged. Docs + SyncService event-order tests updated.

## Test plan
- [ ] Unit/integration: `npm test -- tests/integration/services/SyncService.test.ts` (event order vs DB status)
- [ ] `npm run validate` / `docs:api` freshness
- [ ] Live Electron: start sync / repair one artist — Artists row shows **Syncing…** immediately, then idle/error after finish (Main restart after `src/main/**` change)
- [ ] Confirm `sync:progress` toast/string still behaves as before
- [ ] Hard-kill mid-sync still recovers via #148 (`syncing` → `idle` on next DB init)