### PR TITLE
fix: P1 test-suite false confidence

### DIFF
--- a/.ai/LESSONS.txt
+++ b/.ai/LESSONS.txt
@@ -212,6 +212,10 @@ Invariant Rule: Run `npm run validate` before finishing and remove all unused im
 
 ## Testing
 
+### Problem: Tests that reimplement production logic or swallow failures create false confidence
+**Root Cause:** Suites copied pagination locally instead of importing the hook, property tests `return true` without asserting Zod `safeParse`, and e2e `.catch(() => {})` / "empty input but enabled submit = success" treated missing UI as pass.
+**Invariant Rule:** A test must import and call production code, not a local copy of the algorithm. Property tests assert parse success and failure, never vacuously return true. E2E waits for required state must fail on timeout; optional UI (autocomplete dropdown) may branch, but the required field value / gate visibility must be asserted positively.
+
 ### Problem: Dual-ABI test setup masks Electron-vs-Node native module incompatibilities
 **Root Cause:** When tests rebuild better-sqlite3 against Node.js ABI, they don't execute under Electron's runtime. Edge cases that manifest only under Electron's event loop, WAL semantics, or sandbox behavior pass tests but fail in production.
 **Invariant Rule:** Integration tests involving native modules (better-sqlite3) should ideally run inside Electron via Playwright/electron-vitest. If staying with dual-ABI for speed, document the gap explicitly and add end-to-end Electron tests for critical DB paths.

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -172,6 +172,7 @@ Both P0 rows (#1–#2) are closed — the full v17 audit pack landed (after one 
 
 | Branch | Status | Notes |
 |--------|--------|-------|
+| `fix/p1-test-suite-false-confidence` | started | P1-1..P1-4: property/e2e/hook tests that could not fail on real regressions. P1-5 Gelbooru transport `[]` vs Rule34 throw — prod silent-failure, **not** fixed in this branch. |
 | `chore/split-viewer-dialog` | ✅ merged | [#153](https://github.com/KazeKaze93/RuleDesk/pull/153) — Mechanical split: `ViewerDialog` shell + `ViewerContent` / `ViewerMedia` / `TagsDrawer` / `PostNotFoundFallback`; `buildViewerOriginQueryKey` consolidation |
 | `chore/split-playlists-page` | ✅ merged | [#152](https://github.com/KazeKaze93/RuleDesk/pull/152) — Mechanical split: `PlaylistsPage` list/CRUD; `PlaylistGallery` + virtuoso wrappers under `components/playlists/` |
 | `chore/remove-dead-onboarding-component` | ✅ merged | [#145](https://github.com/KazeKaze93/RuleDesk/pull/145) — Removed `Onboarding.tsx`; first launch is Age Gate → AccountGate / `SettingsAccountTab` (no Skip) |

--- a/package-lock.json
+++ b/package-lock.json
@@ -76,6 +76,7 @@
         "eslint-plugin-react-refresh": "^0.4.24",
         "fast-check": "^4.5.3",
         "globals": "^16.5.0",
+        "jsdom": "^30.0.1",
         "msw": "^2.12.7",
         "playwright": "^1.57.0",
         "postcss": "^8.4.32",
@@ -101,6 +102,59 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@asamuzakjp/css-color": {
+      "version": "6.0.7",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/css-color/-/css-color-6.0.7.tgz",
+      "integrity": "sha512-vC/bk1Lz7Tn/EfU9/apOTBk80/8dyGyWMowPoV1tJ52muDGsDqt2HPT2klrFUiY60MQmQv9q8yIht15JnBgDGw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@csstools/css-calc": "^3.3.0",
+        "@csstools/css-color-parser": "^4.1.10",
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0",
+        "lru-cache": "^11.5.2"
+      },
+      "engines": {
+        "node": "^22.13.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@asamuzakjp/css-color/node_modules/lru-cache": {
+      "version": "11.5.2",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.5.2.tgz",
+      "integrity": "sha512-4pfM1Ff0x50o0tQwb5ucw/RzNyD0/YJME6IVcStalZuMWxdt3sR3huStTtxz4PUmvZfRguvDejasvQ2kifR11g==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
+    "node_modules/@asamuzakjp/dom-selector": {
+      "version": "8.3.2",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/dom-selector/-/dom-selector-8.3.2.tgz",
+      "integrity": "sha512-93Z1N+BQNXysodoicpOIyNh2drHfz/CTf9nnT0FEx72GJcIiwgydD7tGAr78j41LsYn3hlRn+LdGPuBLn1Bl8Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "bidi-js": "^1.0.3",
+        "css-tree": "^3.2.1",
+        "is-potential-custom-element-name": "^1.0.1",
+        "lru-cache": "^11.5.2"
+      },
+      "engines": {
+        "node": "^22.13.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@asamuzakjp/dom-selector/node_modules/lru-cache": {
+      "version": "11.5.2",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.5.2.tgz",
+      "integrity": "sha512-4pfM1Ff0x50o0tQwb5ucw/RzNyD0/YJME6IVcStalZuMWxdt3sR3huStTtxz4PUmvZfRguvDejasvQ2kifR11g==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": "20 || >=22"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -431,6 +485,19 @@
         "node": ">=18"
       }
     },
+    "node_modules/@bramus/specificity": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/@bramus/specificity/-/specificity-2.4.2.tgz",
+      "integrity": "sha512-ctxtJ/eA+t+6q2++vj5j7FYX3nRu311q1wfYH3xjlLOsczhlhxAg2FWNUXhpGvAw3BWo1xBcvOV6/YLc2r5FJw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "css-tree": "^3.0.0"
+      },
+      "bin": {
+        "specificity": "bin/cli.js"
+      }
+    },
     "node_modules/@clack/core": {
       "version": "0.5.0",
       "resolved": "https://registry.npmjs.org/@clack/core/-/core-0.5.0.tgz",
@@ -452,6 +519,146 @@
         "@clack/core": "0.5.0",
         "picocolors": "^1.0.0",
         "sisteransi": "^1.0.5"
+      }
+    },
+    "node_modules/@csstools/color-helpers": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/@csstools/color-helpers/-/color-helpers-6.1.0.tgz",
+      "integrity": "sha512-064IFJdjTfUqnjpCVpMOdbr8FLQBhinbZj6yRv2An2E41O/pLEXqfFRWqGq/SxlE5PEUYTlvWsG2r8MswAVvkg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "engines": {
+        "node": ">=20.19.0"
+      }
+    },
+    "node_modules/@csstools/css-calc": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-calc/-/css-calc-3.3.0.tgz",
+      "integrity": "sha512-c5ihYsPkdG6JCkU2zTMm4+k6r7RXuGxtWYhu5DHMIiF1FHzrfmHL5so11AoFpUv/tu61xfcmT4AmKoFfMPoqdQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@csstools/css-color-parser": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@csstools/css-color-parser/-/css-color-parser-4.1.10.tgz",
+      "integrity": "sha512-UZhQLIUyJaaMepqehrCODwCg2KW25vFvLWBmqYFaPclYvvxzj/sG8LBOhBFCp11i9uE7t1EyS+RAoV9tztPFyw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@csstools/color-helpers": "^6.1.0",
+        "@csstools/css-calc": "^3.3.0"
+      },
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@csstools/css-parser-algorithms": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-parser-algorithms/-/css-parser-algorithms-4.0.0.tgz",
+      "integrity": "sha512-+B87qS7fIG3L5h3qwJ/IFbjoVoOe/bpOdh9hAjXbvx0o8ImEmUsGXN0inFOnk2ChCFgqkkGFQ+TpM5rbhkKe4w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@csstools/css-syntax-patches-for-csstree": {
+      "version": "1.1.7",
+      "resolved": "https://registry.npmjs.org/@csstools/css-syntax-patches-for-csstree/-/css-syntax-patches-for-csstree-1.1.7.tgz",
+      "integrity": "sha512-fQ+05118eQS1cofO3aJpB5efgpBZMvIzwr/sbC8kDLVA5XLG8q1kJV5yzrUAI1f7lvhPnm8fgIjzFB8/O/5Dig==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "peerDependencies": {
+        "css-tree": "^3.2.1"
+      },
+      "peerDependenciesMeta": {
+        "css-tree": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@csstools/css-tokenizer": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-tokenizer/-/css-tokenizer-4.0.0.tgz",
+      "integrity": "sha512-QxULHAm7cNu72w97JUNCBFODFaXpbDg+dP8b/oWFAZ2MTRppA3U00Y2L1HqaS4J6yBqxwa/Y3nMBaxVKbB/NsA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.19.0"
       }
     },
     "node_modules/@develar/schema-utils": {
@@ -2102,6 +2309,24 @@
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/@exodus/bytes": {
+      "version": "1.15.1",
+      "resolved": "https://registry.npmjs.org/@exodus/bytes/-/bytes-1.15.1.tgz",
+      "integrity": "sha512-S6mL0yNB/Abt9Ei4tq8gDhcczc4S3+vQ4ra7vxnAf+YHC02srtqxKKZghx2Dq6p0e66THKwR6r8N6P95wEty7Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      },
+      "peerDependencies": {
+        "@noble/hashes": "^1.8.0 || ^2.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@noble/hashes": {
+          "optional": true
+        }
       }
     },
     "node_modules/@floating-ui/core": {
@@ -6318,6 +6543,16 @@
         "node": "20.x || 22.x || 23.x || 24.x || 25.x"
       }
     },
