### PR TITLE
fix: show loading state in Post Metadata while tag resolve is in flight

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,6 +145,7 @@ The full-screen viewer provides a polished media viewing experience:
 - **Tags Drawer** - Right-side sheet with tags grouped by type:
   - **Click** tag to add to search (**include**)
   - **Right-click** to add **exclude** (`-tag`); state shown with **green** (include) / **red** (exclude) ring styling
+  - Artist / Character / Copyright show a compact resolving indicator while tag-type lookup is in flight; “No artist detected” / “No character detected” / “No copyright detected” only after the lookup finishes with no match (session-cached hits render immediately)
 *✅ Implemented in `ViewerDialog` / `TagsDrawer` via `useSearchStore` (`addIncludeTag` / `addExcludeTag`).*
 
 ### Progressive Image Loading

--- a/docs/api-guide.md
+++ b/docs/api-guide.md
@@ -1285,7 +1285,7 @@ Resolves tags to their canonical form using the booru API. Returns artist tags (
 
 **When to use:** When you need to identify which tags in a post are artist tags. Used in viewer to highlight artist names.
 
-**Typical scenario:** User opens a post in viewer → component calls `resolveTags` with all post tags → receives list of artist tags → highlights artist names in UI.
+**Typical scenario:** User opens a post in viewer → component calls `resolveTags` with all post tags → receives list of artist tags → highlights artist names in UI. While that React Query is `isLoading`, Post Metadata shows a resolving indicator instead of “No artist detected”.
 
 **Parameters:**
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -718,7 +718,7 @@ const posts = await db.query.posts.findMany({
    - **Viewer (`src/renderer/features/viewer/`):**
 
      - **ViewerDialog.tsx** - Full-screen shell (queue, cache lookup via `buildViewerOriginQueryKey`, keyboard/side buttons). `openViewer({ hasNextPage })` is the react-query infinite-query flag (Playlist/Artist/Browse/Favorites/Updates). Do not derive it from loaded count vs page size (`n * 50`) or `allPosts.length < totalCount` — a full last page makes those inequalities false while `getNextPageParam` still reports more data, and the viewer next-arrow then dead-ends.
-     - **ViewerContent.tsx** / **ViewerMedia.tsx** / **TagsDrawer.tsx** / **PostNotFoundFallback.tsx** - chrome, media, tags, shadow-insert fallback
+     - **ViewerContent.tsx** / **ViewerMedia.tsx** / **TagsDrawer.tsx** / **PostNotFoundFallback.tsx** - chrome, media, tags, shadow-insert fallback. `TagsDrawer` Artist / Character / Copyright: in-flight resolve uses React Query `isLoading` (`isPending && isFetching`); confirmed empty is “No … detected”; session-cached hits (`staleTime: Infinity`) skip the loading row on first paint.
      - **buildViewerOriginQueryKey.ts** - origin → React Query key (Artist / Browse / Favorites / Updates / Playlist)
 
    - **Dialogs:**

--- a/docs/glossary.md
+++ b/docs/glossary.md
@@ -229,7 +229,7 @@ A full-screen immersive viewer for viewing posts with keyboard shortcuts, downlo
 - Auto-hide controls
 - Keyboard navigation (←/→)
 - Download and favorites
-- Tags drawer
+- Tags drawer (Artist/Character/Copyright distinguish in-flight resolve from confirmed-absent)
 
 **Related:** [Viewer Experience](../README.md#viewer-experience), [Full-Screen Viewer](../README.md#-full-screen-viewer)
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -172,7 +172,7 @@ Both P0 rows (#1–#2) are closed — the full v17 audit pack landed (after one 
 
 | Branch | Status | Notes |
 |--------|--------|-------|
-| `fix/post-metadata-artist-character-loading-state` | 🟡 in progress | TagsDrawer Artist/Character/Copyright: React Query `isLoading` vs confirmed-absent copy; no Main / `tag-resolve-coordinator` changes |
+| `fix/post-metadata-artist-character-loading-state` | 🟡 open | [#168](https://github.com/KazeKaze93/RuleDesk/pull/168) — TagsDrawer Artist/Character/Copyright: React Query `isLoading` vs confirmed-absent copy; no Main / `tag-resolve-coordinator` changes |
 | `fix/gelbooru-transport-failure-silent-swallow` | ✅ merged | [#157](https://github.com/KazeKaze93/RuleDesk/pull/157) — Gelbooru `fetchPosts` throws `ProviderSearchError("network"|"parse")` instead of `[]`; SearchController heuristics stay on genuine empty API pages only. |
 | `fix/p1-test-suite-false-confidence` | ✅ merged | [#156](https://github.com/KazeKaze93/RuleDesk/pull/156) — P1-1..P1-4: property/e2e/hook tests that could not fail on real regressions. P1-5 Gelbooru transport `[]` vs Rule34 throw — prod silent-failure, **not** fixed in this branch. |
 | `fix/p2-test-suite-reliability` | ✅ merged | [#158](https://github.com/KazeKaze93/RuleDesk/pull/158) — Duplicate mock-db helper removed; component tests import real UI + RTL; throttle uses fake timers. E2E rebuild-skip / retries and Artist/Playlist GridContainer copies — recorded in [Backlog](#backlog-not-implemented-yet), not in this branch. |

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -53,7 +53,7 @@ The short version: the core product is shipped, now we focus on parity gaps and 
 
 **Current state:** 🟡 polish / edge cases
 
-- ✅ **Tags drawer** (`ViewerDialog` / `TagsDrawer`): click to **include** tag in query, **right-click** to **exclude**; green/red ring styling and `aria-pressed` for include vs exclude state (see `useSearchStore` `addIncludeTag` / `addExcludeTag`).
+- ✅ **Tags drawer** (`ViewerDialog` / `TagsDrawer`): click to **include** tag in query, **right-click** to **exclude**; green/red ring styling and `aria-pressed` for include vs exclude state (see `useSearchStore` `addIncludeTag` / `addExcludeTag`). Artist / Character / Copyright wait on React Query `isLoading` (in-flight resolve) and only show “No … detected” after the query settles empty — not while `tag_metadata` lookup is still queued behind `ProviderThrottle`.
 - ✅ **Progressive stills in grid:** `PostCard` promotes **preview → sample** when the card enters the viewport (image decode + deduped URLs); videos use separate hover/preview behavior.
 - ⏳ Card/overlay consistency on special surfaces (e.g. playlist-only affordances) if any remain.
 
@@ -172,6 +172,7 @@ Both P0 rows (#1–#2) are closed — the full v17 audit pack landed (after one 
 
 | Branch | Status | Notes |
 |--------|--------|-------|
+| `fix/post-metadata-artist-character-loading-state` | 🟡 in progress | TagsDrawer Artist/Character/Copyright: React Query `isLoading` vs confirmed-absent copy; no Main / `tag-resolve-coordinator` changes |
 | `fix/gelbooru-transport-failure-silent-swallow` | ✅ merged | [#157](https://github.com/KazeKaze93/RuleDesk/pull/157) — Gelbooru `fetchPosts` throws `ProviderSearchError("network"|"parse")` instead of `[]`; SearchController heuristics stay on genuine empty API pages only. |
 | `fix/p1-test-suite-false-confidence` | ✅ merged | [#156](https://github.com/KazeKaze93/RuleDesk/pull/156) — P1-1..P1-4: property/e2e/hook tests that could not fail on real regressions. P1-5 Gelbooru transport `[]` vs Rule34 throw — prod silent-failure, **not** fixed in this branch. |
 | `fix/p2-test-suite-reliability` | ✅ merged | [#158](https://github.com/KazeKaze93/RuleDesk/pull/158) — Duplicate mock-db helper removed; component tests import real UI + RTL; throttle uses fake timers. E2E rebuild-skip / retries and Artist/Playlist GridContainer copies — recorded in [Backlog](#backlog-not-implemented-yet), not in this branch. |

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -351,7 +351,8 @@ On Browse **Source: All**, Videos / Images are applied in the live API search ta
 1. Open a post in the viewer
 2. Click the **"Tags"** button (or press **T**) to open the tags drawer
 3. **Click** a tag to **include** it in the search query; **right-click** to add an **exclude** (`-tag`); included/excluded tags are highlighted (**green** / **red** rings) in the drawer
-4. The gallery or browse view updates to match the query in the top bar
+4. Artist, Character, and Copyright may show a small resolving spinner until tag types are looked up (this can take a moment on first view). “No artist detected” / “No character detected” means the lookup finished and no tag of that type was found — not that the panel is empty forever while lookup is still running
+5. The gallery or browse view updates to match the query in the top bar
 
 **Clear filters:**
 

--- a/src/renderer/features/viewer/TagsDrawer.tsx
+++ b/src/renderer/features/viewer/TagsDrawer.tsx
@@ -1,4 +1,11 @@
-import { useCallback, useEffect, useMemo, useState } from "react";
+import {
+  useCallback,
+  useEffect,
+  useMemo,
+  useState,
+  type ReactElement,
+  type ReactNode,
+} from "react";
 import { useQuery } from "@tanstack/react-query";
 import { useNavigate } from "react-router-dom";
 import { useShallow } from "zustand/react/shallow";
@@ -19,7 +26,7 @@ import {
   TooltipProvider,
   TooltipTrigger,
 } from "../../components/ui/tooltip";
-import { Copy } from "lucide-react";
+import { Copy, Loader2 } from "lucide-react";
 import { useSearchStore } from "../../store/searchStore";
 import { useViewerStore, type ViewerOrigin } from "../../store/viewerStore";
 import { cn } from "../../lib/utils";
@@ -27,6 +34,52 @@ import { VIEWER_OVERLAY_Z, viewerOverlayClass } from "./viewer-layers";
 
 const VIEWER_TAG_HINT_SEEN_KEY = "hasSeenTagHint";
 const RESOLVE_TAGS_BATCH_SIZE = 100;
+const RESOLVED_TAG_VALUE_ROW_CLASS =
+  "flex h-5 items-center text-sm text-muted-foreground";
+
+type ResolvedTagFieldProps = {
+  title: string;
+  tags: string[];
+  isResolving: boolean;
+  emptyLabel: string;
+  loadingLabel: string;
+  renderTag: (tag: string) => ReactNode;
+};
+
+function ResolvedTagField({
+  title,
+  tags,
+  isResolving,
+  emptyLabel,
+  loadingLabel,
+  renderTag,
+}: ResolvedTagFieldProps): ReactElement {
+  let body: ReactNode;
+  if (tags.length > 0) {
+    body = <div className="min-h-5 space-y-1">{tags.map((tag) => renderTag(tag))}</div>;
+  } else if (isResolving) {
+    body = (
+      <p
+        className={RESOLVED_TAG_VALUE_ROW_CLASS}
+        role="status"
+        aria-live="polite"
+        aria-busy="true"
+        aria-label={loadingLabel}
+      >
+        <Loader2 className="h-3.5 w-3.5 shrink-0 animate-spin" aria-hidden="true" />
+      </p>
+    );
+  } else {
+    body = <p className={RESOLVED_TAG_VALUE_ROW_CLASS}>{emptyLabel}</p>;
+  }
+
+  return (
+    <div>
+      <h3 className="mb-2 text-sm font-semibold">{title}</h3>
+      {body}
+    </div>
+  );
+}
 
 const chunkTags = (tags: string[], chunkSize: number): string[][] => {
   const chunks: string[][] = [];
@@ -132,7 +185,8 @@ export const TagsDrawer = ({
   // Clean IPC call - no credentials passed from UI
   // Main Process handles authentication and persistent SQLite cache internally
   // Pass ALL tags to resolveTags - no client-side slice to ensure artist tags are found even if they're beyond position 20
-  const { data: resolvedArtistTags = [] } = useQuery<string[]>({
+  const { data: resolvedArtistTags = [], isLoading: isResolvingArtistTags } =
+    useQuery<string[]>({
     queryKey: ['resolve-tags-ipc', tagsString],
     queryFn: async () => {
       if (!tagsString) return [];
@@ -151,7 +205,8 @@ export const TagsDrawer = ({
   });
 
   // Resolve character tags (type=4) from API
-  const { data: resolvedCharacterTags = [] } = useQuery<string[]>({
+  const { data: resolvedCharacterTags = [], isLoading: isResolvingCharacterTags } =
+    useQuery<string[]>({
     queryKey: ['resolve-character-tags-ipc', tagsString],
     queryFn: async () => {
       if (!tagsString) return [];
@@ -170,7 +225,8 @@ export const TagsDrawer = ({
   });
 
   // Resolve copyright tags (type=3) from API
-  const { data: resolvedCopyrightTags = [] } = useQuery<string[]>({
+  const { data: resolvedCopyrightTags = [], isLoading: isResolvingCopyrightTags } =
+    useQuery<string[]>({
     queryKey: ['resolve-copyright-tags-ipc', tagsString],
     queryFn: async () => {
       if (!tagsString) return [];
@@ -384,66 +440,51 @@ export const TagsDrawer = ({
               </p>
             </div>
           )}
-          {/* Copyright Section */}
-          <div>
-            <h3 className="mb-2 text-sm font-semibold">Copyright</h3>
-            {copyrightTags.length > 0 ? (
-              <div className="space-y-1">
-                {copyrightTags.map((tag) => (
-                  renderTagActionButton(
-                    tag,
-                    "link",
-                    "text-purple-600 hover:underline",
-                    "h-auto min-h-0 w-full justify-start p-0 text-sm"
-                  )
-                ))}
-              </div>
-            ) : (
-              <p className="text-sm text-muted-foreground">
-                No copyright detected
-              </p>
-            )}
-          </div>
-          {/* Character Section */}
-          <div>
-            <h3 className="mb-2 text-sm font-semibold">Character</h3>
-            {characterTags.length > 0 ? (
-              <div className="space-y-1">
-                {characterTags.map((tag) => (
-                  renderTagActionButton(
-                    tag,
-                    "link",
-                    "text-green-600 hover:underline",
-                    "h-auto min-h-0 w-full justify-start p-0 text-sm"
-                  )
-                ))}
-              </div>
-            ) : (
-              <p className="text-sm text-muted-foreground">
-                No character detected
-              </p>
-            )}
-          </div>
-          {/* Artist Section */}
-          <div>
-            <h3 className="mb-2 text-sm font-semibold">Artist</h3>
-            {artistTags.length > 0 ? (
-              <div className="space-y-1">
-                {artistTags.map((tag) => (
-                  renderTagActionButton(
-                    tag,
-                    "link",
-                    "text-red-600 hover:underline",
-                    "h-auto min-h-0 w-full justify-start p-0 text-sm"
-                  )
-                ))}
-              </div>
-            ) : (
-              <p className="text-sm text-muted-foreground">
-                No artist detected
-              </p>
-            )}
-          </div>
+          <ResolvedTagField
+            title="Copyright"
+            tags={copyrightTags}
+            isResolving={isResolvingCopyrightTags}
+            emptyLabel="No copyright detected"
+            loadingLabel="Resolving copyright"
+            renderTag={(tag) =>
+              renderTagActionButton(
+                tag,
+                "link",
+                "text-purple-600 hover:underline",
+                "h-auto min-h-0 w-full justify-start p-0 text-sm"
+              )
+            }
+          />
+          <ResolvedTagField
+            title="Character"
+            tags={characterTags}
+            isResolving={isResolvingCharacterTags}
+            emptyLabel="No character detected"
+            loadingLabel="Resolving character"
+            renderTag={(tag) =>
+              renderTagActionButton(
+                tag,
+                "link",
+                "text-green-600 hover:underline",
+                "h-auto min-h-0 w-full justify-start p-0 text-sm"
+              )
+            }
+          />
+          <ResolvedTagField
+            title="Artist"
+            tags={artistTags}
+            isResolving={isResolvingArtistTags}
+            emptyLabel="No artist detected"
+            loadingLabel="Resolving artist"
+            renderTag={(tag) =>
+              renderTagActionButton(
+                tag,
+                "link",
+                "text-red-600 hover:underline",
+                "h-auto min-h-0 w-full justify-start p-0 text-sm"
+              )
+            }
+          />
           {/* General Tags Section */}
           <div>
             <h3 className="mb-2 text-sm font-semibold">

--- a/tests/unit/TEST_COVERAGE.md
+++ b/tests/unit/TEST_COVERAGE.md
@@ -49,6 +49,7 @@ In-memory DB fixtures live in `tests/helpers/mock-db.ts` and are covered by `tes
 | `db/sync-status-recovery.test.ts` | Hard-kill `syncing` → `idle` reset |
 | `db/fts-table-check.test.ts` | `postsFtsTableExists` |
 | `db/fts-triggers.test.ts` | FTS5 content-table triggers |
+| `features/viewer/TagsDrawer.resolved-tags.test.tsx` | Post Metadata Artist/Character: loading vs found vs confirmed-absent |
 | `features/viewer/buildViewerOriginQueryKey.test.ts` | Viewer origin → React Query key |
 | `features/viewer/openViewer-hasNextPage.test.ts` | Gallery `openViewer` passes react-query `hasNextPage`, not count-vs-page-size |
 | `features/viewer/gallery-background-scroll-queue.test.ts` | Masonry / local grid infinite scroll use `handleLoadMore` (`appendQueueIds`) |

--- a/tests/unit/features/viewer/TagsDrawer.resolved-tags.test.tsx
+++ b/tests/unit/features/viewer/TagsDrawer.resolved-tags.test.tsx
@@ -1,0 +1,240 @@
+// @vitest-environment jsdom
+import { cleanup, render, screen, waitFor } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { MemoryRouter } from "react-router-dom";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { Post } from "@shared/types/db";
+import { EXTERNAL_ARTIST_ID } from "@/shared/constants";
+import { TagsDrawer } from "@/renderer/features/viewer/TagsDrawer";
+import { makePost } from "../../components/PostCard/makePost";
+
+vi.mock("electron-log/renderer", () => ({
+  default: {
+    info: vi.fn(),
+    error: vi.fn(),
+    warn: vi.fn(),
+    debug: vi.fn(),
+  },
+}));
+
+type Deferred<T> = {
+  promise: Promise<T>;
+  resolve: (value: T) => void;
+};
+
+function createDeferred<T>(): Deferred<T> {
+  let resolve!: (value: T) => void;
+  const promise = new Promise<T>((res) => {
+    resolve = res;
+  });
+  return { promise, resolve };
+}
+
+function createQueryClient(): QueryClient {
+  return new QueryClient({
+    defaultOptions: {
+      queries: {
+        retry: false,
+        gcTime: Infinity,
+      },
+    },
+  });
+}
+
+function installResolveApi(overrides?: {
+  resolveTags?: () => Promise<string[]>;
+  resolveCharacterTags?: () => Promise<string[]>;
+  resolveCopyrightTags?: () => Promise<string[]>;
+  getTrackedArtists?: () => Promise<never[]>;
+}): {
+  resolveTags: ReturnType<typeof vi.fn>;
+  resolveCharacterTags: ReturnType<typeof vi.fn>;
+  resolveCopyrightTags: ReturnType<typeof vi.fn>;
+  getTrackedArtists: ReturnType<typeof vi.fn>;
+} {
+  const api = {
+    getTrackedArtists: vi.fn(overrides?.getTrackedArtists ?? (async () => [])),
+    resolveTags: vi.fn(overrides?.resolveTags ?? (async () => [])),
+    resolveCharacterTags: vi.fn(
+      overrides?.resolveCharacterTags ?? (async () => [])
+    ),
+    resolveCopyrightTags: vi.fn(
+      overrides?.resolveCopyrightTags ?? (async () => [])
+    ),
+  };
+  window.api = api as Window["api"];
+  return api;
+}
+
+function renderDrawer(post: Post, queryClient: QueryClient) {
+  return render(
+    <QueryClientProvider client={queryClient}>
+      <MemoryRouter>
+        <TagsDrawer
+          post={post}
+          isOpen
+          onOpenChange={vi.fn()}
+          queue={null}
+        />
+      </MemoryRouter>
+    </QueryClientProvider>
+  );
+}
+
+function untrackedPost(tags: string): Post {
+  return makePost({
+    artistId: EXTERNAL_ARTIST_ID,
+    tags,
+  });
+}
+
+const originalResizeObserver = globalThis.ResizeObserver;
+
+afterEach(() => {
+  cleanup();
+  globalThis.ResizeObserver = originalResizeObserver;
+});
+
+beforeEach(() => {
+  window.localStorage.setItem("hasSeenTagHint", "true");
+  globalThis.ResizeObserver = class {
+    observe(): void {}
+    unobserve(): void {}
+    disconnect(): void {}
+  };
+});
+
+describe("TagsDrawer artist/character resolve states", () => {
+  it("shows a loading status while resolve is in-flight, not confirmed-absent copy", async () => {
+    const artist = createDeferred<string[]>();
+    const character = createDeferred<string[]>();
+    installResolveApi({
+      resolveTags: () => artist.promise,
+      resolveCharacterTags: () => character.promise,
+      resolveCopyrightTags: async () => [],
+    });
+    const queryClient = createQueryClient();
+    renderDrawer(untrackedPost("wlop 2b general_tag"), queryClient);
+
+    expect(
+      await screen.findByRole("status", { name: "Resolving artist" })
+    ).toBeTruthy();
+    expect(
+      screen.getByRole("status", { name: "Resolving character" })
+    ).toBeTruthy();
+    expect(screen.queryByText("No artist detected")).toBeNull();
+    expect(screen.queryByText("No character detected")).toBeNull();
+  });
+
+  it("shows resolved artist and character tags without user interaction", async () => {
+    const artist = createDeferred<string[]>();
+    const character = createDeferred<string[]>();
+    installResolveApi({
+      resolveTags: () => artist.promise,
+      resolveCharacterTags: () => character.promise,
+      resolveCopyrightTags: async () => [],
+    });
+    const queryClient = createQueryClient();
+    renderDrawer(untrackedPost("wlop 2b general_tag"), queryClient);
+
+    await screen.findByRole("status", { name: "Resolving artist" });
+    artist.resolve(["wlop"]);
+    character.resolve(["2b"]);
+
+    await waitFor(() => {
+      expect(screen.getByRole("button", { name: "wlop" })).toBeTruthy();
+      expect(screen.getByRole("button", { name: "2b" })).toBeTruthy();
+    });
+    expect(screen.queryByRole("status", { name: "Resolving artist" })).toBeNull();
+    expect(
+      screen.queryByRole("status", { name: "Resolving character" })
+    ).toBeNull();
+    expect(screen.queryByText("No artist detected")).toBeNull();
+    expect(screen.queryByText("No character detected")).toBeNull();
+  });
+
+  it("shows confirmed-absent copy after resolve returns empty, without a loading status", async () => {
+    const artist = createDeferred<string[]>();
+    const character = createDeferred<string[]>();
+    installResolveApi({
+      resolveTags: () => artist.promise,
+      resolveCharacterTags: () => character.promise,
+      resolveCopyrightTags: async () => [],
+    });
+    const queryClient = createQueryClient();
+    renderDrawer(untrackedPost("solo highres"), queryClient);
+
+    await screen.findByRole("status", { name: "Resolving artist" });
+    artist.resolve([]);
+    character.resolve([]);
+
+    await waitFor(() => {
+      expect(screen.getByText("No artist detected")).toBeTruthy();
+      expect(screen.getByText("No character detected")).toBeTruthy();
+    });
+    expect(screen.queryByRole("status", { name: "Resolving artist" })).toBeNull();
+    expect(
+      screen.queryByRole("status", { name: "Resolving character" })
+    ).toBeNull();
+  });
+
+  it("renders cached found tags on the first paint without a loading status", () => {
+    installResolveApi();
+    const tagsString = "wlop 2b general_tag";
+    const queryClient = createQueryClient();
+    queryClient.setQueryData(["artists"], []);
+    queryClient.setQueryData(["resolve-tags-ipc", tagsString], ["wlop"]);
+    queryClient.setQueryData(
+      ["resolve-character-tags-ipc", tagsString],
+      ["2b"]
+    );
+    queryClient.setQueryData(["resolve-copyright-tags-ipc", tagsString], []);
+
+    renderDrawer(untrackedPost(tagsString), queryClient);
+
+    expect(screen.getByRole("button", { name: "wlop" })).toBeTruthy();
+    expect(screen.getByRole("button", { name: "2b" })).toBeTruthy();
+    expect(screen.queryByRole("status", { name: "Resolving artist" })).toBeNull();
+    expect(
+      screen.queryByRole("status", { name: "Resolving character" })
+    ).toBeNull();
+    expect(screen.queryByText("No artist detected")).toBeNull();
+    expect(screen.queryByText("No character detected")).toBeNull();
+  });
+
+  it("does not keep the previous post's loading status when switching posts", async () => {
+    const postATags = "alpha_tag";
+    const postBTags = "wlop general_tag";
+    const artistA = createDeferred<string[]>();
+    installResolveApi({
+      resolveTags: () => artistA.promise,
+      resolveCharacterTags: async () => [],
+      resolveCopyrightTags: async () => [],
+    });
+    const queryClient = createQueryClient();
+    queryClient.setQueryData(["artists"], []);
+    queryClient.setQueryData(["resolve-tags-ipc", postBTags], ["wlop"]);
+    queryClient.setQueryData(["resolve-character-tags-ipc", postBTags], []);
+    queryClient.setQueryData(["resolve-copyright-tags-ipc", postBTags], []);
+
+    const view = renderDrawer(untrackedPost(postATags), queryClient);
+    await screen.findByRole("status", { name: "Resolving artist" });
+
+    view.rerender(
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter>
+          <TagsDrawer
+            post={untrackedPost(postBTags)}
+            isOpen
+            onOpenChange={vi.fn()}
+            queue={null}
+          />
+        </MemoryRouter>
+      </QueryClientProvider>
+    );
+
+    expect(screen.getByRole("button", { name: "wlop" })).toBeTruthy();
+    expect(screen.queryByRole("status", { name: "Resolving artist" })).toBeNull();
+    expect(screen.queryByText("No artist detected")).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary
- Post Metadata treated in-flight tag resolve and confirmed-absent as the same empty copy (`No artist detected` / `No character detected`), because `useQuery` `data = []` covers both pending and settled-empty and the UI never checked `isLoading`.
- Renderer now has three states: compact `role=status` spinner while the query is in-flight, tag value when found, and `No X detected` only after the query settles empty. Same branch for Copyright (identical pattern in the same component). Main / `tag-resolve-coordinator` unchanged.
- Session React Query cache (`staleTime: Infinity`) still paints found tags on the first frame with no spinner flash. Five unit tests cover loading / found / confirmed-absent / cached first paint / next-prev without stuck loading.

## Test plan
- [ ] Post with already-resolved (found) tags: Artist/Character appear immediately, no spinner flash
- [ ] Post with unresolved tags: spinner shows, then the correct value appears with no user action
- [ ] Post with confirmed `not_found`: after resolve, `No artist detected` / `No character detected` with no spinner
- [ ] Fast next/prev in Browse does not keep the previous post's loading status
- [ ] Existing metadata-panel tests still pass (`TagsDrawer.resolved-tags.test.tsx`; `npm run validate`)

## Out of scope
IPC contract and `tag-resolve-coordinator.ts` are unchanged. Data source is the same; only renderer state discrimination changed.

## Open question (before merge)
`staleTime: Infinity` is keyed by post tags and is an in-memory React Query cache (no `persistQueryClient`). It does **not** survive app restart; the next process hits Main, which still owns `tag_metadata.not_found` TTL (7 days, `TAG_RESOLVE_NOT_FOUND_TTL_MS`).

Gap that remains: a **single long-lived session** (>7 days) can keep a confirmed-absent row in renderer cache after Main TTL expiry, so the panel could show stale `No X detected` until restart. Not a blocker for this loading-state fix. Accept as session-cache trade-off (already documented as session cache in `TagsDrawer`), or follow up with invalidation / a finite `staleTime`.