### PR TITLE
fix: Gelbooru transport failure throws instead of []

### DIFF
--- a/docs/api-guide.md
+++ b/docs/api-guide.md
@@ -2003,7 +2003,7 @@ All IPC methods can throw errors. Always wrap calls in try-catch blocks or let R
 | Layer | Responsibility |
 |-------|----------------|
 | `Rule34Provider.fetchPosts` | Throws `ProviderSearchError` with `kind` (`auth`, `rate_limit`, `network`, `parse`); XML fallback only on `parse`, never on auth/429 |
-| `GelbooruProvider.fetchPosts` | On HTTP 429 throws `ProviderSearchError("rate_limit")` after `notifyRateLimited(retryAfterMs)` (shared host gate); other failures still log + return `[]`. Non-JSON content-type on 200 remains `[]` with a warn (unchanged) |
+| `GelbooruProvider.fetchPosts` | Throws `ProviderSearchError` with `kind` (`rate_limit` on HTTP 429 after `notifyRateLimited`; `network` on transport/timeout; `parse` on non-JSON 200). Genuine empty JSON `[]` still returns `[]` so Browse alias/user: heuristics can run. |
 | `throwProviderSearchIpcError` (main) | Serializes to IPC-safe `Error` + enumerable payload fields |
 | `parseProviderSearchErrorPayload` (shared) | Normalizes Electron invoke wrapper → typed payload for UI |
 | `BrowseErrorState` (renderer) | User-facing centered error state (not a destructive banner) |

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -172,6 +172,7 @@ Both P0 rows (#1–#2) are closed — the full v17 audit pack landed (after one 
 
 | Branch | Status | Notes |
 |--------|--------|-------|
+| `fix/gelbooru-transport-failure-silent-swallow` | started | Gelbooru `fetchPosts` throws `ProviderSearchError("network"|"parse")` instead of `[]`; SearchController heuristics stay on genuine empty API pages only. |
 | `fix/p1-test-suite-false-confidence` | ✅ merged | [#156](https://github.com/KazeKaze93/RuleDesk/pull/156) — P1-1..P1-4: property/e2e/hook tests that could not fail on real regressions. P1-5 Gelbooru transport `[]` vs Rule34 throw — prod silent-failure, **not** fixed in this branch. |
 | `chore/split-viewer-dialog` | ✅ merged | [#153](https://github.com/KazeKaze93/RuleDesk/pull/153) — Mechanical split: `ViewerDialog` shell + `ViewerContent` / `ViewerMedia` / `TagsDrawer` / `PostNotFoundFallback`; `buildViewerOriginQueryKey` consolidation |
 | `chore/split-playlists-page` | ✅ merged | [#152](https://github.com/KazeKaze93/RuleDesk/pull/152) — Mechanical split: `PlaylistsPage` list/CRUD; `PlaylistGallery` + virtuoso wrappers under `components/playlists/` |

--- a/src/main/providers/gelbooru-provider.ts
+++ b/src/main/providers/gelbooru-provider.ts
@@ -13,7 +13,11 @@ import {
 import { MAX_RANDOM_PAGES } from "../../shared/constants";
 import { z } from "zod";
 import { ProviderThrottle, pickRandomUA, ProviderRateLimitGateError } from "./provider-throttle";
-import { ProviderSearchError } from "./provider-search-errors";
+import {
+  isProviderSearchError,
+  ProviderSearchError,
+} from "./provider-search-errors";
+import { isAxiosTransportFailure } from "./rule34-post-response";
 import { getProxyAgent } from "../lib/proxy";
 import { redactErrorForLog } from "../lib/redact-error";
 
@@ -243,7 +247,7 @@ export class GelbooruProvider implements IBooruProvider {
         typeof rawContentType === "string" ? rawContentType : "";
       if (!contentType.includes("application/json") && !contentType.includes("text/json")) {
         logger.warn(`[Gelbooru] Unexpected Content-Type: ${contentType}. Expected JSON.`);
-        return [];
+        throw new ProviderSearchError("parse");
       }
 
       const { data } = response;
@@ -307,18 +311,20 @@ export class GelbooruProvider implements IBooruProvider {
       
       return posts;
     } catch (error) {
-      if (
-        error instanceof ProviderSearchError &&
-        error.kind === "rate_limit"
-      ) {
-        this.throttle.notifyRateLimited(error.retryAfterMs);
+      if (isProviderSearchError(error)) {
+        if (error.kind === "rate_limit") {
+          this.throttle.notifyRateLimited(error.retryAfterMs);
+        }
         throw error;
       }
       logger.error(
         `[Gelbooru] Error fetching page ${page}`,
         redactErrorForLog(error)
       );
-      return [];
+      if (isAxiosTransportFailure(error)) {
+        throw new ProviderSearchError("network");
+      }
+      throw new ProviderSearchError("parse");
     }
   }
 

--- a/tests/integration/controllers/SearchController.errors.test.ts
+++ b/tests/integration/controllers/SearchController.errors.test.ts
@@ -1,0 +1,152 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { createMockDb } from "../../helpers/mock-db";
+import { container, DI_TOKENS } from "@/main/core/di/Container";
+import { settings, SETTINGS_ID } from "@/main/db/schema";
+import { ProviderSearchError } from "@/main/providers/provider-search-errors";
+import type Database from "better-sqlite3";
+
+let activeSqlite: Database.Database | null = null;
+
+vi.mock("@/main/db/client", () => ({
+  getSqliteInstance: () => {
+    if (!activeSqlite) {
+      throw new Error("Test sqlite instance is not initialized");
+    }
+    return activeSqlite;
+  },
+}));
+
+vi.mock("electron", () => ({
+  app: { getPath: () => "/tmp" },
+  safeStorage: {
+    isEncryptionAvailable: () => true,
+    decryptString: vi.fn((buffer: Buffer) => buffer.toString()),
+  },
+  ipcMain: {
+    handle: vi.fn(),
+    on: vi.fn(),
+    removeHandler: vi.fn(),
+  },
+}));
+
+vi.mock("electron-log", () => ({
+  default: {
+    info: vi.fn(),
+    error: vi.fn(),
+    debug: vi.fn(),
+    warn: vi.fn(),
+    transports: {
+      main: { level: false },
+      renderer: { level: false },
+      console: { level: false, format: "" },
+      file: { level: "info", resolvePathFn: vi.fn() },
+      ipc: {},
+    },
+    errorHandler: {
+      startCatching: vi.fn(),
+    },
+  },
+}));
+
+const fetchPostsMock = vi.fn();
+const searchTagsMock = vi.fn();
+
+vi.mock("@/main/providers", () => ({
+  getProvider: vi.fn(() => ({
+    formatTag: (tag: string, type?: string) => {
+      const clean = tag.trim().toLowerCase();
+      if (type === "uploader") {
+        return `user:${clean}`;
+      }
+      return clean;
+    },
+    fetchPosts: fetchPostsMock,
+    searchTags: searchTagsMock,
+  })),
+}));
+
+import { SearchController } from "@/main/ipc/controllers/SearchController";
+
+async function invokeSearch(
+  controller: SearchController,
+  tags: string[]
+): Promise<unknown> {
+  const searchMethodUnknown = Reflect.get(controller, "search");
+  if (typeof searchMethodUnknown !== "function") {
+    throw new Error("SearchController.search method is unavailable");
+  }
+  return searchMethodUnknown.call(controller, null, {
+    tags,
+    page: 1,
+    isRandom: false,
+  });
+}
+
+describe("SearchController empty result vs transport failure", () => {
+  let mockDb: ReturnType<typeof createMockDb>;
+  let controller: SearchController;
+
+  beforeEach(async () => {
+    container.clear();
+    mockDb = createMockDb();
+    activeSqlite = mockDb.sqlite;
+    container.register(DI_TOKENS.DB, mockDb.db);
+    await mockDb.db.insert(settings).values({
+      id: SETTINGS_ID,
+      userId: "12345",
+      encryptedApiKey: Buffer.from("test-api-key").toString("base64"),
+      provider: "gelbooru",
+      isSafeMode: false,
+      isAdultConfirmed: true,
+      isAdultVerified: true,
+    });
+    controller = new SearchController();
+    fetchPostsMock.mockReset();
+    searchTagsMock.mockReset();
+    searchTagsMock.mockResolvedValue([]);
+  });
+
+  afterEach(() => {
+    if (mockDb?.sqlite) {
+      try {
+        mockDb.sqlite.close();
+      } catch {
+        // Ignore close errors in tests.
+      }
+    }
+    activeSqlite = null;
+    container.clear();
+  });
+
+  it("does not run autocomplete/user:/strip heuristics when fetchPosts throws network", async () => {
+    fetchPostsMock.mockRejectedValueOnce(new ProviderSearchError("network"));
+
+    await expect(invokeSearch(controller, ["missing_tag"])).rejects.toMatchObject({
+      name: "ProviderSearchError",
+      code: "NETWORK_ERROR",
+      providerKind: "network",
+    });
+
+    expect(fetchPostsMock).toHaveBeenCalledTimes(1);
+    expect(searchTagsMock).not.toHaveBeenCalled();
+  });
+
+  it("still runs autocomplete and user: fallbacks on a genuine empty API page", async () => {
+    fetchPostsMock.mockResolvedValue([]);
+
+    const resultUnknown = await invokeSearch(controller, ["missing_tag"]);
+    if (
+      !resultUnknown ||
+      typeof resultUnknown !== "object" ||
+      !("posts" in resultUnknown) ||
+      !Array.isArray(resultUnknown.posts)
+    ) {
+      throw new Error("Unexpected search result shape");
+    }
+
+    expect(resultUnknown.posts).toEqual([]);
+    expect(searchTagsMock).toHaveBeenCalledTimes(1);
+    expect(fetchPostsMock.mock.calls.length).toBeGreaterThan(1);
+    expect(String(fetchPostsMock.mock.calls[1]?.[0])).toContain("user:");
+  });
+});

--- a/tests/unit/TEST_COVERAGE.md
+++ b/tests/unit/TEST_COVERAGE.md
@@ -29,7 +29,7 @@ Vitest covers unit logic, integration flows (IPC + SQLite), and property-based f
 | `shared/autocomplete-label-count.test.ts` | 2 | Rule34 autocomplete `(count)` label parse |
 | `lib/filter-artist-autocomplete.test.ts` | 5 | Add Artist artist-only filter (Gelbooru category + Rule34 top-N) |
 | `providers/rule34-provider-fetch-posts.test.ts` | 7 | fetchPosts error classification + searchTags live shape (no `type`) |
-| `providers/gelbooru-provider-fetch-posts.test.ts` | 7 | Gelbooru fetchPosts 429 + searchTags `category` → `SearchResults.type` |
+| `providers/gelbooru-provider-fetch-posts.test.ts` | 8 | Gelbooru fetchPosts 429 / network / parse + empty JSON `[]` + searchTags `category` → `SearchResults.type` |
 | `services/tag-resolve-coordinator.test.ts` | 8 | Tag resolve dedup / rate limit + Add Artist user-priority options |
 | `services/secure-storage.test.ts` | 3 | `SecureStorage` encrypt/decrypt (sole crypto path) |
 | `services/video-proxy-server.test.ts` | 8 | Video proxy allowlist / cache / eviction |
@@ -41,7 +41,7 @@ Vitest covers unit logic, integration flows (IPC + SQLite), and property-based f
 
 | Suite | Location | Tests |
 |-------|----------|-------|
-| Integration | `tests/integration/` | 22 |
+| Integration | `tests/integration/` | 24 |
 | Property / fuzzing | `tests/property/fuzzing.test.ts` | 12 |
 
 ### Integration highlights
@@ -51,6 +51,7 @@ Vitest covers unit logic, integration flows (IPC + SQLite), and property-based f
 | `controllers/ArtistsController.limit.test.ts` | `MAX_TRACKED_ARTISTS` truncation |
 | `controllers/ArtistsController.test.ts` | Add/update artist IPC |
 | `controllers/SearchController.blacklist.test.ts` | Browse blacklist filtering |
+| `controllers/SearchController.errors.test.ts` | Network throw skips alias/user: heuristics; genuine `[]` still runs them |
 | `controllers/SettingsController.test.ts` | Partial settings save |
 | `services/SyncService.queue.test.ts` | `runExclusive` — repair after full sync |
 | `services/SyncService.test.ts` | Sync pagination, graceful errors, auth → `SYNC.ERROR`, per-artist `syncStatus` / `lastError`, `sync:artist` / repair event order |

--- a/tests/unit/providers/gelbooru-provider-fetch-posts.test.ts
+++ b/tests/unit/providers/gelbooru-provider-fetch-posts.test.ts
@@ -135,7 +135,7 @@ describe("GelbooruProvider.fetchPosts rate-limit classification", () => {
     notifySpy.mockRestore();
   });
 
-  it("returns [] for non-JSON content-type on HTTP 200 (XML fallback path)", async () => {
+  it("throws parse error for non-JSON content-type on HTTP 200", async () => {
     axiosGetMock.mockResolvedValueOnce({
       status: 200,
       headers: { "content-type": "text/xml; charset=utf-8" },
@@ -144,18 +144,36 @@ describe("GelbooruProvider.fetchPosts rate-limit classification", () => {
 
     await expect(
       provider.fetchPosts("solo", 1, settings, false, 50)
-    ).resolves.toEqual([]);
+    ).rejects.toMatchObject({
+      kind: "parse",
+    });
 
     expect(axiosGetMock).toHaveBeenCalledTimes(1);
   });
 
-  it("returns [] on transport failure (unchanged non-429 catch path)", async () => {
+  it("throws network error on transport failure", async () => {
     const timeoutError = new AxiosError("timeout of 15000ms exceeded");
     timeoutError.code = "ECONNABORTED";
     axiosGetMock.mockRejectedValueOnce(timeoutError);
 
     await expect(
       provider.fetchPosts("solo", 1, settings, false, 50)
+    ).rejects.toMatchObject({
+      kind: "network",
+    });
+
+    expect(axiosGetMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("returns [] for a genuine well-formed empty JSON array", async () => {
+    axiosGetMock.mockResolvedValueOnce({
+      status: 200,
+      headers: { "content-type": "application/json" },
+      data: [],
+    });
+
+    await expect(
+      provider.fetchPosts("missing_tag", 1, settings, false, 50)
     ).resolves.toEqual([]);
 
     expect(axiosGetMock).toHaveBeenCalledTimes(1);


### PR DESCRIPTION
## Summary
- `GelbooruProvider.fetchPosts` now throws `ProviderSearchError(network)` on transport/timeout and `(parse)` on non-JSON HTTP 200, matching Rule34.
- Genuine empty JSON `[]` still returns `[]` so SearchController alias/user: heuristics keep working.
- HTTP 429 path unchanged.

## Test plan
- [x] `npm run typecheck` / `lint` / `test` (309 passed)
- [x] Unit: timeout throws `network`; XML content-type throws `parse`; empty JSON `[]` still succeeds
- [x] Integration: network throw skips autocomplete heuristics; empty page still runs them
- [ ] Live Electron Browse on Gelbooru network failure (no local API credentials)
