### PR TITLE
docs: fix factual drift after two days of branches

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,12 +106,12 @@ This is the sandboxed browser environment. It handles presentation.
 
 The application is organized into the following main sections accessible via the Sidebar:
 
-- **Updates (Subscriptions)** - View new posts from tracked artists and tag subscriptions
-- **Browse (All posts)** - Search the live booru API with chip-based tags, infinite scroll, and advanced filters; Favorites/Subscriptions modes search the local cache
+- **Updates** - View new posts from tracked artists
+- **Browse (All posts)** - Search the live booru API with chip-based tags, infinite scroll, and advanced filters; Favorites / Browse Source Subscriptions filter modes search the local cache
 - **Favorites** - Local favorites only (`isFavorited` in SQLite). There is no booru account-favorites sync path
 - **Playlists (Collections)** - Create and manage curated collections of posts
 - **Statistics** - Extended local metrics and distribution charts via `getExtendedStats` (counts, pie charts, top artists/tags, provider artist split, DB size)
-- **Tracked (Artists/Tags management)** - Manage tracked artists, tags, and subscriptions
+- **Tracked (Artists/Tags management)** - Manage tracked artists and tags
 - **Settings** - Configure downloads, sync, appearance, account, backup/restore, and Danger-zone wipe
 
 ## 🎨 Core UX Principles