+    "node_modules/bidi-js": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/bidi-js/-/bidi-js-1.0.3.tgz",
+      "integrity": "sha512-RKshQI1R3YQ+n9YJz2QQ147P66ELpa1FQEg20Dk8oW9t2KgLbpDLLp9aGZ7y8WHSshDknG0bknqGw5/tyCs5tw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "require-from-string": "^2.0.2"
+      }
+    },
     "node_modules/binary-extensions": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.3.0.tgz",
@@ -7278,6 +7513,20 @@
         "node": ">= 8"
       }
     },
+    "node_modules/css-tree": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-3.2.1.tgz",
+      "integrity": "sha512-X7sjQzceUhu1u7Y/ylrRZFU2FS6LRiFVp6rKLPg23y3x3c3DOKAwuXGDp+PAGjh6CSnCjYeAul8pcT8bAl+lSA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mdn-data": "2.27.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12.20.0 || ^14.13.0 || >=15.0.0"
+      }
+    },
     "node_modules/cssesc": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/cssesc/-/cssesc-3.0.0.tgz",
@@ -7419,6 +7668,35 @@
         "node": ">=12"
       }
     },
+    "node_modules/data-urls": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-7.0.0.tgz",
+      "integrity": "sha512-23XHcCF+coGYevirZceTVD7NdJOqVn+49IHyxgszm+JIiHLoB2TkmPtsYkNWT1pvRSGkc35L6NHs0yHkN2SumA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-mimetype": "^5.0.0",
+        "whatwg-url": "^16.0.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "node_modules/data-urls/node_modules/whatwg-url": {
+      "version": "16.0.1",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-16.0.1.tgz",
+      "integrity": "sha512-1to4zXBxmXHV3IiSSEInrreIlu02vUOvrhxJJH5vcxYTBDAx51cqZiKdyTxlecdKNSjj8EcxGBxNf6Vg+945gw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@exodus/bytes": "^1.11.0",
+        "tr46": "^6.0.0",
+        "webidl-conversions": "^8.0.1"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
     "node_modules/debounce-fn": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/debounce-fn/-/debounce-fn-6.0.0.tgz",
@@ -7450,6 +7728,13 @@
           "optional": true
         }
       }