@@ -287,7 +287,7 @@ The application is stable and production-ready (see **`package.json`** → `vers
 - ✅ **Search Functionality:** Local artist search, remote tag search via booru autocomplete API, and direct booru search (`searchBooru` method) with tag resolution (`resolveTags`, `resolveCharacterTags`, `resolveCopyrightTags`, `resolveTagsByType`)
 - ✅ **Sidebar Navigation:** Persistent grouped sidebar structure (Discover / Library / System) with the current shipped IA.
 - ✅ **Global Top Bar:** Search (chip-based include/exclude with OR-group tokens), syntax-help popover, `FiltersPanel` (AI, media, source), dedicated date sort control, view toggle, `SyncStatusBadge`
-- ✅ **Advanced Filtering:** Filter by AI-generated tags, media type (image/video), and source (all/favorites/subscriptions)
+- ✅ **Advanced Filtering:** Filter by AI-generated tags, media type (image/video), and source (all / favorites / Browse Source Subscriptions filter)
 - ✅ **Sorting:** Sort by date order (newest/oldest) across main feeds
 - ✅ **View Modes:** Grid (virtualized) and masonry (CSS columns) are both shipped and user-selectable.
   *Trade-off remains intentional: masonry prioritizes visual layout over full virtualization on huge feeds.*
@@ -314,13 +314,12 @@ The application is stable and production-ready (see **`package.json`** → `vers
    - Visit https://rule34.xxx/index.php?page=account&s=options
    - Copy your **User ID** and **API Key** from the API Access section
 
-2. **Onboarding:**
+2. **Age Gate and account:**
 
    - Launch the application
-   - Confirm legal age / ToS in the mandatory Age Gate
-   - Option A: enter User ID + API Key and click "Save and Login" (or paste the account page URL into either field — both values fill in automatically)
-   - Option B: click "Skip for now" to continue in Browse-only mode
-   - Add API key later in `Settings -> Account` to unlock Updates and Artists (Favorites and Playlists work locally without credentials)
+   - Confirm legal age / ToS in the mandatory Age Gate (`AgeGate.tsx`)
+   - If no API key is stored, AccountGate (`SettingsAccountTab` in `App.tsx`) requires User ID + API Key — **Save API Key** (or paste the account page URL into either field). There is no Skip; the main shell loads only after `hasApiKey` is true
+   - Credentials can be updated later in Settings → Account
 
 3. **Add Artists:**
 
@@ -387,7 +386,7 @@ Current priority is roadmap parity and UX polish on top of already shipped core 
 
 - ✅ **Global top bar** — `GlobalTopBar.tsx` + `FiltersPanel` (AI, media, source) and separate date sort control
 - ✅ **AI / media / source** — Backed by `searchStore` and post queries
-- ✅ **Source on Browse** — Favorites/Subscriptions require a tag query when using those modes (`SourceSwitcher`); **intentional** (see [roadmap](./docs/roadmap.md#closed-by-design-not-backlog)). Local modes apply AI/media in SQL before pagination. Subscriptions is `sinceTracking` (join by artist + publish date), not tag-intersection. Remote Source: All AI hide/only on **Rule34** is injected into the booru tag query; Gelbooru still uses the Browse worker.
+- ✅ **Source on Browse** — Favorites / Browse Source Subscriptions filter require a tag query when using those modes (`SourceSwitcher`); **intentional** (see [roadmap](./docs/roadmap.md#closed-by-design-not-backlog)). Local modes apply AI/media in SQL before pagination. Browse Source Subscriptions filter is `sinceTracking` (join by artist + publish date), not tag-intersection. Distinct from the unimplemented tag-combination subscriptions feature/table. Remote Source: All AI hide/only on **Rule34** is injected into the booru tag query; Gelbooru still uses the Browse worker.
 - 🟡 **View modes** — Grid (`VirtuosoGrid`) vs masonry (CSS columns); different scaling behavior on huge lists
 - ✅ **FTS5** — Tag search where integrated in browse/search flows
 
@@ -523,7 +522,7 @@ npm run test:verify
 
 ### Testing
 
-**Vitest** covers unit, integration, and property-based tests (**209 tests** across 30 files). **Playwright** covers E2E flows. Full suite inventory: [`tests/unit/TEST_COVERAGE.md`](tests/unit/TEST_COVERAGE.md).
+**Vitest** covers unit, integration, and property-based tests. **Playwright** covers E2E flows. Treat `npm test` output as the count source of truth; the file inventory in [`tests/unit/TEST_COVERAGE.md`](tests/unit/TEST_COVERAGE.md) may lag.
 
 ```bash
 # Full suite: rebuild for Node → run all Vitest tests → rebuild for Electron

--- a/docs/api-guide.md
+++ b/docs/api-guide.md
@@ -123,7 +123,7 @@ const allPosts: Post[] = data?.pages.flatMap((page: Post[]) => page) || [];
 
 **Scenario:** Infinite scroll on the Browse page against the live booru API (`searchBooru`). Rule34 offset pagination is capped at four pages; deeper scroll uses cursor pagination via `beforePostId` / `nextBeforePostId`.
 
-Browse **Favorites** / **Subscriptions** do not use this remote helper: they call `getArtistPosts` with `isFavorited` / `sinceTracking` and pass `aiFilter` / `mediaType` / `sortOrder` into SQL so filters apply before `LIMIT`/`OFFSET`. The React Query key is `buildBrowseSearchQueryKey({ tags, source, aiFilter, mediaType, sortOrder })` (chip tags + `aiFilter`; injected AI tokens are request-only).
+Browse **Favorites** / **Browse Source Subscriptions filter** do not use this remote helper: they call `getArtistPosts` with `isFavorited` / `sinceTracking` and pass `aiFilter` / `mediaType` / `sortOrder` into SQL so filters apply before `LIMIT`/`OFFSET`. The React Query key is `buildBrowseSearchQueryKey({ tags, source, aiFilter, mediaType, sortOrder })` (chip tags + `aiFilter`; injected AI tokens are request-only).
 
 On **Source: All** with provider **Rule34**, Browse appends AI filter tags to the `searchBooru` request via `buildRemoteBooruTagListForIpc` (`hide` → exclude tokens; `only` → OR-group). Conflict with the user's own AI chips skips injection and keeps worker AI filtering. **Gelbooru** does not inject (worker-only) until separately verified.
 
@@ -424,7 +424,7 @@ Returns a `http://127.0.0.1` URL served by the main-process `VideoProxyServer` t
 
 Retrieves tracked artists from the local database (newest activity first).
 
-**Limit:** Returns at most `MAX_TRACKED_ARTISTS` (5000). If the user has more subscriptions, the list is truncated and Main logs a warning — UI should not assume a complete unbounded list.
+**Limit:** Returns at most `MAX_TRACKED_ARTISTS` (5000). If the user has more tracked artists, the list is truncated and Main logs a warning — UI should not assume a complete unbounded list.
 
 **When to use:** Load the list of tracked artists for display in the Tracked page, sidebar, or artist selection dropdown.
 
@@ -608,24 +608,30 @@ if (settings) {
 **Real-world usage in React component:**
 
 ```typescript
-// In App.tsx - check if user needs onboarding
+// In App.tsx — Age Gate first, then AccountGate if no API key
 import type { IpcSettings } from "../../../shared/schemas/settings";
+import { AgeGate } from "@/components/onboarding/AgeGate";
 
 const { data: settings } = useQuery<IpcSettings | null>({
   queryKey: ["settings"],
   queryFn: () => window.api.getSettings(),
 });
 
-if (!settings || !settings.hasApiKey) {
-  // No settings or no API key configured - show onboarding
+const legalConfirmed =
+  settings?.isAdultVerified === true && settings.tosAcceptedAt !== null;
+if (!legalConfirmed) {
   return (
-    <Onboarding
-      onComplete={() => queryClient.invalidateQueries(["settings"])}
+    <AgeGate
+      onComplete={(updated) => queryClient.setQueryData(["settings"], updated)}
     />
   );
 }
 
-// Settings exist and API key is configured - show main app
+if (!settings.hasApiKey) {
+  // AccountGate in App.tsx renders SettingsAccountTab (saveSettings)
+  return <AccountGate />;
+}
+
 return <MainApp />;
 ```
 
@@ -639,12 +645,12 @@ Saves settings to the database. Supports partial updates (credentials, sync opti
 
 **⚠️ SECURITY CONTRACT:**
 
-- **Input:** API key is sent from Renderer in **plaintext** (unavoidable during onboarding)
+- **Input:** API key is sent from Renderer in **plaintext** (unavoidable during AccountGate / Settings → Account)
 - **Processing:** API key is **immediately encrypted** in Main Process using `safeStorage` API
 - **Storage:** Only **encrypted** key is stored in database
 - **Output:** API key is **NEVER** returned to Renderer (see `getSettings()` which returns `hasApiKey: boolean`)
 
-**When to use:** During onboarding flow when user enters their credentials, or when updating credentials in Settings.
+**When to use:** During AccountGate (`SettingsAccountTab`) when the user first enters credentials, or when updating credentials in Settings → Account.
 
 **Typical scenario:** User pastes credentials from Rule34.xxx account page → form validates → calls `saveSettings` → credentials encrypted and stored → user proceeds to main app.
 
@@ -959,7 +965,9 @@ return (
 
 ### `openExternal(url: string)`
 
-Opens a URL in the default external browser. Only allows rule34.xxx URLs for security.
+Opens a URL in the default external browser after `ViewerController` validates it against `ALLOWED_HOSTS` in `src/main/config/allowed-hosts.ts`.
+
+This allowlist is **user-click `shell.openExternal` only** (exact hostname, HTTPS). It is **not** `provider.allowedDomains` / `provider.cdnDomains` (CSP + video-proxy) and **not** the Sync provider registry. Currently the live set is `rule34.xxx` and `www.rule34.xxx`; `gelbooru.com` / `www.gelbooru.com` are present in the file but commented out.
 
 **Parameters:**
 
@@ -977,13 +985,13 @@ await window.api.openExternal(
 
 **IPC Channel:** `app:open-external`
 
-**Security:** Only HTTPS URLs from rule34.xxx domain are allowed.
+**Security:** Only HTTPS URLs whose hostname is in `ALLOWED_HOSTS`. Gelbooru post pages cannot be opened this way until those hosts are uncommented.
 
 ---
 
 ### `syncAll()`
 
-Initiates background synchronization of all tracked artists. Fetches new posts from Rule34.xxx API.
+Initiates background synchronization of all tracked artists. `SyncService` dispatches each artist through `getProvider(artist.provider)` (**Rule34** and **Gelbooru**). This is independent of the `openExternal` / `ALLOWED_HOSTS` allowlist.
 
 **Returns:** `Promise<boolean>`
 
@@ -2147,13 +2155,11 @@ Use these files as the canonical implementation reference for exact BaseControll
 
 Potential next additions (not committed to a release):
 
-- `updateArtist(artistId: number, data: Partial<Artist>)` - Update artist settings
-- `getSubscriptions()` / `addSubscription(...)` / `deleteSubscription(...)` - Subscription management
 - `getBackupList()` / `deleteBackup(...)` - Backup lifecycle management
 
 ## External API Integration
 
-The application integrates with **Rule34.xxx API**. Integration is handled in the Main process via `SyncService` and `SearchController`, and is not directly exposed as raw HTTP from the Renderer (Browse uses IPC `searchBooru`).
+The application integrates with booru providers via `IBooruProvider` (**Rule34.xxx** and **Gelbooru**). Integration is handled in the Main process via `SyncService` and `SearchController`, and is not directly exposed as raw HTTP from the Renderer (Browse uses IPC `searchBooru`).
 
 **SyncService (tracked artists):**
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -643,7 +643,7 @@ const posts = await db.query.posts.findMany({
 
    - **Remote gallery (Source: All):** live booru search via IPC `searchBooru`, infinite scroll through `useGalleryInfiniteScroll`.
    - **Rule34 deep pagination:** offset pages 1–4 (`RULE34_MAX_OFFSET_PAGES`), then cursor via meta-tag `id:<postId>` (`beforePostId` / `nextBeforePostId`); `getSearchBrowseNextPageParam()` drives React Query `pageParam`.
-   - **Local source modes:** Favorites / Subscriptions query cached DB posts via `getArtistPosts` (page + `LIMIT`/`OFFSET`). `aiFilter` / `mediaType` / `sortOrder` are passed into SQL (`buildPostFilterConditions`) so filtering happens **before** pagination — same pattern as `ArtistGallery`. Favorites maps to `isFavorited`; Subscriptions maps to `sinceTracking` (join `posts.artistId` + `publishedAt >= artists.createdAt`). Worker-side tag-intersection against tracked artist tags is **not** used.
+   - **Local source modes:** Favorites / Browse Source Subscriptions filter query cached DB posts via `getArtistPosts` (page + `LIMIT`/`OFFSET`). `aiFilter` / `mediaType` / `sortOrder` are passed into SQL (`buildPostFilterConditions`) so filtering happens **before** pagination — same pattern as `ArtistGallery`. Favorites maps to `isFavorited`; Browse Source Subscriptions filter maps to `sinceTracking` (join `posts.artistId` + `publishedAt >= artists.createdAt`). Worker-side tag-intersection against tracked artist tags is **not** used. Distinct from the unimplemented tag-combination subscriptions feature/table.
    - **Remote AI filter (Rule34):** Browse injects verified AI tag tokens into the `searchBooru` tags array (`buildRemoteBooruTagListForIpc` / `buildRemoteAiFilterTagInjection` in `searchStore.ts`): `hide` → `-ai_generated -ai-generated -ai_generation -ai-generated_content`; `only` → OR-group `( ai_generated ~ … )`. Injection is **Rule34-only**. Defensive skip when the user's include/exclude chips already conflict with the filter (avoids API empty-page AND of `tag -tag`); then the worker AI path remains the fallback. **Gelbooru** (and any non-Rule34 provider) never injects — worker AI filtering only (live Gelbooru tag injection not verified).
    - **Client-side filter/sort (remote only):** `useWorkerFilteredPosts` runs when Source is **All** and filters are non-default after accounting for injection (`usesDefaultRemoteFilters`: no chip tags + worker AI All + Media All). When Rule34 injection succeeds, worker receives `aiFilter: "all"` and only media/sort remain; Gelbooru / conflict keep worker AI. Worker output is mapped via `mapWorkerPostToPost()` in `src/renderer/lib/map-worker-post.ts` (preserves `mediaType`, `viewCount`, `lastViewedAt`; infers `mediaType` from `fileUrl` when missing).
    - Filter config is debounced (~250 ms) on the remote worker path; raw post pages are not debounced (scroll/load latency). Browse `queryKey` is `buildBrowseSearchQueryKey({ tags, source, aiFilter, mediaType, sortOrder })` with **chip tags** (not injected tokens) + `aiFilter` — isomorphic with viewer cache lookup; changing AI filter still refetches.
@@ -952,7 +952,7 @@ sequenceDiagram
 
 5. **Validation** - The IPC handler validates the request (though `getTrackedArtists` has no parameters, validation still runs for consistency).
 
-6. **Database query** - The handler calls `getTrackedArtistsWithStats()` (newest activity first), capped at `MAX_TRACKED_ARTISTS` (**5000**). If the DB has more subscriptions, the list is truncated and Main logs a warning.
+6. **Database query** - The handler calls `getTrackedArtistsWithStats()` (newest activity first), capped at `MAX_TRACKED_ARTISTS` (**5000**). If the DB has more tracked artists, the list is truncated and Main logs a warning.
 
 7. **Response** - The array of artists flows back:
 
@@ -1596,6 +1596,10 @@ src/
 │   │   ├── paths.ts               # DB/userData path constants (data.bin, .rdcache, backup prefix)
 │   │   ├── schema.ts              # Drizzle ORM schema definitions
 │   │   └── backfill-media-type.ts # Background media_type backfill
+│   ├── config/                    # Main-process constants / allowlists
+│   │   ├── allowed-hosts.ts       # shell.openExternal host allowlist (user click; not provider CDN)
+│   │   ├── constants.ts           # SYNC_SHUTDOWN_DRAIN_MS, VIDEO_CACHE_MAX_BYTES, …
+│   │   └── tag-resolve-constants.ts
 │   ├── ipc/                       # IPC (Inter-Process Communication)
 │   │   ├── controllers/           # IPC Controllers (domain-based)
 │   │   │   ├── ArtistsController.ts
@@ -1610,7 +1614,6 @@ src/
 │   │   │   ├── ViewerController.ts
 │   │   │   ├── FileController.ts
 │   │   │   ├── StatsController.ts
-│   │   │   ├── BlacklistController.ts
 │   │   │   ├── VideoProxyController.ts
 │   │   │   └── SystemController.ts
 │   │   ├── channels.ts            # IPC channel constants
@@ -1681,6 +1684,8 @@ src/
 │   │   ├── artists/               # Artist details/tracked/gallery/post card
 │   │   ├── settings/
 │   │   └── viewer/                # ViewerDialog shell + media/tags/query-key helpers
+│   ├── workers/                   # Renderer Web Workers (not Node worker_threads)
+│   │   └── data-processor.worker.ts # Remote Browse only (source=all): AI/media/sort; local Favorites / Browse Source Subscriptions filter use SQL
 │   ├── hooks/                     # App-level hooks
 │   ├── lib/                        # Utilities
 │   │   ├── hooks/                  # Custom React hooks
@@ -1882,7 +1887,7 @@ See [Roadmap](./roadmap.md#-security--reliability-hardening) for detailed securi
 
 ### Future Considerations
 
-1. **Tag Subscriptions:** Subscribe to tag combinations (see `docs/database.md` / schema notes)
+1. **tag-combination subscriptions feature/table:** Not implemented (see `docs/database.md` / planned product work). Distinct from the shipped Browse Source Subscriptions filter (`sinceTracking`).
 2. **Content Script Injection:** DOM enhancements for external sites
 3. **Statistics page:** extended aggregate metrics are shipped on the same `StatsPage` via `getExtendedStats` (totals, rating/media/viewed/favorites pie charts, provider artist split, top artists/tags, DB size). Further additions should stay in the same page/IPC pattern — see [roadmap — Planned product work](./roadmap.md#planned-product-work)
 4. **Multi-Booru Support:** additional providers on top of the existing `IBooruProvider` pattern (Rule34, Gelbooru)

--- a/docs/database.md
+++ b/docs/database.md
@@ -476,7 +476,7 @@ All database operations are accessed through Drizzle ORM using the database inst
 
 Retrieves tracked artists for IPC/UI via `getTrackedArtistsWithStats()` in `src/main/db/queries/artists.ts` (newest activity first).
 
-**Limit:** At most `MAX_TRACKED_ARTISTS` (**5000**, `src/shared/constants.ts`). If the DB has more rows, the query applies `.limit(5000)` and Main logs a warning — the UI must not assume an unbounded subscription list.
+**Limit:** At most `MAX_TRACKED_ARTISTS` (**5000**, `src/shared/constants.ts`). If the DB has more rows, the query applies `.limit(5000)` and Main logs a warning — the UI must not assume an unbounded tracked-artist list.
 
 **Example (query helper):**
 
@@ -1069,7 +1069,7 @@ Planned database improvements:
   - `playlists` table with support for manual and smart playlists
   - `playlist_entries` junction table with composite primary key
   - Full CRUD operations via `PlaylistController`
-- ⏳ **Subscriptions Table:** Tag subscriptions feature planned (schema not yet implemented)
+- ⏳ **tag-combination subscriptions feature/table:** Not implemented (no table in `schema.ts`). Distinct from the shipped **Browse Source Subscriptions filter** (`sinceTracking` on `posts` + `artists`).
 - ⏳ Post deduplication logic
 - ✅ Extended **Statistics** aggregates are shipped via `getExtendedStats` (totals, distributions, top artists/tags, timeline-ready data, DB size)
 - ⏳ Export/import functionality

--- a/docs/glossary.md
+++ b/docs/glossary.md
@@ -104,7 +104,7 @@ An abstraction layer that allows RuleDesk to support multiple booru sources with
 
 ### Browse
 
-The **Browse** page searches the live booru API (Source: **All**) or filters posts from the local cache (Source: **Favorites** / **Subscriptions**). Infinite scroll loads 50 posts per batch; on Rule34, RuleDesk continues past the API offset cap using cursor pagination (`id:<postId>`).
+The **Browse** page searches the live booru API (Source: **All**) or filters posts from the local cache (Source: **Favorites** / **Browse Source Subscriptions filter**). Infinite scroll loads 50 posts per batch; on Rule34, RuleDesk continues past the API offset cap using cursor pagination (`id:<postId>`).
 
 **Related:** [User Guide - Search](./user-guide.md#search), [Rule34 pagination](./rule34-api-reference.md#pagination-beyond-the-offset-cap), [searchBooru](./api-guide.md#searchbooru)
 
@@ -245,7 +245,7 @@ A system for marking and managing favorite posts. Favorites are stored locally i
 
 ### Tracked Artists / `MAX_TRACKED_ARTISTS`
 
-Artists (tags, uploaders, or query subscriptions) stored in the local `artists` table and surfaced via `getTrackedArtists()` IPC.
+Artists (tag, uploader, or query type) stored in the local `artists` table and surfaced via `getTrackedArtists()` IPC.
 
 **Cap:** IPC returns at most **5000** rows (`MAX_TRACKED_ARTISTS` in `src/shared/constants.ts`). Larger libraries are truncated with a Main-process warning — not a silent full export.
 
@@ -253,11 +253,17 @@ Artists (tags, uploaders, or query subscriptions) stored in the local `artists` 
 
 ---
 
-### Subscriptions
+### Browse Source Subscriptions filter
 
-Tag-based subscriptions for tracking specific tag combinations. Currently planned but not yet implemented.
+Shipped Browse **Source** toggle (`SourceSwitcher` value `subscriptions`, panel label **Subscriptions**). Local cache query with `sinceTracking`: posts published after the artist was tracked (`posts.artistId` + `publishedAt >= artists.createdAt`). Not tag-intersection with tracked artist names. Requires a non-empty tag query when selecting this source.
 
-**Related:** [Roadmap - Subscriptions](./roadmap.md#-subscriptions--updates)
+**Related:** [User Guide — Filters](./user-guide.md#filters-and-sorting), [Closed by design](./roadmap.md#closed-by-design-not-backlog)
+
+### tag-combination subscriptions feature/table
+
+Not implemented. No subscriptions table in `schema.ts`, no subscription IPC (`getSubscriptions` / `addSubscription` / `deleteSubscription` do not exist). Distinct from the Browse Source Subscriptions filter above.
+
+**Related:** [Planned product work](./roadmap.md#planned-product-work), [Database — Future Enhancements](./database.md#future-enhancements)
 
 ---
 
@@ -270,7 +276,7 @@ Curated collections of posts independent of Artists/Trackers. Users can create p
 - Create, rename, and delete playlists
 - Add posts to playlists via quick menu on Post Cards or in viewer
 - View playlist galleries with grid and masonry layouts
-- Filter and sort posts within playlists (FTS5 tag search, rating, media type, AI filter)
+- Filter and sort posts within playlists (FTS5 tag search, media type, AI filter)
 - Smart playlists with dynamic tag-based queries
 
 **Related:** [Roadmap](./roadmap.md#-active-roadmap-priority-tasks), [Database Schema - Playlists](./database.md#table-playlists)

--- a/docs/index.md
+++ b/docs/index.md
@@ -59,7 +59,7 @@ Welcome to the RuleDesk documentation. This index provides a structured navigati
 
 #### Setup & First Launch
 - [README.md - Quick Start](../README.md#-quick-start) - Launch checklist
-- [User Guide - First Launch](./user-guide.md#first-launch) - Initial onboarding steps
+- [User Guide - First Launch](./user-guide.md#first-launch) - Age Gate and account
 - [README.md - Settings](../README.md#-settings) - Core configuration
 
 #### Daily Usage
@@ -100,7 +100,7 @@ Engineering materials are intentionally grouped here to keep the top-level index
 - [Rule34 API Reference](./rule34-api-reference.md) - External API specifics
 - [README — Development Setup](../README.md#-development-setup) - Local dev, quality gates, testing, CI/CD
 - [Unit test guide](../tests/unit/README.md) - Vitest unit/property test layout
-- [Test coverage summary](../tests/unit/TEST_COVERAGE.md) - Suite inventory (**209** Vitest tests across 30 files)
+- [Test coverage summary](../tests/unit/TEST_COVERAGE.md) - Suite inventory (count: trust `npm test`; this file may lag)
 - [Integration test notes](../tests/integration/README.md) - IPC + SQLite integration tests
 - [.cursorrules](../.cursorrules) - Engineering standards (includes English-only UI copy; no i18n stack)
 - [Canonical Lessons](../.ai/LESSONS.txt) - Reusable invariants (do not add root `LESSONS.md`)
@@ -111,7 +111,7 @@ Engineering materials are intentionally grouped here to keep the top-level index
 |------|---------|
 | Typecheck + lint + img policy | `npm run validate` |
 | IPC API docs freshness | `npm run docs:api` (CI: then `git diff --exit-code docs/api.md`) |
-| All Vitest suites (209 tests) | `npm test` |
+| All Vitest suites | `npm test` |
 | Pre-PR full gate | `npm run test:verify` |
 | Production dependency audit | `npm audit --omit=dev --audit-level=high` |
 
@@ -174,5 +174,5 @@ This documentation is maintained alongside the codebase. When making changes:
 
 ---
 
-**Last Updated:** July 2026 — Audit v17 pack complete: PRs #105–#115 (including P0 video-cache #114 and sync-cursor #115). See [roadmap — branch tracking](./roadmap.md#-technical-improvements-from-audit--dx). Vitest **209** / **30** files (`npm run test:run`).
+**Last Updated:** August 2026 — see [roadmap — branch tracking](./roadmap.md#-technical-improvements-from-audit--dx). Vitest count: trust `npm test` / `npm run test:run` (do not hardcode).
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -7,7 +7,7 @@ This document reflects the current roadmap for RuleDesk `v17.x` and is aligned w
 - [Recent Fixes & Current Status](#-recent-fixes--current-status-completed)
 - [Active Roadmap](#-active-roadmap-priority-tasks)
 - [Navigation & UX Revamp](#-navigation--ux-revamp)
-- [Subscriptions / Updates](#-subscriptions--updates)
+- [Updates feed](#-updates-feed)
 - [Security & Reliability](#-security--reliability-hardening)
 - [Milestones](#-milestones)
 - [Technical Improvements & DX](#-technical-improvements-from-audit--dx)
@@ -46,7 +46,7 @@ The short version: the core product is shipped, now we focus on parity gaps and 
 
 - ✅ Global top bar exists and is used across core pages (includes `SyncStatusBadge`).
 - ✅ `FiltersPanel`: AI, media, source; wired to `searchStore` and post pipelines.
-- ✅ **Browse → Source (Favorites / Subscriptions):** requires at least one tag in the search box — **intentional** (`SourceSwitcher`). Local AI/media filters run in SQL before `LIMIT`. Subscriptions is **`sinceTracking` only** (posts published after the artist was tracked), not worker tag-intersection. Treated as **closed**; not a gap (see [Closed by design](#closed-by-design-not-backlog)).
+- ✅ **Browse → Source (Favorites / Browse Source Subscriptions filter):** requires at least one tag in the search box — **intentional** (`SourceSwitcher`). Local AI/media filters run in SQL before `LIMIT`. The Browse Source Subscriptions filter is **`sinceTracking` only** (posts published after the artist was tracked), not worker tag-intersection. Treated as **closed**; not a gap (see [Closed by design](#closed-by-design-not-backlog)). Distinct from the unimplemented [tag-combination subscriptions feature/table](#planned-product-work).
 - ✅ Search is chip-based and supports include/exclude, OR-groups, wildcard/fuzzy token forms (`*`, `~`) in query tokens.
 
 ### B. Viewer and Gallery Polish - High Priority
@@ -75,7 +75,7 @@ The short version: the core product is shipped, now we focus on parity gaps and 
 - 🟡 **Optional polish (backlog, not “missing v1”):** additional tooltips for dense controls, item order tweaks for first-run discoverability, and density tuning on small windows. This is **UX refinement** on the current structure — we are **not** tracking alignment to an obsolete written wireframe; the product is what ships in the build.
 - ✅ **Masonry vs grid** — two explicit modes; **closed** as a gap ([Closed by design](#closed-by-design-not-backlog)).
 
-## 📰 Subscriptions / Updates
+## 📰 Updates feed
 
 ### Feed Enhancements
 
@@ -148,7 +148,7 @@ The short version: the core product is shipped, now we focus on parity gaps and 
 
 | # | Branch | PR | Status |
 |---|--------|----|--------|
-| — | `audit/sync-pagination-large-artists` | — | 🔄 in progress (graceful sync cancel + quit drain + FTS trigger recovery on DB init) |
+| — | `audit/sync-pagination-large-artists` | — | ✅ merged into master (no dedicated PR number): `requestCancel` / `waitUntilIdle` + quit drain (`SYNC_SHUTDOWN_DRAIN_MS` in `main.ts`) + `ensureFtsTriggers` on DB init (`fts-triggers.ts`) |
 
 ### Audit v17 — branch tracking (complete)
 
@@ -172,11 +172,12 @@ Both P0 rows (#1–#2) are closed — the full v17 audit pack landed (after one 
 
 | Branch | Status | Notes |
 |--------|--------|-------|
-| `chore/split-viewer-dialog` | 🔄 in progress | Mechanical split of `ViewerDialog` + `buildViewerOriginQueryKey` consolidation |
+| `chore/split-viewer-dialog` | ✅ merged | [#153](https://github.com/KazeKaze93/RuleDesk/pull/153) — Mechanical split: `ViewerDialog` shell + `ViewerContent` / `ViewerMedia` / `TagsDrawer` / `PostNotFoundFallback`; `buildViewerOriginQueryKey` consolidation |
 | `chore/split-playlists-page` | ✅ merged | [#152](https://github.com/KazeKaze93/RuleDesk/pull/152) — Mechanical split: `PlaylistsPage` list/CRUD; `PlaylistGallery` + virtuoso wrappers under `components/playlists/` |
+| `chore/remove-dead-onboarding-component` | ✅ merged | [#145](https://github.com/KazeKaze93/RuleDesk/pull/145) — Removed `Onboarding.tsx`; first launch is Age Gate → AccountGate / `SettingsAccountTab` (no Skip) |
 
 - Shadow-insert cache-miss path (`PostNotFoundFallback`) is not live-tested after the ViewerDialog split — check when a natural case appears (remote playlist post absent from RQ cache); do not force a synthetic miss.
-| `fix/artist-autocomplete-throttle-cancellation` | 🔄 started | Add Artist second-pass: `user` throttle + Main abort of superseded waves; intervals unchanged |
+| `fix/artist-autocomplete-throttle-cancellation` | ✅ merged | [#151](https://github.com/KazeKaze93/RuleDesk/pull/151) — Add Artist second-pass: `user` throttle + Main abort of superseded waves; intervals unchanged |
 | `feat/add-artist-autocomplete-artist-only` | ✅ merged | [#150](https://github.com/KazeKaze93/RuleDesk/pull/150) — Add Artist autocomplete: Gelbooru `category===artist`; Rule34 top-5 DAPI second-pass; Browse search unfiltered |
 | `feat/sync-status-live-ui` | ✅ merged | [#149](https://github.com/KazeKaze93/RuleDesk/pull/149) — invalidate `["artists"]` on `sync:artist` + repair start/end; preload wires `REPAIR_*`; `sync:progress` payload unchanged |
 | `feat/sync-status-write-and-recovery` | ✅ merged | [#148](https://github.com/KazeKaze93/RuleDesk/pull/148) — persist per-artist `syncStatus` / `lastError`; `resetStaleSyncingArtists` on DB init |
@@ -190,7 +191,7 @@ Both P0 rows (#1–#2) are closed — the full v17 audit pack landed (after one 
 
 - ✅ **Testing:** Vitest (unit, integration, property/fuzzing) + Playwright; ABI rebuild scripts for Node vs Electron.
 - ✅ **CI:** `validate` → `docs:api` freshness → `npm test` → production `npm audit --omit=dev --audit-level=high`; release tags wait for quality + e2e, then Windows zip + Linux AppImage.
-- ✅ **Post-audit regression tests:** **209** Vitest tests across **30** files (includes collapse/throttle + `SecureStorage` + video-proxy suites — see [`TEST_COVERAGE.md`](../tests/unit/TEST_COVERAGE.md); inventory file may lag — trust `npm test` count).
+- ✅ **Post-audit regression tests:** Vitest unit + integration + property suites (includes collapse/throttle + `SecureStorage` + video-proxy). Inventory in [`TEST_COVERAGE.md`](../tests/unit/TEST_COVERAGE.md) may lag — trust `npm test` output as the count source of truth.
 - ✅ **Main process HMR/watch**, shared Zod IPC helpers, provider search typed errors, video pipeline baseline (`<video>` attrs / hardware decode flags).
 
 - ⏳ **Tooling / hygiene:** keep `validate` green; remaining shared validation consolidation as needed. Dev-only audit noise (electron-builder transitive deps) is separate from production `npm audit`.
@@ -213,7 +214,7 @@ Both P0 rows (#1–#2) are closed — the full v17 audit pack landed (after one 
 
 | Topic | Status |
 |-------|--------|
-| **Browse → Source: Favorites / Subscriptions** | Requires a **non-empty tag query** in `SourceSwitcher` so those modes are selected in the context of a search. Local results come from SQL (`isFavorited` / `sinceTracking`) with AI/media applied before pagination. Subscriptions is **sinceTracking-only** (join by artist + publish date), not tag-intersection with tracked artist names. **Working as designed.** |
+| **Browse Source Subscriptions filter** (and Favorites) | Requires a **non-empty tag query** in `SourceSwitcher` so those modes are selected in the context of a search. Local results come from SQL (`isFavorited` / `sinceTracking`) with AI/media applied before pagination. Browse Source Subscriptions filter is **sinceTracking-only** (join by artist + publish date), not tag-intersection with tracked artist names. **Working as designed.** Distinct from the unimplemented tag-combination subscriptions feature/table. |
 | **Masonry vs grid** | Two **first-class** view toggles. No silent fallback; no open “masonry not implemented” item. |
 | **Viewer tags / progressive cards** | Shipped (`TagsDrawer`, `PostCard`). |
 
@@ -225,6 +226,7 @@ Items explicitly scheduled for product/engineering (beyond small bugs).
 
 | Item | Description |
 |------|-------------|
+| **tag-combination subscriptions feature/table** | Not implemented (no table in `schema.ts`, no subscription IPC). Distinct from the shipped **Browse Source Subscriptions filter** (`sinceTracking`). |
 
 ---
 

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -74,7 +74,9 @@ Clone the repo, run `npm install`, then `npm run dev`. See [README — Developme
 
 ## First Launch
 
-When you first open RuleDesk, you'll see the **Onboarding** screen. This is where you'll enter your API credentials.
+When you first open RuleDesk, **Age Gate** (`AgeGate.tsx`) must be completed before any content loads: confirm you are an adult and accept the Terms. That calls `confirmLegal` and stores `isAdultVerified` / `tosAcceptedAt`.
+
+If no API key is configured (`hasApiKey` is false), **AccountGate** in `App.tsx` is shown next. It renders **Settings → Account** (`SettingsAccountTab`): enter User ID and API Key (or paste the account page URL into either field) and click **Save API Key**. There is no Skip — without credentials the main app does not load. You can change credentials later in Settings → Account.
 
 ### What are API Credentials?
 
@@ -247,7 +249,7 @@ Each post card shows:
 - The search area in the top bar uses the available width before action buttons and can grow to a second chip row when the first row is full.
 - **Infinite scroll:** on Browse with **Source: All**, scroll down to load more posts from the booru API (50 per batch; RuleDesk continues past the API offset cap automatically).
 - **API failures vs empty results:** a genuine empty search shows the “no posts” empty state; auth, rate-limit, network, or parse failures show a centered error screen with **Retry** (and **Open Settings** when credentials are invalid).
-- Browse source modes **Favorites** / **Subscriptions** query your **local cache** (SQL `isFavorited` / `sinceTracking`) and still require a non-empty tag query in the Source switcher by design. AI and Media filters on those modes run in SQL before pagination. On **Source: All** with Rule34, AI hide/only is sent as booru tags in the live search (so pages stay full); Gelbooru still filters AI client-side after each page. **Subscriptions** means posts published after you started tracking the artist, not posts whose tags happen to match a tracked artist name.
+- Browse source modes **Favorites** / **Browse Source Subscriptions filter** (panel label **Subscriptions**) query your **local cache** (SQL `isFavorited` / `sinceTracking`) and still require a non-empty tag query in the Source switcher by design. AI and Media filters on those modes run in SQL before pagination. On **Source: All** with Rule34, AI hide/only is sent as booru tags in the live search (so pages stay full); Gelbooru still filters AI client-side after each page. The Browse Source Subscriptions filter means posts published after you started tracking the artist, not posts whose tags happen to match a tracked artist name. It is not the unimplemented tag-combination subscriptions feature/table.
 
 ### Favorites
 
@@ -323,7 +325,7 @@ The download will start, and you'll see a progress indicator.
 **Filter by source:**
 
 1. In views that show the filter panel, open the top bar **Filters** control
-2. Choose **All** (live booru API), **Favorites** (local cache), or **Subscriptions** (local cache: posts published after you started tracking the artist)
+2. Choose **All** (live booru API), **Favorites** (local cache), or **Subscriptions** (Browse Source Subscriptions filter: local cache, posts published after you started tracking the artist)
 3. Gallery updates automatically
 
 **Filter by media type:**
@@ -383,7 +385,7 @@ RuleDesk has a **sidebar** on the left side with the main sections:
 ### Sidebar Sections
 
 - **Updates** - See new posts from your tracked sources. A purple badge shows unread count and auto-refreshes periodically.
-- **Browse** - Search the live booru (Source: All) or filter cached posts (Favorites / Subscriptions); infinite scroll, filters, and sorting
+- **Browse** - Search the live booru (Source: All) or filter cached posts (Favorites / Browse Source Subscriptions filter); infinite scroll, filters, and sorting
 - **Favorites** - Your favorited posts collection
 - **Playlists** - Manual playlists and smart collections
 - **Statistics** - Local library aggregates and charts (`/stats`)
@@ -570,8 +572,8 @@ Open **Statistics** from the sidebar to see a quick health overview of your loca
 **Solutions:**
 
 1. Confirm API credentials in **Settings → Account**
-2. Clear restrictive filters (AI, media). On Browse Favorites/Subscriptions those filters run in SQL before pagination. On Source: All with Rule34, AI hide/only is applied in the live API tag query (fuller pages); Gelbooru and conflict cases still filter client-side after each API page. Media filters on Source: All remain client-side.
-3. If using **Favorites** / **Subscriptions**, add at least one tag in the search bar (required by design)
+2. Clear restrictive filters (AI, media). On Browse Favorites / Browse Source Subscriptions filter those filters run in SQL before pagination. On Source: All with Rule34, AI hide/only is applied in the live API tag query (fuller pages); Gelbooru and conflict cases still filter client-side after each API page. Media filters on Source: All remain client-side.
+3. If using **Favorites** / **Browse Source Subscriptions filter**, add at least one tag in the search bar (required by design)
 4. If Browse shows a centered error screen (not the empty “no posts” state), use **Retry** or **Open Settings** for auth failures — messages distinguish invalid API credentials, rate limits, and network errors
 
 ### Video playback glitches / stuck loading

--- a/tests/unit/README.md
+++ b/tests/unit/README.md
@@ -31,7 +31,7 @@ Vitest tests for gallery logic, filters, layout, and shared utilities. Property-
 
 ### Core (Main)
 
-- **`core/di-container.test.ts`** — `Container` keyed by `token.id`; re-entrant circular detection
+- **`core/di-container.test.ts`** — `Container` keyed by `token.id` (instance Map; no circular-dependency detection)
 
 ### Worker mapping
 


### PR DESCRIPTION
## Summary
- Align roadmap tracking with merged work (#145 Onboarding removal, #151 throttle-cancellation, #153 ViewerDialog split, sync-pagination quit drain already on master).
- Replace stale Onboarding.tsx / Skip first-launch copy with Age Gate → AccountGate (`SettingsAccountTab`); split Browse Source Subscriptions filter (`sinceTracking`, shipped) from unimplemented tag-combination subscriptions feature/table.
- Drop hardcoded Vitest 209/30 counts; document `openExternal` ALLOWED_HOSTS vs Sync provider dispatch; remove non-existent IPC from api-guide Evolution Notes.

## Test plan
- [ ] Skim `git diff origin/master...HEAD` — docs only, no `docs/api.md`, no code.
- [ ] Glossary + README + user-guide use the two Subscriptions terms consistently.
- [ ] First Launch sections no longer mention `Onboarding.tsx` or Skip.
- [ ] Roadmap still lists Gelbooru live-verify and shadow-insert cache-miss as open.