+    },
+    "node_modules/decimal.js": {
+      "version": "10.6.0",
+      "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.6.0.tgz",
+      "integrity": "sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/decimal.js-light": {
       "version": "2.5.1",
@@ -8792,6 +9077,19 @@
       "license": "MIT",
       "dependencies": {
         "once": "^1.4.0"
+      }
+    },
+    "node_modules/entities": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-8.0.0.tgz",
+      "integrity": "sha512-zwfzJecQ/Uej6tusMqwAqU/6KL2XaB2VZ2Jg54Je6ahNBGNH6Ek6g3jjNCF0fG9EWQKGZNddNjU5F1ZQn/sBnA==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
       }
     },
     "node_modules/env-paths": {
@@ -10371,6 +10669,19 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/html-encoding-sniffer": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-6.0.0.tgz",
+      "integrity": "sha512-CV9TW3Y3f8/wT0BRFc1/KAVQ3TUHiXmaAb6VW9vtiMFf7SLoMd1PdAc4W3KFOFETBJUb90KatHqlsZMWV+R9Gg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@exodus/bytes": "^1.6.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
     "node_modules/html-escaper": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.2.tgz",
@@ -10801,6 +11112,13 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/is-potential-custom-element-name": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz",
+      "integrity": "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/is-ssh": {
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/is-ssh/-/is-ssh-1.4.1.tgz",
@@ -11030,6 +11348,67 @@
       "license": "LGPL-2.1+",
       "engines": {
         "node": ">=0.1.90"
+      }
+    },
+    "node_modules/jsdom": {
+      "version": "30.0.1",
+      "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-30.0.1.tgz",
+      "integrity": "sha512-52v7mUVUfNQVYYqE1lcdaymWL0njO7lTLUog6ZvW2U5KsbiLk/GnZlVJ+qx0xfNJZ6Gn+KSpPNE52vurbxZwrA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/css-color": "^6.0.5",
+        "@asamuzakjp/dom-selector": "^8.3.0",
+        "@bramus/specificity": "^2.4.2",
+        "@csstools/css-syntax-patches-for-csstree": "^1.1.7",
+        "@exodus/bytes": "^1.15.1",
+        "css-tree": "^3.2.1",
+        "data-urls": "^7.0.0",
+        "decimal.js": "^10.6.0",
+        "html-encoding-sniffer": "^6.0.0",
+        "is-potential-custom-element-name": "^1.0.1",
+        "lru-cache": "^11.5.2",
+        "parse5": "^8.0.1",
+        "saxes": "^6.0.0",
+        "symbol-tree": "^3.2.4",
+        "tough-cookie": "^6.0.2",
+        "undici": "^8.9.0",
+        "w3c-xmlserializer": "^5.0.0",
+        "webidl-conversions": "^8.0.1",
+        "whatwg-mimetype": "^5.0.0",
+        "whatwg-url": "^17.1.0",
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": "^22.22.2 || ^24.15.0 || >=26.0.0"
+      },
+      "peerDependencies": {
+        "canvas": "^3.2.3"
+      },
+      "peerDependenciesMeta": {
+        "canvas": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/jsdom/node_modules/lru-cache": {
+      "version": "11.5.2",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.5.2.tgz",
+      "integrity": "sha512-4pfM1Ff0x50o0tQwb5ucw/RzNyD0/YJME6IVcStalZuMWxdt3sR3huStTtxz4PUmvZfRguvDejasvQ2kifR11g==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
+    "node_modules/jsdom/node_modules/undici": {
+      "version": "8.10.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-8.10.0.tgz",
+      "integrity": "sha512-HvltHd7avK13QIw/oLe4qoOLyoVSoafqJ2jYOrtMRBkbYT31eiBQ8O0ehRKZiEZCMEyLFQNIADpgCWC5fALvYQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=22.19.0"
       }
     },
     "node_modules/jsesc": {
@@ -11538,6 +11917,13 @@
       "engines": {
         "node": ">= 0.4"
       }
+    },
+    "node_modules/mdn-data": {
+      "version": "2.27.1",
+      "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.27.1.tgz",
+      "integrity": "sha512-9Yubnt3e8A0OKwxYSXyhLymGW4sCufcLG6VdiDdUGVkPhpqLxlvP5vl1983gQjJl3tqbrM731mjaZaP68AgosQ==",
+      "dev": true,
+      "license": "CC0-1.0"
     },
     "node_modules/media-typer": {
       "version": "0.3.0",
@@ -12456,6 +12842,19 @@
       },
       "engines": {
         "node": ">=14.13.0"
+      }
+    },
+    "node_modules/parse5": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-8.0.1.tgz",
+      "integrity": "sha512-z1e/HMG90obSGeidlli3hj7cbocou0/wa5HacvI3ASx34PecNjNQeaHNo5WIZpWofN9kgkqV1q5YvXe3F0FoPw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "entities": "^8.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
       }
     },
     "node_modules/parseurl": {
@@ -14022,6 +14421,19 @@
       "integrity": "sha512-yqYn1JhPczigF94DMS+shiDMjDowYO6y9+wB/4WgO0Y19jWYk0lQ4tuG5KI7kj4FTp1wxPj5IFfcrz/s1c3jjQ==",
       "license": "BlueOak-1.0.0"
     },
+    "node_modules/saxes": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/saxes/-/saxes-6.0.0.tgz",
+      "integrity": "sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "xmlchars": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=v12.22.7"
+      }
+    },
     "node_modules/scheduler": {
       "version": "0.23.2",
       "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.23.2.tgz",
@@ -14714,6 +15126,13 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/symbol-tree": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
+      "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/system-architecture": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/system-architecture/-/system-architecture-0.1.0.tgz",
@@ -15226,9 +15645,9 @@
       }
     },
     "node_modules/tough-cookie": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-6.0.0.tgz",
-      "integrity": "sha512-kXuRi1mtaKMrsLUxz3sQYvVl37B0Ns6MzfrtV5DvJceE9bPyspOqk9xxv7XbZWcfLWbFmm997vl83qUWVJA64w==",
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-6.0.2.tgz",
+      "integrity": "sha512-exgYmnmL/sJpR3upZfXG5PoatXQii55xAiXGXzY+sROLZ/Y+SLcp9PgJNI9Vz37HpQ74WvDcLT8eqm+kV3FzrA==",
       "dev": true,
       "license": "BSD-3-Clause",
       "dependencies": {
@@ -15236,6 +15655,19 @@
       },
       "engines": {
         "node": ">=16"
+      }
+    },
+    "node_modules/tr46": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-6.0.0.tgz",
+      "integrity": "sha512-bLVMLPtstlZ4iMQHpFHTR7GAGj2jxi8Dg0s2h2MafAE4uSWF98FC/3MomU51iQAMf8/qDUbKWf5GxuvvVcXEhw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "punycode": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=20"
       }
     },
     "node_modules/truncate-utf8-bytes": {
@@ -17348,6 +17780,19 @@
         }
       }
     },
+    "node_modules/w3c-xmlserializer": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/w3c-xmlserializer/-/w3c-xmlserializer-5.0.0.tgz",
+      "integrity": "sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/wcwidth": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/wcwidth/-/wcwidth-1.0.1.tgz",
@@ -17371,6 +17816,41 @@
         "@types/emscripten": {
           "optional": true
         }
+      }
+    },
+    "node_modules/webidl-conversions": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-8.0.1.tgz",
+      "integrity": "sha512-BMhLD/Sw+GbJC21C/UgyaZX41nPt8bUTg+jWyDeg7e7YN4xOM05YPSIXceACnXVtqyEw/LMClUQMtMZ+PGGpqQ==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/whatwg-mimetype": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-5.0.0.tgz",
+      "integrity": "sha512-sXcNcHOC51uPGF0P/D4NVtrkjSU2fNsm9iog4ZvZJsL3rjoDAzXZhkm2MWt1y+PUdggKAYVoMAIYcs78wJ51Cw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/whatwg-url": {
+      "version": "17.1.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-17.1.0.tgz",
+      "integrity": "sha512-3GeworPmc2ZfEEHP7lEbUfBX/L75wdEsi0rLNhXcXxnoN5jyq0SL5gCy06SGW2cyTIZdTvWIDQNQoza++vKeaw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@exodus/bytes": "^1.15.1",
+        "tr46": "^6.0.0",
+        "webidl-conversions": "^8.0.1"
+      },
+      "engines": {
+        "node": "^22.14.0 || >=24.0.0"
       }
     },
     "node_modules/when-exit": {
@@ -17520,6 +18000,16 @@
       "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
       "license": "ISC"
     },
+    "node_modules/xml-name-validator": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-5.0.0.tgz",
+      "integrity": "sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/xml-naming": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/xml-naming/-/xml-naming-0.1.0.tgz",
@@ -17544,6 +18034,13 @@
       "engines": {
         "node": ">=8.0"
       }
+    },
+    "node_modules/xmlchars": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
+      "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/y18n": {
       "version": "5.0.8",

--- a/package.json
+++ b/package.json
@@ -85,6 +85,7 @@
     "eslint-plugin-react-refresh": "^0.4.24",
     "fast-check": "^4.5.3",
     "globals": "^16.5.0",
+    "jsdom": "^30.0.1",
     "msw": "^2.12.7",
     "playwright": "^1.57.0",
     "postcss": "^8.4.32",

--- a/tests/e2e/age-gate-persistence.spec.ts
+++ b/tests/e2e/age-gate-persistence.spec.ts
@@ -6,54 +6,42 @@ import os from 'os';
 import { fileURLToPath } from 'url';
 import { waitForWindow } from './utils/window-helpers';
 import { waitForAppReady } from './utils/app-ready';
-import {
-  isAccountGateVisible,
-  isAgeGateVisible,
-  isMainAppShellVisible,
-} from './utils/onboarding';
 
-// Get __dirname equivalent in ES modules
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 
-/**
- * Launches Electron app with a specific user data directory (for persistence testing)
- */
+const AGE_GATE_CHECKBOX = '#age-confirm';
+
 async function launchAppWithUserData(userDataDir: string) {
   const mainEntry = path.resolve(__dirname, '../../out/main/main.cjs');
-  
+
   if (!fs.existsSync(mainEntry)) {
     throw new Error(`Main entry point not found: ${mainEntry}. Run 'npm run build' first.`);
   }
 
-  // Determine if we're in headless mode (CI or when HEADLESS is not explicitly set to 'false')
   const isHeadless = process.env.CI === 'true' || process.env.HEADLESS !== 'false';
 
   const app = await electron.launch({
     args: [
       mainEntry,
       `--user-data-dir=${userDataDir}`,
-      // Headless mode flags for Electron (Electron doesn't support --headless flag directly)
-      // Playwright handles headless mode automatically, but we add stability flags for CI
-      // SECURITY WARNING: --no-sandbox is UNSAFE and only used in isolated test environment
       ...(isHeadless ? [
         '--disable-gpu',
-        '--no-sandbox', // ⚠️ UNSAFE: Only for CI/test environment, never in production
+        '--no-sandbox',
         '--disable-dev-shm-usage',
         '--disable-software-rasterizer',
-        '--force-device-scale-factor=1', // Force device scale factor for consistent rendering
-        '--enable-logging', // Enable logging for debugging in CI
-        '--disable-features=CalculateNativeWinOcclusion', // Disable window occlusion calculation for headless
-        '--disable-background-timer-throttling', // Prevent throttling in background
-        '--disable-backgrounding-occluded-windows', // Prevent backgrounding occluded windows
-        '--disable-renderer-backgrounding', // Prevent renderer backgrounding
+        '--force-device-scale-factor=1',
+        '--enable-logging',
+        '--disable-features=CalculateNativeWinOcclusion',
+        '--disable-background-timer-throttling',
+        '--disable-backgrounding-occluded-windows',
+        '--disable-renderer-backgrounding',
       ] : []),
     ],
     env: {
       ...process.env,
       NODE_ENV: 'test',
       ELECTRON_ENABLE_LOGGING: 'true',
-      // Additional headless environment variables for Linux CI
       ...(isHeadless && process.platform === 'linux' ? {
         DISPLAY: process.env.DISPLAY || ':99',
       } : {}),
@@ -76,92 +64,78 @@ async function getFirstWindowPage(app: Awaited<ReturnType<typeof launchAppWithUs
   }
 }
 
+function createUserDataDir(): string {
+  return fs.mkdtempSync(path.join(os.tmpdir(), 'ruledesk-agegate-persistence-'));
+}
+
+function removeUserDataDir(userDataDir: string): void {
+  if (!fs.existsSync(userDataDir)) {
+    return;
+  }
+  try {
+    fs.rmSync(userDataDir, { recursive: true, force: true });
+  } catch (error) {
+    console.warn('Failed to clean up userData directory (files may be locked):', error);
+  }
+}
+
 test.describe('Age Gate Persistence', () => {
-  let userDataDir: string;
-
-  test.beforeAll(() => {
-    // Create a persistent temp directory for this test suite
-    userDataDir = fs.mkdtempSync(path.join(os.tmpdir(), 'ruledesk-agegate-persistence-'));
-    console.log('Created persistent userData directory:', userDataDir);
-  });
-
-  test.afterAll(() => {
-    // Clean up the persistent directory after all tests
-    if (userDataDir && fs.existsSync(userDataDir)) {
-      try {
-        fs.rmSync(userDataDir, { recursive: true, force: true });
-        console.log('Cleaned up persistent userData directory:', userDataDir);
-      } catch (error) {
-        console.warn('Failed to clean up userData directory (files may be locked):', error);
-      }
-    }
-  });
-
   test('should show Age Gate on first launch', async () => {
+    const userDataDir = createUserDataDir();
     const app = await launchAppWithUserData(userDataDir);
-    
+
     try {
       const page = await getFirstWindowPage(app);
       await waitForAppReady(page, 30000);
 
-      const ageCheckbox = page.locator('#age-confirm');
-      await expect(ageCheckbox).toBeVisible({ timeout: 10000 });
-      console.log('[E2E] Age Gate is visible on first launch (expected)');
+      await expect(page.locator(AGE_GATE_CHECKBOX)).toBeVisible({ timeout: 10000 });
     } finally {
       await app.close();
-      await new Promise(resolve => setTimeout(resolve, 1000));
+      removeUserDataDir(userDataDir);
     }
   });
 
   test('should NOT show Age Gate on second launch after confirmation', async () => {
-    let app = await launchAppWithUserData(userDataDir);
-    
+    const userDataDir = createUserDataDir();
+
     try {
-      const page = await getFirstWindowPage(app);
-      await waitForAppReady(page, 30000);
+      let app = await launchAppWithUserData(userDataDir);
 
-      if (await isAgeGateVisible(page)) {
-        console.log('[E2E] Age Gate detected. Confirming...');
+      try {
+        const page = await getFirstWindowPage(app);
+        await waitForAppReady(page, 30000);
 
-        await page.locator('#age-confirm').check();
+        const ageCheckbox = page.locator(AGE_GATE_CHECKBOX);
+        await expect(ageCheckbox).toBeVisible({ timeout: 10000 });
+
+        await ageCheckbox.check();
         await page.locator('#tos-accept').check();
 
         const confirmButton = page.getByRole('button', { name: /enter ruledesk/i });
         await expect(confirmButton).toBeEnabled({ timeout: 3000 });
         await confirmButton.click();
 
-        await expect(page.locator('#age-confirm')).not.toBeVisible({ timeout: 10000 });
-        await page.waitForTimeout(2000);
+        await expect(ageCheckbox).not.toBeVisible({ timeout: 10000 });
+      } finally {
+        await app.close();
+        await new Promise(resolve => setTimeout(resolve, 2000));
+      }
 
-        console.log('[E2E] Age Gate confirmed successfully');
+      app = await launchAppWithUserData(userDataDir);
+
+      try {
+        const page = await getFirstWindowPage(app);
+        await waitForAppReady(page, 30000);
+
+        await expect(page.locator(AGE_GATE_CHECKBOX)).not.toBeVisible({ timeout: 15000 });
+        await expect(
+          page.getByRole('heading', { name: /sign in to ruledesk/i })
+        ).toBeVisible({ timeout: 15000 });
+      } finally {
+        await app.close();
       }
     } finally {
-      await app.close();
-      await new Promise(resolve => setTimeout(resolve, 2000));
-    }
-
-    app = await launchAppWithUserData(userDataDir);
-    
-    try {
-      const page = await getFirstWindowPage(app);
-      await waitForAppReady(page, 30000);
-
-      await Promise.race([
-        page.getByRole('heading', { name: /sign in to ruledesk/i }).waitFor({ state: 'visible', timeout: 10000 }).catch(() => {}),
-        page.getByRole('link', { name: /^artists$/i }).waitFor({ state: 'visible', timeout: 10000 }).catch(() => {}),
-        page.locator('#api-key').waitFor({ state: 'visible', timeout: 10000 }).catch(() => {}),
-      ]);
-
-      expect(await isAgeGateVisible(page)).toBe(false);
-      console.log('[E2E] Age Gate is NOT visible on second launch (expected - persistence works!)');
-
-      const isAccountGate = await isAccountGateVisible(page);
-      const isMainApp = await isMainAppShellVisible(page);
-
-      expect(isMainApp || isAccountGate).toBe(true);
-      console.log('[E2E] App navigated past Age Gate correctly');
-    } finally {
-      await app.close();
+      removeUserDataDir(userDataDir);
     }
   });
 });

--- a/tests/e2e/scenarios.spec.ts
+++ b/tests/e2e/scenarios.spec.ts
@@ -63,88 +63,27 @@ test.describe('User Journeys', () => {
     // Fill the tag input
     const tagInput = addArtistDialog.locator('input[placeholder*="Search on"]');
     await expect(tagInput).toBeVisible({ timeout: 3000 });
-    
-    // Use a real tag for realism (sakimichan is a popular artist tag)
+
     const testTag = 'sakimichan';
-    
-    // Clear any existing value first
+    const testTagPattern = new RegExp(testTag, 'i');
+
     await tagInput.clear();
-    await page.waitForTimeout(100);
-    
-    // Type the tag character by character to simulate real user input
-    // This triggers handleTagChange which sets the value via react-hook-form
-    await tagInput.type(testTag, { delay: 30 });
-    
-    // Wait for debounce (300ms) + potential API call
-    await page.waitForTimeout(800);
-    
-    // Option 1: Try to select from dropdown if it appears (user clicks on suggestion)
-    const dropdownOption = addArtistDialog.locator('[role="option"]').first();
-    const hasDropdown = await dropdownOption.isVisible({ timeout: 2000 }).catch(() => false);
-    
-    if (hasDropdown) {
-      console.log('[E2E] Dropdown appeared, selecting first option');
-      await dropdownOption.click();
-      
-      // After selecting from dropdown, AsyncAutocomplete clears the input
-      // but react-hook-form should update it via setValue
-      // Wait for the value to be set by react-hook-form
-      await page.waitForFunction(
-        (expectedTag) => {
-          const input = document.querySelector('input[placeholder*="Search on"]') as HTMLInputElement;
-          return input && input.value.toLowerCase().includes(expectedTag.toLowerCase());
-        },
-        testTag.toLowerCase(),
-        { timeout: 5000 }
-      ).catch(() => {
-        // If waitForFunction fails, try to get the value directly
-        console.log('[E2E] Warning: waitForFunction failed, checking input value directly');
-      });
-      
-      await page.waitForTimeout(500);
-    } else {
-      // Option 2: User typed text directly (no dropdown or user wants to use typed text)
-      // The value is already set via handleTagChange, just need to ensure it's committed
-      console.log('[E2E] No dropdown, using typed text directly');
-      // Press Tab or blur to ensure the value is committed
-      await tagInput.press('Tab');
-      await page.waitForTimeout(300);
+    await tagInput.pressSequentially(testTag, { delay: 30 });
+
+    const matchingOption = addArtistDialog
+      .locator('[role="option"]')
+      .filter({ hasText: testTagPattern })
+      .first();
+    const hasMatchingOption = await matchingOption
+      .isVisible({ timeout: 4000 })
+      .catch(() => false);
+
+    if (hasMatchingOption) {
+      await matchingOption.click();
     }
+
+    await expect(tagInput).toHaveValue(testTagPattern);
     
-    // Verify that the input has the value
-    // In controlled mode (react-hook-form), the value might be set via setValue
-    // So we need to wait a bit for the form state to update
-    await page.waitForTimeout(500);
-    
-    const inputValue = await tagInput.inputValue();
-    
-    // If input is empty but dropdown was selected, the value might be in react-hook-form state
-    // Check if the submit button is enabled (which means form has a valid tag value)
-    if (inputValue.length === 0) {
-      console.log('[E2E] Input appears empty, checking if form state has value via submit button state');
-      const submitButton = addArtistDialog.getByRole('button', { name: 'Start Tracking' });
-      const isEnabled = await submitButton.isEnabled({ timeout: 2000 }).catch(() => false);
-      
-      if (isEnabled) {
-        // Button is enabled, which means form has a valid tag value
-        // The input might be cleared but form state has the value
-        console.log('[E2E] Submit button is enabled, form has valid tag value (input may be cleared by AsyncAutocomplete)');
-      } else {
-        // Button is disabled, form doesn't have a value - this is an error
-        throw new Error(`Input value is empty and submit button is disabled. Expected tag: ${testTag}`);
-      }
-    } else {
-      // Input has value, verify it matches
-      expect(inputValue.length).toBeGreaterThan(0);
-      expect(inputValue.toLowerCase()).toContain(testTag.toLowerCase());
-    }
-    
-    // Wait a bit more for react-hook-form to update the form state
-    await page.waitForTimeout(500);
-    
-    // Find the submit button - it should be visible in the modal
-    // The button text is "Start Tracking" (from AddArtistModal.tsx line 170)
-    // Use a more reliable selector - find by text within the form
     const submitButton = addArtistDialog.getByRole('button', { name: 'Start Tracking' });
     
     // Check if button exists and is visible

--- a/tests/property/fuzzing.test.ts
+++ b/tests/property/fuzzing.test.ts
@@ -105,11 +105,16 @@ describe('Property-Based Testing (Fuzzing)', () => {
             type: 'tag'  // valid enum
           });
           
-          // Если имя валидное (не пустое после trim) - должно пройти, иначе ошибка Zod
+          // AddArtistSchema.name is z.string().trim().min(1) — any non-empty
+          // trimmed string must parse; whitespace-only / empty must fail.
           if (name.trim().length > 0) {
-            // Zod might strip/trim, so we just check it doesn't crash
-            return true;
+            expect(result.success).toBe(true);
+            if (result.success) {
+              expect(result.data.name).toBe(name.trim());
+            }
+            return result.success;
           }
+          expect(result.success).toBe(false);
           return !result.success;
         })
       );
@@ -196,8 +201,14 @@ describe('Property-Based Testing (Fuzzing)', () => {
               type: 'tag',
             });
             
-            if (result.success) {
-              expect(result.data.name).toBe(nameWithWhitespace.trim());
+            const trimmed = nameWithWhitespace.trim();
+            if (trimmed.length === 0) {
+              expect(result.success).toBe(false);
+            } else {
+              expect(result.success).toBe(true);
+              if (result.success) {
+                expect(result.data.name).toBe(trimmed);
+              }
             }
           }
         )

--- a/tests/unit/TEST_COVERAGE.md
+++ b/tests/unit/TEST_COVERAGE.md
@@ -8,7 +8,7 @@ Vitest covers unit logic, integration flows (IPC + SQLite), and property-based f
 
 | File | Tests | Area |
 |------|-------|------|
-| `hooks/useGalleryInfiniteScroll.test.ts` | 7 | Infinite scroll pagination |
+| `hooks/useGalleryInfiniteScroll.test.ts` | 9 | Real `useGalleryInfiniteScroll` (default + Browse `getSearchBrowseNextPageParam`, 150ms debounce, unmount timer cleanup, `handleAtBottomStateChange`) |
 | `hooks/useWorkerFilteredPosts.test.ts` | 7 | Worker post → Post field mapping |
 | `lib/filter-utils.test.ts` | 29 | AI tags, video detection |
 | `lib/backup-retention-size-cap.test.ts` | 6 | Backup size-cap prune (no over-delete / keep newest over cap) |
@@ -68,8 +68,8 @@ npm run test:verify                   # validate + all tests + ABI restore
 
 ## Approach
 
-- Vitest node environment
-- Logic-first tests; minimal React rendering
+- Vitest node environment (jsdom only for `useGalleryInfiniteScroll` hook render tests)
+- Logic-first tests; hook debounce/unmount coverage renders the real hook via `react-dom` (no `@testing-library/react`)
 - Integration tests use in-memory SQLite (`tests/helpers/mock-db.ts`)
 - Property tests guard schema and SQL escaping invariants
 - Post-audit: pure `mapWorkerPostToPost()` in `src/renderer/lib/map-worker-post.ts` (tested without Web Worker)

--- a/tests/unit/hooks/useGalleryInfiniteScroll.test.ts
+++ b/tests/unit/hooks/useGalleryInfiniteScroll.test.ts
@@ -1,172 +1,375 @@
-import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+// @vitest-environment jsdom
+import { createElement, act, type ReactNode } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { useGalleryInfiniteScroll } from "@/renderer/hooks/useGalleryInfiniteScroll";
+import { getSearchBrowseNextPageParam } from "@/renderer/utils/react-query-cache";
+import type { SearchBooruPageResult } from "@/shared/schemas/search";
 
-// Mock electron-log
-vi.mock("electron-log/renderer", () => ({
-  default: {
-    info: vi.fn(),
-    error: vi.fn(),
-    warn: vi.fn(),
-    debug: vi.fn(),
-  },
-}));
+const POSTS_PER_PAGE = 50;
+const DEFAULT_DEBOUNCE_MS = 150;
 
-// Mock React hooks
-vi.mock("react", () => ({
-  useCallback: <T>(fn: T) => fn,
-  useEffect: (fn: () => void | (() => void)) => {
-    // Return cleanup function
-    return fn();
-  },
-  useRef: <T>(initial: T) => ({ current: initial }),
-}));
+type PostItem = { id: number };
 
-// Mock @tanstack/react-query
-const mockUseInfiniteQuery = vi.fn();
-vi.mock("@tanstack/react-query", () => ({
-  useInfiniteQuery: (options: unknown) => mockUseInfiniteQuery(options),
-}));
+type BrowsePage = SearchBooruPageResult<PostItem>;
 
-// Test pagination logic directly (without React rendering)
-describe("useGalleryInfiniteScroll - Pagination Logic", () => {
+function makeItems(count: number, startId = 1): PostItem[] {
+  return Array.from({ length: count }, (_, index) => ({ id: startId + index }));
+}
+
+function createQueryClient(): QueryClient {
+  return new QueryClient({
+    defaultOptions: {
+      queries: {
+        retry: false,
+        gcTime: Infinity,
+      },
+    },
+  });
+}
+
+async function flushAct(): Promise<void> {
+  await act(async () => {
+    await Promise.resolve();
+  });
+}
+
+async function waitForCondition(
+  assertion: () => void,
+  maxTicks = 80
+): Promise<void> {
+  let lastError: unknown;
+  for (let tick = 0; tick < maxTicks; tick += 1) {
+    try {
+      assertion();
+      return;
+    } catch (error) {
+      lastError = error;
+      await flushAct();
+    }
+  }
+  throw lastError;
+}
+
+type MountedHook<TApi> = {
+  result: { current: TApi | null };
+  unmount: () => void;
+};
+
+function mountHook<TApi>(
+  queryClient: QueryClient,
+  renderHook: () => TApi
+): MountedHook<TApi> {
+  const result: { current: TApi | null } = { current: null };
+  const container = document.createElement("div");
+  document.body.appendChild(container);
+  const root: Root = createRoot(container);
+
+  function Harness(): ReactNode {
+    result.current = renderHook();
+    return null;
+  }
+
+  act(() => {
+    root.render(
+      createElement(
+        QueryClientProvider,
+        { client: queryClient },
+        createElement(Harness)
+      )
+    );
+  });
+
+  return {
+    result,
+    unmount: () => {
+      act(() => {
+        root.unmount();
+      });
+      container.remove();
+    },
+  };
+}
+
+describe("useGalleryInfiniteScroll", () => {
+  let queryClient: QueryClient;
+
   beforeEach(() => {
-    vi.clearAllMocks();
+    queryClient = createQueryClient();
+    Reflect.set(globalThis, "IS_REACT_ACT_ENVIRONMENT", true);
   });
 
   afterEach(() => {
-    vi.restoreAllMocks();
+    vi.useRealTimers();
+    queryClient.clear();
   });
 
-  describe("Default pagination logic (Local DB)", () => {
-    it("should return next page if last page has exactly POSTS_PER_PAGE items", () => {
-      const POSTS_PER_PAGE = 50;
-      const lastPage = Array.from({ length: 50 }, (_, i) => ({ id: i + 1 }));
-      const allPages = [lastPage];
+  describe("default pagination (local DB page size)", () => {
+    it("sets hasNextPage when the last page has exactly POSTS_PER_PAGE items", async () => {
+      const fetchFn = vi.fn(async () => makeItems(POSTS_PER_PAGE));
+      const { result, unmount } = mountHook(queryClient, () =>
+        useGalleryInfiniteScroll({
+          queryKey: ["gallery-default-full"],
+          fetchFn,
+          initialPageParam: 1,
+        })
+      );
 
-      const defaultGetNextPageParam = (
-        lastPage: unknown[],
-        allPages: unknown[][]
-      ) => {
-        return lastPage.length === POSTS_PER_PAGE
-          ? allPages.length + 1
-          : undefined;
-      };
+      await waitForCondition(() => {
+        expect(result.current?.allPosts).toHaveLength(POSTS_PER_PAGE);
+        expect(result.current?.hasNextPage).toBe(true);
+      });
 
-      const result = defaultGetNextPageParam(lastPage, allPages);
-      expect(result).toBe(2);
+      unmount();
     });
 
-    it("should return undefined if last page has less than POSTS_PER_PAGE items", () => {
-      const POSTS_PER_PAGE = 50;
-      const lastPage = Array.from({ length: 30 }, (_, i) => ({ id: i + 1 }));
-      const allPages = [lastPage];
+    it("clears hasNextPage when the last page is shorter than POSTS_PER_PAGE", async () => {
+      const fetchFn = vi.fn(async () => makeItems(30));
+      const { result, unmount } = mountHook(queryClient, () =>
+        useGalleryInfiniteScroll({
+          queryKey: ["gallery-default-partial"],
+          fetchFn,
+          initialPageParam: 1,
+        })
+      );
 
-      const defaultGetNextPageParam = (
-        lastPage: unknown[],
-        allPages: unknown[][]
-      ) => {
-        return lastPage.length === POSTS_PER_PAGE
-          ? allPages.length + 1
-          : undefined;
-      };
+      await waitForCondition(() => {
+        expect(result.current?.allPosts).toHaveLength(30);
+        expect(result.current?.hasNextPage).toBe(false);
+      });
 
-      const result = defaultGetNextPageParam(lastPage, allPages);
-      expect(result).toBeUndefined();
+      unmount();
     });
 
-    it("should return undefined if last page is empty", () => {
-      const POSTS_PER_PAGE = 50;
-      const lastPage: unknown[] = [];
-      const allPages = [lastPage];
+    it("clears hasNextPage when the last page is empty", async () => {
+      const fetchFn = vi.fn(async (): Promise<PostItem[]> => []);
+      const { result, unmount } = mountHook(queryClient, () =>
+        useGalleryInfiniteScroll({
+          queryKey: ["gallery-default-empty"],
+          fetchFn,
+          initialPageParam: 1,
+        })
+      );
 
-      const defaultGetNextPageParam = (
-        lastPage: unknown[],
-        allPages: unknown[][]
-      ) => {
-        return lastPage.length === POSTS_PER_PAGE
-          ? allPages.length + 1
-          : undefined;
-      };
+      await waitForCondition(() => {
+        expect(result.current?.allPosts).toEqual([]);
+        expect(result.current?.hasNextPage).toBe(false);
+      });
 
-      const result = defaultGetNextPageParam(lastPage, allPages);
-      expect(result).toBeUndefined();
-    });
-  });
-
-  describe("Custom pagination logic (External API - Browse)", () => {
-    it("should continue loading if page has any posts", () => {
-      const lastPage = Array.from({ length: 30 }, (_, i) => ({ id: i + 1 }));
-      const allPages = [lastPage];
-
-      const browseGetNextPageParam = (
-        lastPage: unknown[],
-        allPages: unknown[][]
-      ) => {
-        if (lastPage.length === 0) return undefined;
-        return allPages.length + 1;
-      };
-
-      const result = browseGetNextPageParam(lastPage, allPages);
-      expect(result).toBe(2);
-    });
-
-    it("should stop loading only when page is empty", () => {
-      const lastPage: unknown[] = [];
-      const allPages = [lastPage];
-
-      const browseGetNextPageParam = (
-        lastPage: unknown[],
-        allPages: unknown[][]
-      ) => {
-        if (lastPage.length === 0) return undefined;
-        return allPages.length + 1;
-      };
-
-      const result = browseGetNextPageParam(lastPage, allPages);
-      expect(result).toBeUndefined();
-    });
-
-    it("should continue loading even with less than 50 posts", () => {
-      const lastPage = Array.from({ length: 10 }, (_, i) => ({ id: i + 1 }));
-      const allPages = [lastPage];
-
-      const browseGetNextPageParam = (
-        lastPage: unknown[],
-        allPages: unknown[][]
-      ) => {
-        if (lastPage.length === 0) return undefined;
-        return allPages.length + 1;
-      };
-
-      const result = browseGetNextPageParam(lastPage, allPages);
-      expect(result).toBe(2); // Should continue even with 10 posts
+      unmount();
     });
   });
 
-  describe("Pagination edge cases", () => {
-    it("should handle multiple pages correctly", () => {
-      const page1 = Array.from({ length: 50 }, (_, i) => ({ id: i + 1 }));
-      const page2 = Array.from({ length: 50 }, (_, i) => ({ id: i + 51 }));
-      const page3 = Array.from({ length: 30 }, (_, i) => ({ id: i + 101 }));
-      const allPages = [page1, page2, page3];
+  describe("Browse pagination via getSearchBrowseNextPageParam", () => {
+    it("keeps hasNextPage when the API reports hasMore on a partial visible page", async () => {
+      const fetchFn = vi.fn(
+        async (): Promise<BrowsePage> => ({
+          posts: makeItems(30),
+          hasMore: true,
+          apiFetchedCount: POSTS_PER_PAGE,
+          nextBeforePostId: 100,
+        })
+      );
+      const { result, unmount } = mountHook(queryClient, () =>
+        useGalleryInfiniteScroll<BrowsePage, PostItem, unknown[], number>({
+          queryKey: ["gallery-browse-has-more"],
+          fetchFn,
+          initialPageParam: 1,
+          flattenPage: (page) => page.posts,
+          getNextPageParam: (lastPage, allPages) =>
+            getSearchBrowseNextPageParam(lastPage, allPages, POSTS_PER_PAGE),
+        })
+      );
 
-      const defaultGetNextPageParam = (
-        lastPage: unknown[],
-        allPages: unknown[][]
-      ) => {
-        const POSTS_PER_PAGE = 50;
-        return lastPage.length === POSTS_PER_PAGE
-          ? allPages.length + 1
-          : undefined;
-      };
+      await waitForCondition(() => {
+        expect(result.current?.allPosts).toHaveLength(30);
+        expect(result.current?.hasNextPage).toBe(true);
+      });
 
-      // Test page 1 -> page 2
-      expect(defaultGetNextPageParam(page1, [page1])).toBe(2);
+      unmount();
+    });
 
-      // Test page 2 -> page 3
-      expect(defaultGetNextPageParam(page2, [page1, page2])).toBe(3);
+    it("clears hasNextPage when the API returned zero rows", async () => {
+      const fetchFn = vi.fn(
+        async (): Promise<BrowsePage> => ({
+          posts: [],
+          hasMore: false,
+          apiFetchedCount: 0,
+        })
+      );
+      const { result, unmount } = mountHook(queryClient, () =>
+        useGalleryInfiniteScroll<BrowsePage, PostItem, unknown[], number>({
+          queryKey: ["gallery-browse-empty"],
+          fetchFn,
+          initialPageParam: 1,
+          flattenPage: (page) => page.posts,
+          getNextPageParam: (lastPage, allPages) =>
+            getSearchBrowseNextPageParam(lastPage, allPages, POSTS_PER_PAGE),
+        })
+      );
 
-      // Test page 3 (last, < 50) -> stop
-      expect(defaultGetNextPageParam(page3, allPages)).toBeUndefined();
+      await waitForCondition(() => {
+        expect(result.current?.allPosts).toEqual([]);
+        expect(result.current?.hasNextPage).toBe(false);
+      });
+
+      unmount();
+    });
+  });
+
+  describe("debounce, unmount cleanup, and at-bottom handler", () => {
+    it("does not fetch the next page until the default 150ms debounce elapses", async () => {
+      const fetchFn = vi.fn(async (page: number) =>
+        makeItems(POSTS_PER_PAGE, (page - 1) * POSTS_PER_PAGE + 1)
+      );
+      const { result, unmount } = mountHook(queryClient, () =>
+        useGalleryInfiniteScroll({
+          queryKey: ["gallery-debounce"],
+          fetchFn,
+          initialPageParam: 1,
+        })
+      );
+
+      await waitForCondition(() => {
+        expect(result.current?.allPosts).toHaveLength(POSTS_PER_PAGE);
+        expect(result.current?.hasNextPage).toBe(true);
+      });
+      expect(fetchFn).toHaveBeenCalledTimes(1);
+
+      vi.useFakeTimers();
+      act(() => {
+        result.current?.handleEndReached();
+      });
+
+      await act(async () => {
+        vi.advanceTimersByTime(DEFAULT_DEBOUNCE_MS - 1);
+      });
+      expect(fetchFn).toHaveBeenCalledTimes(1);
+
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(1);
+      });
+      await waitForCondition(() => {
+        expect(fetchFn).toHaveBeenCalledTimes(2);
+      });
+
+      unmount();
+    });
+
+    it("resets the debounce window on rapid handleEndReached calls", async () => {
+      const fetchFn = vi.fn(async (page: number) =>
+        makeItems(POSTS_PER_PAGE, (page - 1) * POSTS_PER_PAGE + 1)
+      );
+      const { result, unmount } = mountHook(queryClient, () =>
+        useGalleryInfiniteScroll({
+          queryKey: ["gallery-debounce-reset"],
+          fetchFn,
+          initialPageParam: 1,
+        })
+      );
+
+      await waitForCondition(() => {
+        expect(result.current?.hasNextPage).toBe(true);
+      });
+      expect(fetchFn).toHaveBeenCalledTimes(1);
+
+      vi.useFakeTimers();
+      act(() => {
+        result.current?.handleEndReached();
+      });
+      await act(async () => {
+        vi.advanceTimersByTime(100);
+      });
+      act(() => {
+        result.current?.handleEndReached();
+      });
+      await act(async () => {
+        vi.advanceTimersByTime(DEFAULT_DEBOUNCE_MS - 1);
+      });
+      expect(fetchFn).toHaveBeenCalledTimes(1);
+
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(1);
+      });
+      await waitForCondition(() => {
+        expect(fetchFn).toHaveBeenCalledTimes(2);
+      });
+
+      unmount();
+    });
+
+    it("clears the pending debounce timer on unmount", async () => {
+      const fetchFn = vi.fn(async (page: number) =>
+        makeItems(POSTS_PER_PAGE, (page - 1) * POSTS_PER_PAGE + 1)
+      );
+      const { result, unmount } = mountHook(queryClient, () =>
+        useGalleryInfiniteScroll({
+          queryKey: ["gallery-unmount-cleanup"],
+          fetchFn,
+          initialPageParam: 1,
+        })
+      );
+
+      await waitForCondition(() => {
+        expect(result.current?.hasNextPage).toBe(true);
+      });
+      expect(fetchFn).toHaveBeenCalledTimes(1);
+
+      vi.useFakeTimers();
+      act(() => {
+        result.current?.handleEndReached();
+      });
+      unmount();
+
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(DEFAULT_DEBOUNCE_MS + 50);
+      });
+      expect(fetchFn).toHaveBeenCalledTimes(1);
+    });
+
+    it("schedules a load when handleAtBottomStateChange(true) and not when false", async () => {
+      const fetchFn = vi.fn(async (page: number) =>
+        makeItems(POSTS_PER_PAGE, (page - 1) * POSTS_PER_PAGE + 1)
+      );
+      const { result, unmount } = mountHook(queryClient, () =>
+        useGalleryInfiniteScroll({
+          queryKey: ["gallery-at-bottom"],
+          fetchFn,
+          initialPageParam: 1,
+        })
+      );
+
+      await waitForCondition(() => {
+        expect(result.current?.hasNextPage).toBe(true);
+      });
+      expect(fetchFn).toHaveBeenCalledTimes(1);
+
+      vi.useFakeTimers();
+      act(() => {
+        result.current?.handleAtBottomStateChange(false);
+      });
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(DEFAULT_DEBOUNCE_MS + 50);
+      });
+      expect(fetchFn).toHaveBeenCalledTimes(1);
+
+      act(() => {
+        result.current?.handleAtBottomStateChange(true);
+      });
+      await act(async () => {
+        vi.advanceTimersByTime(DEFAULT_DEBOUNCE_MS - 1);
+      });
+      expect(fetchFn).toHaveBeenCalledTimes(1);
+
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(1);
+      });
+      await waitForCondition(() => {
+        expect(fetchFn).toHaveBeenCalledTimes(2);
+      });
+
+      unmount();
     });
   });
 });


### PR DESCRIPTION
## Summary
- Property and e2e tests now assert real success/failure instead of swallowing empty input, missing Age Gate, or vacuous `return true`.
- `useGalleryInfiniteScroll` unit tests import the real hook (debounce 150ms, unmount cleanup, `handleAtBottomStateChange`) instead of a local pagination copy.
- Gelbooru transport `[]` vs Rule34 throw is confirmed as a prod silent-failure (LESSONS); **not** changed in this branch.

## Test plan
- [x] `npm run typecheck` / `lint` / `test` (306 passed)
- [x] Property fuzzing run 3×
- [x] Age Gate persistence e2e passed; fail-probe with a wrong selector failed as required
- [ ] Add Artist e2e needs `TEST_USER_ID` / `TEST_API_KEY` (not present locally)
